### PR TITLE
Enable linking to SCORE

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -51,5 +51,5 @@ bazel_dep(name = "score_python_basics", version = "0.3.0")
 
 # Checker rule for CopyRight checks/fixes
 bazel_dep(name = "score_cr_checker", version = "0.2.2")
-bazel_dep(name = "score_docs_as_code", version = "0.2.1")
+bazel_dep(name = "score_docs_as_code", version = "0.2.2")
 bazel_dep(name = "score_format_checker", version = "0.1.1")

--- a/process/BUILD
+++ b/process/BUILD
@@ -24,7 +24,15 @@ docs(
     conf_dir = "process",  # Where 'conf.py' is
     docs_targets = [
         {
-            "suffix": "",  # local build without any dependencies on external needs
+            "suffix": "",  # latest main branch documentation build
+            "external_needs_info": [
+                {
+                    "base_url": "https://eclipse-score.github.io/score/main",
+                    "json_url": "https://eclipse-score.github.io/score/main/needs.json",
+                    "version": "0.1",
+                    "id_prefix": "score_",
+                },
+            ],
         },
     ],
     source_dir = "process",  # Where the RST files are located


### PR DESCRIPTION
This enables the linkage to the score repository in order to allow for linking to there (one way). 

To link to a need from score, use the 'id' you want to link to an prefix it via `SCORE_` . 

Example: 

`doc__platform_problem_resolution_plan` would then become  `SCORE_doc__platform_problem_resolution_plan` 

--- 

You can see that the link works (at least from Sphinx side) in two ways. 
- The warning disappears 
- An arrow appears after the link indicating it redirects to an external website, like so:

<img width="984" alt="image" src="https://github.com/user-attachments/assets/c8238a8e-0397-4e03-bef0-37994a3a803d" />

