### PR TITLE
Fix command arguments for docs build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,5 +38,5 @@ jobs:
       id-token: write
 
     with:
-      bazel-target: "//process:incremental_latest -- --github_user=${{ github.repository_owner }} --github_repo=${{ github.event.repository.name }}"
+      bazel-target: "//process:incremental_latest"
       retention-days: 3


### PR DESCRIPTION
I made a mistake, the 'arguments' to fix the version picker are not yet in the newest docs-as-code release, therefore the version before did not work. 
