### PR TITLE
bump version to 1.0.1

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -13,8 +13,8 @@
 
 module(
     name = "score_process",
-    version = "0.2.0",
-    compatibility_level = 0,
+    version = "1.0.1",
+    compatibility_level = 1,
 )
 
 ###############################################################################


### PR DESCRIPTION
1.0.0 release was internally labeled 0.2.0

We need to fix that in order to publish to our bazel registry