### PR TITLE
removing s-core and place holder links

### DIFF
--- a/process/folder_templates/features/feature_name/safety_planning/index.rst
+++ b/process/folder_templates/features/feature_name/safety_planning/index.rst
@@ -32,10 +32,10 @@ Feature Safety Planning
     - Adjust ``status`` to be ``valid``
     - Adjust ``safety`` and ``tags`` according to your needs
 
-.. list-table:: Feature <feature_name> Workproducts
+.. list-table:: Feature <feature_name> Work products
     :header-rows: 1
 
-    * - Workproduct Id
+    * - Work product Id
       - Link to process
       - Process status
       - Link to issue

--- a/process/folder_templates/modules/module_name/component_name/docs/component_classification.rst
+++ b/process/folder_templates/modules/module_name/component_name/docs/component_classification.rst
@@ -154,7 +154,7 @@ Step 2: Determine (C): the uncertainty of finding systematic faults based on the
 
 | (C=1) shall be selected when none of the determined complexity measures indicate HM or NM.
 | (C=2) shall be selected when at least one of the determined complexity measures indicate HM or NM, but the gaps evaluated are acceptable, means
-|       the risk of systematic faults due to these gaps is sufficiently low in the context of S-CORE or manageable by mitigating the gaps.
+|       the risk of systematic faults due to these gaps is sufficiently low in the context of the project or manageable by mitigating the gaps.
 | (C=3) in all other cases.
 |
 

--- a/process/folder_templates/modules/module_name/docs/manual/safety_manual.rst
+++ b/process/folder_templates/modules/module_name/docs/manual/safety_manual.rst
@@ -38,7 +38,7 @@ Introduction/Scope
 
 Assumed Platform Safety Requirements
 ------------------------------------
-| For the <S-CORE platform / module name> the following safety related stakeholder requirements are assumed to define the top level functionality (purpose) of the <S-CORE platform / module name>. I.e. from these all the feature and component requirements implemented are derived.
+| For the <Project platform / module name> the following safety related stakeholder requirements are assumed to define the top level functionality (purpose) of the <Project platform / module name>. I.e. from these all the feature and component requirements implemented are derived.
 | <List here all the stakeholder requirements, with safety not equal to QM, the module's components requirements are derived from.>
 
 Assumptions of Use
@@ -46,8 +46,8 @@ Assumptions of Use
 
 Assumptions on the Environment
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-| Generally the assumption of the S-CORE platform SEooC is that it is integrated in a safe system, i.e. the POSIX OS it runs on is qualified and also the HW related failures are taken into account by the system integrator, if not otherwise stated in the module's safety concept.
-| <List here all the OS calls the S-CORE platform expects to be safe.>
+| Generally the assumption of the project platform SEooC is that it is integrated in a safe system, i.e. the POSIX OS it runs on is qualified and also the HW related failures are taken into account by the system integrator, if not otherwise stated in the module's safety concept.
+| <List here all the OS calls the project platform expects to be safe.>
 
 List of AoUs expected from the environment the platform / module runs on:
 
@@ -68,7 +68,7 @@ Assumptions on the User
 | As there is no assumption on which specific OS and HW is used, the integration testing of the stakeholder and feature requirements is expected to be performed by the user of the platform SEooC. Tests covering all stakeholder and feature requirements performed on a reference platform (tbd link to reference platform specification), reviewed and passed are included in the platform SEooC safety case.
 | Additionally the components of the platform may have additional specific assumptions how they are used. These are part of every module documentation: <link to add>. Assumptions from components to their users can be fulfilled in two ways:
 | 1. There are assumption which need to be fulfilled by all SW components, e.g. "every user of an IPC mechanism needs to make sure that he provides correct data (including appropriate ASIL level)" - in this case the AoU is marked as "platform".
-| 2. There are assumption which can be fulfilled by a safety mechanism realized by some other S-CORE platform component and are therefore not relevant for an user who uses the whole platform. But those are relevant if you chose to use the module SEooC stand-alone - in this case the AoU is marked as "module". An example would be the "JSON read" which requires "The user shall provide a string as input which is not corrupted due to HW or QM SW errors." - which is covered when using together with safe S-CORE platform persistency feature.
+| 2. There are assumption which can be fulfilled by a safety mechanism realized by some other project platform component and are therefore not relevant for an user who uses the whole platform. But those are relevant if you chose to use the module SEooC stand-alone - in this case the AoU is marked as "module". An example would be the "JSON read" which requires "The user shall provide a string as input which is not corrupted due to HW or QM SW errors." - which is covered when using together with safe project platform persistency feature.
 
 List of AoUs on the user of the platform features or the module of this safety manual:
 

--- a/process/folder_templates/modules/module_name/docs/release/release_note.rst
+++ b/process/folder_templates/modules/module_name/docs/release/release_note.rst
@@ -49,7 +49,7 @@ Release Note
 |  Disclaimer
 |  ----------
 |  This release note does not "release for production", as it does not come with a safety argumentation and a performed safety assessment.
-|  The work products compiled in the safety package are created with care according to a process satisfying standards, but the S-CORE project,
+|  The work products compiled in the safety package are created with care according to a process satisfying standards, but the as the project,
 |  being a non-profit and open source organization, can not take over any liability for its content.
 |
 | New Features

--- a/process/folder_templates/modules/module_name/docs/safety_mgt/module_safety_package_fdr.rst
+++ b/process/folder_templates/modules/module_name/docs/safety_mgt/module_safety_package_fdr.rst
@@ -48,14 +48,14 @@ The purpose of this review checklist is to report status of the formal review fo
           - Comment
 
         * - 1
-          - Is a safety package provided which matches the safety plan (i.e. all planned workproducts referenced)?
+          - Is a safety package provided which matches the safety plan (i.e. all planned work products referenced)?
           - [YES | NO ]
           - <Rationale for result>
 
         * - 2
           - Is the argument how functional safety is achieved, provided in the safety package, plausible and sufficient?
           - NO
-          - The argument is intentionally not provided by S-CORE.
+          - The argument is intentionally not provided by the project.
 
         * - 3
           - Are the referenced work products available?

--- a/process/folder_templates/modules/module_name/docs/safety_mgt/module_safety_plan.rst
+++ b/process/folder_templates/modules/module_name/docs/safety_mgt/module_safety_plan.rst
@@ -36,7 +36,7 @@ Module Safety Plan
 Functional Safety Management Context
 ====================================
 
-This Safety Plan adds to the :ref:`process_safety_management` all the module development relevant workproducts needed for ISO 26262 conformity.
+This Safety Plan adds to the :ref:`process_safety_management` all the module development relevant work products needed for ISO 26262 conformity.
 
 Functional Safety Management Scope
 ==================================
@@ -58,21 +58,21 @@ Tailoring
 
 Additional to the tailoring in the SW platform project as defined in the :ref:`process_safety_management` we define here the additional tailoring on module level.
 
-- Excluded for this module are additionally the following workproducts (and their related requirements):
-  - <ISO 26262 reference>: <workproduct/requirement> - <Argumentation why it is not needed or replaced by another workproduct or activity.>
+- Excluded for this module are additionally the following work products (and their related requirements):
+  - <ISO 26262 reference>: <work product/requirement> - <Argumentation why it is not needed or replaced by another work product or activity.>
 
-Functional Safety Module Workproducts
-=====================================
+Functional Safety Module Work products
+======================================
 
-One set of workproducts for the module and one set for each component of the module:
+One set of work products for the module and one set for each component of the module:
 
-Module Workproducts List
-------------------------
+Module Work products List
+-------------------------
 
-.. list-table:: Module Workproducts
+.. list-table:: Module Work products
         :header-rows: 1
 
-        * - Workproduct Id
+        * - Work product Id
           - Link to process
           - Process status
           - Link to issue
@@ -122,8 +122,8 @@ Module Workproducts List
           - <WP status (manual)>
 
         * - :need:`wp__module_sw_build_config`
-          - `REPLACE_doc__software_development_plan`
-          - `copy('status', need_id='REPLACE_doc__software_development_plan')`
+          - :need:`gd_temp__software_development_plan`
+          - `copy('status', need_id='gd_temp__software_development_plan')`
           - <Link to issue>
           - <Link to WP>
           - <automated>
@@ -149,13 +149,13 @@ Module Workproducts List
           - :need:`doc__module_name_release_note`
           - :ndf:`copy('status', need_id='doc__module_name_release_note')`
 
-Component <name> Workproducts List
-----------------------------------
+Component <name> Work products List
+-----------------------------------
 
-.. list-table:: Component <name> Workproducts
+.. list-table:: Component <name> Work products
         :header-rows: 1
 
-        * - Workproduct Id
+        * - Work product Id
           - Link to process
           - Process status
           - Link to issue
@@ -252,16 +252,16 @@ In case an OSS element is used in the module, part 6 has to be filled out.
 OSS (sub-)component qualification plan
 ======================================
 
-For the selected OSS component the following workproducts will be implemented (and why):
+For the selected OSS component the following work products will be implemented (and why):
 
 If the OSS element is classified as a
     - component, then the below table shall match the above, adding the reasoning for tailoring of work products according to the OSS component classification.
-    - lower level component, then no workproducts additional to the component’s will be planned and activities below are part of the component’s issues.
+    - lower level component, then no work products additional to the component’s will be planned and activities below are part of the component’s issues.
 
-.. list-table:: OSS (sub-)component <name> Workproducts
+.. list-table:: OSS (sub-)component <name> Work products
         :header-rows: 1
 
-        * - Workproduct Id
+        * - Work product Id
           - Link to issue
           - Reasoning for tailoring
 

--- a/process/folder_templates/modules/module_name/docs/verification/module_verification_report.rst
+++ b/process/folder_templates/modules/module_name/docs/verification/module_verification_report.rst
@@ -33,7 +33,7 @@ Verification Report
     - Adjust ``safety`` and ``tags`` according to your needs
 
 
-This verification report is based on the `REPLACE_doc__verification_plan`.
+This verification report is based on the :need:`gd_temp__verification__plan`.
 It covers all the components of the above stated module.
 
 Verification Report contains:

--- a/process/general_concepts/score_building_blocks_concept.rst
+++ b/process/general_concepts/score_building_blocks_concept.rst
@@ -21,8 +21,8 @@ Building blocks concept
 Building blocks meta model
 ++++++++++++++++++++++++++
 
-The following figure gives an overview about the building blocks of the **S-CORE** **Platform**
-(blue box, top, 2nd column). The objectives of the platform of the **S-CORE** platform include
+The following figure gives an overview about the building blocks of the project **Platform**
+(blue box, top, 2nd column). The objectives of the project platform include
 enabling of feature integration for different use cases and domains. This includes safety-critical
 applications. Thus the intention is, that the platform can be developed as a Safety
 Element out of Context (**SEooC**) (green box, top, 1 column). The objectives of the platform are
@@ -30,7 +30,7 @@ expressed as concrete **Stakeholder Requirements** (blue box, top, 2nd column), 
 by provided **Platform Tests** (blue box, top, 5nd column) for reference hardware platforms. The
 platform consists of **Features** (yellow box, middle, 2nd column).
 
-Further **S-CORE** provides **Software Modules** (red box, middle, 1st column), which can also be
+Further the project provides **Software Modules** (red box, middle, 1st column), which can also be
 developed as a SEooC. A Software Module is defined as a **Component** (green box, middle, 2nd column)
 or a set of components realizing a Feature of the platform. In this sense a Software Module is the
 highest level component in our model. A Software Module represents e.g. executable code or a library.
@@ -63,15 +63,15 @@ to a Component.
 .. figure:: _assets/score_building_blocks_meta_model.drawio.svg
   :width: 100%
   :align: center
-  :alt: Building blocks overview for **S-CORE** platform
+  :alt: Building blocks overview for project platform
 
-  Building blocks overview for **S-CORE** platform
+  Building blocks overview for the project platform
 
 Building blocks example
 +++++++++++++++++++++++
 
 The following figure is an example to explain the elements from the meta model. The user of the
-**S-CORE** platform wants to use the feature key-value-store. For that the user must integrate
+project platform wants to use the feature key-value-store. For that the user must integrate
 the software module "kvstorage". As this modules dependence on another module, the user must also
 integrate the software module "json_al". The module "kvstorage" is built-up by the
 components "kvs" and "fs", where the module "json_al" contains only one component "json_al".

--- a/process/general_concepts/score_lifecycle_concept.rst
+++ b/process/general_concepts/score_lifecycle_concept.rst
@@ -14,10 +14,10 @@
 
 .. _general_concepts_lifecycle:
 
-Lifecylce concept
+Lifecycle concept
 -----------------
 
-Contributions to the **S-CORE** project are driven by Change Requests.
+Contributions to the project are driven by Change Requests.
 
 As features are the main structuring element of the platform, new features are requested by
 a change request from type feature. The request may be supported by source code.
@@ -25,7 +25,7 @@ A new feature request happens in the **Concept Phase**.
 
 During the **Development Phase** features are implemented and verified. The Development
 is planned, checked and adjusted to meet the requirements. Planning is also required from
-several standards especically to achieve functional safety.
+several standards especially to achieve functional safety.
 
 Features are improved during the **Maintenance Phase**. In case bugs are found, they are also
 fixed during this phase.
@@ -33,8 +33,6 @@ fixed during this phase.
 .. figure:: _assets/score_lifecycle_model.drawio.svg
   :width: 100%
   :align: center
-  :alt: Lifecycle model for S-CORE
+  :alt: Lifecycle model for the project
 
-  Lifecycle model for S-CORE
-
-
+  Lifecycle model for the project

--- a/process/general_concepts/score_review_concept.rst
+++ b/process/general_concepts/score_review_concept.rst
@@ -80,7 +80,7 @@ based on an implemented technical reviewer mechanism defined for the modified fi
 between reviewer(s) and author, the safety manager, security manager or quality manager can be added to the review to moderate a solution.
 
 The initial step for requirements and architecture is the (informal) GitHub review on every Pull-Request
-(resp. Change Request, see `REPLACE_doc__contr_guideline`)
+(resp. Change Request, see :need:`gd_guidl__change__change_request`)
 which creates or modifies one of these work products (subject to inspection).
 After this review the work products are in status "valid", which means they can be used for further development and verification steps.
 In this review the checklist entries shall be considered which are tagged as "incremental".

--- a/process/general_concepts/score_traceability_concept.rst
+++ b/process/general_concepts/score_traceability_concept.rst
@@ -21,7 +21,7 @@ Traceability is the key to ensure consistency between work products.
 Furthermore, traceability supports impact analysis, dependency analysis, coverage determination
 for requirements and verification, and tracking of implementation status.
 
-Therefore **S-CORE** requires at least for safety-relevant work products single-requirement
+Therefore the project requires at least for safety-relevant work products single-requirement
 granularity of traceability.
 
 The following figures gives an overview about the traceability between different work products
@@ -30,7 +30,7 @@ on different levels and detail.
 High level traceability overview
 ++++++++++++++++++++++++++++++++
 
-The following figure shows the traceability between the major **S-CORE** work products on each
+The following figure shows the traceability between the major project work products on each
 requirements level. Starting from top, the platform level, going down to feature, component
 to the bottom the unit level. The concept is based on the classical V-model approach.
 
@@ -40,9 +40,9 @@ Change request are traced to all affected work products.
   :width: 100%
   :name: score_wp_traceability
   :align: center
-  :alt: High level traceability overview for **S-CORE** work products
+  :alt: High level traceability overview for project work products
 
-  High level traceability overview for **S-CORE** work products
+  High level traceability overview for project work products
 
 The next figure sets the focus on the feature level and adds the traceability from the Feature
 Requirements to the Feature Architecture, Feature Safety Analysis and the Feature Assumption
@@ -51,9 +51,9 @@ of use. For convenience also the traceability to upper and lower lever requireme
 .. figure:: _assets/score_traceability_model_feat_overview.drawio.svg
   :width: 100%
   :align: center
-  :alt: High level traceability overview for **S-CORE** feature work products
+  :alt: High level traceability overview for project feature work products
 
-  High level traceability overview for **S-CORE** feature work products
+  High level traceability overview for project feature work products
 
 The next figures sets the focus on the component level and adds the traceability from the
 Component Requirements to the Component Architecture, Component Safety Analysis
@@ -64,9 +64,9 @@ from external Components is included.
 .. figure:: _assets/score_traceability_model_cmp_overview_1.drawio.svg
   :width: 100%
   :align: center
-  :alt: High level traceability overview for **S-CORE** component work products
+  :alt: High level traceability overview for project component work products
 
-  High level traceability overview for **S-CORE** component work products
+  High level traceability overview for project component work products
 
 Component Architecture may either built-up of other components, then the traceability may in
 addition also needed to their architectures.
@@ -74,9 +74,9 @@ addition also needed to their architectures.
 .. figure:: _assets/score_traceability_model_cmp_overview_2.drawio.svg
   :width: 100%
   :align: center
-  :alt: High level traceability overview for **S-CORE** component work products including sub-components
+  :alt: High level traceability overview for project component work products including sub-components
 
-  High level traceability overview for **S-CORE** component work products including sub-components
+  High level traceability overview for project component work products including sub-components
 
 Or less complex components may not require a Component Architecture, the traceability is not
 required as the architecture can be skipped.
@@ -84,6 +84,6 @@ required as the architecture can be skipped.
 .. figure:: _assets/score_traceability_model_cmp_overview_3.drawio.svg
   :width: 100%
   :align: center
-  :alt: High level traceability overview for **S-CORE** component work products including sub-components
+  :alt: High level traceability overview for project component work products including sub-components
 
-  High level traceability overview for **S-CORE** component work products including sub-components
+  High level traceability overview for project component work products including sub-components

--- a/process/introduction/index.rst
+++ b/process/introduction/index.rst
@@ -23,7 +23,7 @@ Introduction
 
 Motivation
 ----------
-| The score process model aims to establish organization rules for developing
+| The process model aims to establish organization rules for developing
 | open source software in the automotive industry, which can be used in safety and security context.
 
 Objectives
@@ -40,14 +40,14 @@ Approach
 1. We aim for a process model as common basis for process documentation (compare figure below).
 2. We work code centric (trace text as code) and iteratively.
 3. We aim to develop the process in conformance to the targeted standards (compare figure below).
-4. We aim to establish traceability from the begin (compare figure below, :ref:`wp_traceability_model`).
+4. We aim to establish traceability from the begin (compare :ref:`general_concepts_traceability`).
 5. We aim to verify conformity and traceability by tool automation as much as possible (compare figure below).
-6. We aim for an iterative collaboration model initiated by change requests (compare `REPLACE_doc__contr_guideline`)
+6. We aim for an iterative collaboration model initiated by change requests (compare :need:`gd_guidl__change__change_request`)
 
 
 .. figure:: _assets/score_process_model.drawio.svg
   :width: 100%
   :align: center
-  :alt: S-CORE process model
+  :alt: Overview process model
 
-  S-CORE process model
+  Overview process model

--- a/process/process_areas/architecture_design/guidance/architecture_process_reqs.rst
+++ b/process/process_areas/architecture_design/guidance/architecture_process_reqs.rst
@@ -172,7 +172,7 @@ Traceability to Requirements
    * comp_req <-> comp_arc_(sta|dyn|int|int_op)
 
    .. note::
-      In general the traceability is visualized in :numref:`wp_traceability_model`
+      In general the traceability is visualized in :ref:`general_concepts_traceability`
 
 Checks for Architectural Design
 -------------------------------

--- a/process/process_areas/requirements_engineering/requirements_concept.rst
+++ b/process/process_areas/requirements_engineering/requirements_concept.rst
@@ -293,4 +293,4 @@ Traceability Concept for Requirements
 
 The standards require that a requirement can be traced throughout the complete hierarchy levels including its :ref:`implementation <implementation>` and :ref:`verification <process_verification>`. In this project it is implemented the following way:
 
-In general the traceability is visualized in main development work product traceability model (:numref:`wp_traceability_model`).
+In general the traceability is visualized in main development work product traceability model (:ref:`general_concepts_traceability`).

--- a/process/process_areas/verification/guidance/verification_plan_template.rst
+++ b/process/process_areas/verification/guidance/verification_plan_template.rst
@@ -27,7 +27,7 @@ Verification Plan Template
     It provides a template for a software verification plan and should be adapted to the specific
     project needs.
 
-      The document should start with a header following the `REPLACE_doc__documentation_mgt_plan`.
+      The document should start with a header following the :need:`gd_temp__documentation`.
 
       .. code-block:: rst
 

--- a/process/roles/index.rst
+++ b/process/roles/index.rst
@@ -15,8 +15,8 @@
 Roles
 =====
 
-S-CORE Management Roles
------------------------
+Project Management Roles
+------------------------
 
 .. role:: Project Lead
    :id: rl__project_lead
@@ -39,7 +39,7 @@ S-CORE Management Roles
 
    * Decisions about strategical topics
    * Filling the Project Lead role according to the `Eclipse Foundation Project Handbook <https://www.eclipse.org/projects/handbook>`_
-   * Election of all roles in the S-CORE project, including the :need:`Safety Manager <rl__safety_manager>` on SW platform and module level
+   * Election of all roles in the project, including the :need:`Safety Manager <rl__safety_manager>` on SW platform and module level
    * Approval of release planning and releases
 
    Authority
@@ -48,8 +48,8 @@ S-CORE Management Roles
    * Election and replacement of all role's personnel
    * Decide on addition/removal of modules repositories or split-off of projects
 
-S-CORE process roles
---------------------
+Project Process roles
+---------------------
 
 .. role:: Process Community Member
    :id: rl__process_community
@@ -60,8 +60,8 @@ S-CORE process roles
    The process community members are responsible for the definition of the process architecture of the project integrated management system and how they processes interact.
    The approval and release of the process is done by the safety, quality and security managers and the technical leads (for the parts which affect them).
 
-S-CORE development roles
-------------------------
+Project Development roles
+-------------------------
 
 .. role:: Infrastructure Tooling Community Member
    :id: rl__infrastructure_tooling_community
@@ -76,7 +76,7 @@ S-CORE development roles
    :status: valid
 
    (Eclipse) Open Source Role, person(s) who provide(s) possible contribution(s) as pull request(s) to the main line.
-   Any contributor which contributes code, tests or documentation to S-CORE.
+   Any contributor which contributes code, tests or documentation to the project.
 
    .. note::
       Follows the processes defined by the :need:`rl__process_community`
@@ -102,17 +102,17 @@ S-CORE development roles
    independence argumentation when involved in the development of unit testing on safety critical
    units. In this way the testing community takes a supportive role for unit testing
 
-.. role:: S-CORE Security Team
+.. role:: Project Security Team
    :id: rl__security_team
    :status: valid
    :tags: verification
    :contains: rl__committer
 
    (Eclipse) Open Source Role, person(s) who is(are) responsible for coordinating the resolution of Vulnerabilities within the Project.
-   By default, the S-CORE Security Team includes all Committers. However, the Project may choose a different arrangement and establish specific criteria for team nominations.
+   By default, the project Security Team includes all Committers. However, the Project may choose a different arrangement and establish specific criteria for team nominations.
 
-S-CORE cross functional teams
------------------------------
+Project Feature teams
+---------------------
 
 .. role:: Platform Team
    :id: rl__platform_team
@@ -130,8 +130,8 @@ S-CORE cross functional teams
 
    The module team is responsible for all artifacts within the module SEooCs. Each module has only one responsible team but a team may also be responsible for several (small) modules.
 
-S-CORE Roles list
------------------
+Project Roles list
+------------------
 
 .. needtable::
    :style: table

--- a/process/standards/aspice_40/aspice.rst
+++ b/process/standards/aspice_40/aspice.rst
@@ -34,7 +34,7 @@ All distribution of derivative works shall be made at no cost to the recipient.
 
 Copyright notice
 ----------------
-There is no alteration, transformation or building upon in the *S-CORE* project. Detailed descriptions are included to facilitate process assessment in the *S-CORE* project and are provided in an open source framework free of charge.
+There is no alteration, transformation or building upon in this project. Detailed descriptions are included to facilitate process assessment in projects and are provided in an open source framework free of charge.
 
 
 Tailoring

--- a/process/standards/index.rst
+++ b/process/standards/index.rst
@@ -28,7 +28,7 @@ Standards
 The graphs below presents statistics on:
 
 * percentage of standard requirements linked to guidances
-* percentage of standard workproducts linked to S-CORE workproducts
+* percentage of standard work products linked to process areas work products
 
 ISO26262
 --------
@@ -39,7 +39,7 @@ ISO26262
    :colors: LightSeaGreen, lightgray
    :filter-func: score_metamodel.checks.standards.my_pie_linked_standard_requirements(iso26262)
 
-.. needpie:: Linked Workproducts ISO26262
+.. needpie:: Linked Work products ISO26262
    :labels: Linked, Not Linked
    :legend:
    :colors: LightSeaGreen, lightgray
@@ -63,7 +63,7 @@ ISOPAS8926
    :colors: LightSeaGreen, lightgray
    :filter-func: score_metamodel.checks.standards.my_pie_linked_standard_requirements(isopas8926)
 
-.. needpie:: Linked Workproducts ISOPAS8926
+.. needpie:: Linked Work products ISOPAS8926
    :labels: Linked, Not Linked
    :legend:
    :colors: LightSeaGreen, lightgray
@@ -78,7 +78,7 @@ ISO21434
    :colors: LightSeaGreen, lightgray
    :filter-func: score_metamodel.checks.standards.my_pie_linked_standard_requirements(isosae21434)
 
-.. needpie:: Linked Workproducts ISO21434
+.. needpie:: Linked Work products ISO21434
    :labels: Linked, Not Linked
    :legend:
    :colors: LightSeaGreen, lightgray

--- a/process/standards/iso26262/iso26262.rst
+++ b/process/standards/iso26262/iso26262.rst
@@ -17,16 +17,16 @@
 ISO 26262
 ---------
 
-S-CORE uses the ISO 26262 Second edition 2018-12.
+The project uses the ISO 26262 Second edition 2018-12.
 
 The standard ISO 26262 has several parts. All work products and requirements are
-defined as references below, if those are relevant for the S-CORE project.
+defined as references below, if those are relevant for the project.
 
-Irrelevant parts for S-CORE process requirements and work products compliance are:
+Irrelevant parts for project process requirements and work products compliance are:
 
 "Part 3: Concept phase" - as this is in responsibility of system integrator
 
-"Part 1: Vocabluary" - as it contains no requirements and work products
+"Part 1: Vocabulary" - as it contains no requirements and work products
 
 "Part 5: Product development at the hardware level" - as this is in responsibility of HW provider
 
@@ -34,7 +34,7 @@ Irrelevant parts for S-CORE process requirements and work products compliance ar
 
 "Part 10: Guidelines on ISO 26262" - as it contains no requirements and work products
 
-"Part 11: Guidelines on application of ISO 26262 to semiconductors" - as no semiconductors are in the project scope of S-CORE
+"Part 11: Guidelines on application of ISO 26262 to semiconductors" - as no semiconductors are in the project scope
 
 "Part 12: Adaptation of ISO 26262 for motorcycles" - if needed, motorcycles part is in responsibility of system integrator
 

--- a/process/standards/isosae21434/isosae21434.rst
+++ b/process/standards/isosae21434/isosae21434.rst
@@ -18,9 +18,9 @@ ISO/SAE 21434:2021(E)
 ---------------------
 
 The standard ISO/SAE 21434:2021(E) has several clauses. All work products and requirements are
-defined as references below, if those are relevant for the S-CORE project.
+defined as references below, if those are relevant for the project.
 
-Irrelevant clauses for S-CORE process requirements and work products compliance are:
+Irrelevant clauses for the project process requirements and work products compliance are:
 
 "Clause 1-4:" - as it contains no requirements and work products
 

--- a/process/workflows/index.rst
+++ b/process/workflows/index.rst
@@ -22,8 +22,8 @@ Workflows
    process_management
 
 
-S-CORE Workflow list
---------------------
+Project Workflow list
+---------------------
 
 .. needtable::
    :style: table

--- a/process/workproducts/index.rst
+++ b/process/workproducts/index.rst
@@ -12,17 +12,10 @@
    # SPDX-License-Identifier: Apache-2.0
    # *******************************************************************************
 
-Workproducts
-============
+Work products
+=============
 
-
-.. figure:: _assets/wp_traceability_model.drawio.svg
-  :width: 100%
-  :align: center
-  :alt: Project work product traceability model
-  :name: wp_traceability_model
-
-  Project development work product traceability model
+Project development work product traceability model overview: :ref:`general_concepts_traceability`
 
 
 Platform management
@@ -45,7 +38,7 @@ General
    :tags: safety
    :complies: std_wp__iso26262__management_552
 
-   Trainings for safety and security for S-CORE
+   Trainings for safety and security for the project
 
 Process
 ^^^^^^^
@@ -99,17 +92,17 @@ Supporting activities
 
 
 
-S-CORE Work product Linkage
----------------------------
+Project Work product Linkage
+----------------------------
 
-.. needpie:: S-CORE workproducts contained in exactly one S-CORE workflow
-   :labels: Not-Linked, Linked Workproduct, Linked Workproduct To Multiple Workflows
+.. needpie:: The project work products contained in exactly one project workflow
+   :labels: Not-Linked, Linked Work product, Linked Work product To Multiple Workflows
    :legend:
    :colors: red, green, blue
    :filter-func: score_metamodel.checks.standards.my_pie_workproducts_contained_in_exactly_one_workflow
 
-S-CORE Work product list
-------------------------
+Project Work product list
+-------------------------
 
 .. needtable::
    :style: table


### PR DESCRIPTION
for general concepts, standards, workflows, workproducts, role definition, trustable, folder templates replace workproduct with work product, if applicable

Resolves partly: #57, #74, #73, #72, #71, #75, #76