### PR TITLE
Improvement: Filter in safety plans at folder template

### DIFF
--- a/process/folder_templates/features/feature_name/safety_planning/index.rst
+++ b/process/folder_templates/features/feature_name/safety_planning/index.rst
@@ -115,6 +115,7 @@ Feature Requirements Status
 ---------------------------
 
 .. needtable::
+   :filter: "feature_name" in docname and "requirements" in docname and docname is not None
    :style: table
    :types: feat_req
    :tags: feature_name
@@ -126,6 +127,7 @@ Feature AoU Status
 ------------------
 
 .. needtable::
+   :filter: "feature_name" in docname and "requirements" in docname and docname is not None
    :style: table
    :types: aou_req
    :tags: feature_name
@@ -137,6 +139,7 @@ Feature Architecture Status
 ---------------------------
 
 .. needtable::
+   :filter: "feature_name" in docname and "requirements" in docname and docname is not None
    :style: table
    :types: feat_arc_sta; feat_arc_dyn
    :tags: feature_name

--- a/process/folder_templates/modules/module_name/docs/safety_mgt/module_safety_plan.rst
+++ b/process/folder_templates/modules/module_name/docs/safety_mgt/module_safety_plan.rst
@@ -316,6 +316,7 @@ Component Requirements Status
 -----------------------------
 
 .. needtable::
+   :filter: "component_name" in docname and "requirements" in docname and docname is not None
    :style: table
    :types: comp_req
    :tags: component_name
@@ -327,6 +328,7 @@ Component AoU Status
 --------------------
 
 .. needtable::
+   :filter: "component_name" in docname and "requirements" in docname and docname is not None
    :style: table
    :types: aou_req
    :tags: component_name
@@ -338,6 +340,7 @@ Component Architecture Status
 -----------------------------
 
 .. needtable::
+   :filter: "component_name" in docname and "requirements" in docname and docname is not None
    :style: table
    :types: comp_arc_sta; comp_arc_dyn
    :tags: component_name


### PR DESCRIPTION
Add a filter in the needtables of the safety plans that only the requirements of the related feature or component are listed