### PR TITLE
downgrade aspect-rules-py-version and solve copyright redundance

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -10,21 +10,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
+
 load("@score_docs_as_code//:docs.bzl", "docs")
 load("@score_tooling//:defs.bzl", "copyright_checker", "use_format_targets")
-
-# *******************************************************************************
-# Copyright (c) 2025 Contributors to the Eclipse Foundation
-#
-# See the NOTICE file(s) distributed with this work for additional
-# information regarding copyright ownership.
-#
-# This program and the accompanying materials are made available under the
-# terms of the Apache License Version 2.0 which is available at
-# https://www.apache.org/licenses/LICENSE-2.0
-#
-# SPDX-License-Identifier: Apache-2.0
-# *******************************************************************************
 
 package(default_visibility = ["//visibility:public"])
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -42,7 +42,7 @@ python.toolchain(
 use_repo(python)
 
 # Additional Python rules provided by aspect, e.g. an improved version of
-bazel_dep(name = "aspect_rules_py", version = "1.6.3")
+bazel_dep(name = "aspect_rules_py", version = "1.4.0")
 bazel_dep(name = "buildifier_prebuilt", version = "8.2.0.2")
 
 ###############################################################################


### PR DESCRIPTION
Return aspect-rules-py-version to the last version: 1.4.0 to solve consumer_test error in docs as code.

Clean copyrights in the build file 