### PR TITLE
uplift docs-as-code v1.3.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -13,7 +13,7 @@
 
 module(
     name = "score_process",
-    version = "1.2.0",
+    version = "1.3.0",
     compatibility_level = 1,
 )
 


### PR DESCRIPTION
Enables optional_links warnings as info.

Related: https://github.com/eclipse-score/process_description/issues/178