### PR TITLE
🐛 Add score_sync_toml extension

### DIFF
--- a/process/conf.py
+++ b/process/conf.py
@@ -23,3 +23,11 @@
 project = "Process Description"
 project_url = "https://eclipse-score.github.io/process_description/"
 version = "0.1"
+
+extensions = [
+    # TODO: remove plantuml here once
+    # https://github.com/useblocks/sphinx-needs/pull/1508 is merged and docs-as-code
+    # is updated with new sphinx-needs version
+    "sphinxcontrib.plantuml",
+    "score_sphinx_bundle",
+]


### PR DESCRIPTION
The `process` documentation deviates from docs-as-code in that it maintains its own extensions list and configuration. 
This leads to missing extensions which surfaced with the integration of docs-as-code 2.0.0.

The used extension list is a subset of what `docs-as-code` uses, so this PR changes the configuration to use the docs-as-code standard. This also fixes the [ubproject.toml](https://ubcode.useblocks.com/usage/ubproject.html) generation to use [ubCode](https://ubcode.useblocks.com/).