### PR TITLE
Add explanation that components with safety rating have an red border.

### DIFF
--- a/process/process_areas/architecture_design/_assets/architecture_modeling_example.rst
+++ b/process/process_areas/architecture_design/_assets/architecture_modeling_example.rst
@@ -164,7 +164,7 @@ Component Architecure File(s)
 .. comp_arc_sta:: Component 3
    :id: comp_arc_sta__example_feature__archdes_component_3
    :status: valid
-   :safety: ASIL_B
+   :safety: QM
    :security: NO
    :implements: logic_arc_int__example_feature__archdes_logical_interface_3
    :fulfils: comp_req__example_feature__archdes_example_req

--- a/process/process_areas/architecture_design/architecture_getstrt.rst
+++ b/process/process_areas/architecture_design/architecture_getstrt.rst
@@ -109,6 +109,9 @@ Here are some excerpts of UML diagrams made from the requirements of that file.
 
 Feature Architecture
 ^^^^^^^^^^^^^^^^^^^^
+
+The following section is an example, how an `Feature <https://eclipse-score.github.io/score/main/features/index.html>`_ looks like and how the architecture of an Feature is described. Please notice, that in the diagram components with an safety rating to "ASIL_B" is drawn with an red border (see "Component 1" as example).
+
 .. feat_arc_sta:: Feature Getting Started
       :id: feat_arc_sta__example_feature__archdes_getstrt
       :security: YES


### PR DESCRIPTION
Add explanation that components with safety rating have an red border. 

Please notice, that within the pull request they have still blue borders. This is because of the multi repository structure and is automatically fixed with the next release.
