### PR TITLE
Improvement: Add check for needextend

### DIFF
--- a/process/folder_templates/features/feature_name/requirements/index.rst
+++ b/process/folder_templates/features/feature_name/requirements/index.rst
@@ -75,5 +75,5 @@ Requirements
     - Set the status to valid and start the review/merge process
     - Add other needed requirements for your feature
 
-.. needextend:: "feature_name" in id
+.. needextend:: docname is not None and "feature_name" in id
    :+tags: feature_name

--- a/process/process_areas/quality_management/quality_workflow.rst
+++ b/process/process_areas/quality_management/quality_workflow.rst
@@ -113,7 +113,7 @@ Workflows
    | The :need:`rl__quality_manager` is responsible to adjust the quality management plan, if deviations are detected.
 
 
-.. needextend:: "process_areas/quality_management" in docname
+.. needextend:: docname is not None and "process_areas/quality_management" in docname
    :+tags: quality_management
 
 RAS(IC) for Safety Analysis

--- a/process/process_areas/security_management/security_management_workflow.rst
+++ b/process/process_areas/security_management/security_management_workflow.rst
@@ -144,7 +144,7 @@ Workflow Security Management
    | The security manager :need:`rl__security_manager` consults all project/platform stakeholder as defined in :need:`doc_concept__security_management_process` for security topics and executes regularly security trainings.
 
 
-.. needextend:: "process_areas/security_management" in docname
+.. needextend:: docname is not None and "process_areas/security_management" in docname
    :+tags: security_management
 
 RAS(IC) for Security Management:


### PR DESCRIPTION
Add check "docname is not None" to avoid build warnings in docs-as-code lists