### PR TITLE
Add SW component qualification to verification

### DIFF
--- a/process/process_areas/verification/verification_concept.rst
+++ b/process/process_areas/verification/verification_concept.rst
@@ -206,3 +206,17 @@ revisit the linkage of all test cases to the requirement again.
 
 If the status of the linked test case and the linkage document is valid the attribute *testcovered* shall be set to *YES* during the Sphinx Build.
 Further information can also be depicted from the :ref:`requirements_engineering` process.
+
+Software Component Qualification
+================================
+
+The qualification of pre-existing software (e.g. Open Source project) developed and maintained outside of the project scope,
+requires various verification efforts to guarantee the quality matches the expectations of the project.
+
+Existing requirements, specifications and documentation can be used to fill traceability gaps.
+Existing test cases can be re-used and need to be linked against :need:`wp__requirements_comp` maintained within this project.
+
+Also, details in :ref:`external_tsf` to collect evidence required for component qualification can be referred to rate the maturity
+of the externally provided component.
+Eclipse projects are further supposed to align with the Eclipse Functional Safety Process which is documented
+in the `Eclipse Foundation Functional Safety Process GitLab <https://gitlab.eclipse.org/eclipsefdn/emo-team/policies/functional-safety-process>`_.

--- a/process/process_areas/verification/verification_workflows.rst
+++ b/process/process_areas/verification/verification_workflows.rst
@@ -154,7 +154,7 @@ Workflow Verification
    :tags: verification
    :responsible: rl__committer, rl__testing_community
    :approved_by: rl__project_lead
-   :supported_by: rl__safety_manager, rl__infrastructure_tooling_community
+   :supported_by: rl__safety_manager, rl__infrastructure_tooling_community, rl__contributor
    :input: wp__verification_plan, wp__requirements_comp, wp__requirements_comp_aou,
            wp__component_arch, wp__module_sw_release_note, wp__platform_mgmt,
            wp__sw_component_fmea, wp__sw_component_dfa,
@@ -165,10 +165,17 @@ Workflow Verification
    :has: doc_concept__verification_process, doc_getstrt__verification_process
 
    The verification report is created and maintained by a :need:`rl__committer`.
-   It is based on the :need:`wp__verification_plan` and covers all the components of a module.
+   It is based on the :need:`wp__verification_plan` and covers all the components of a developed module.
    This includes their requirements, AoUs, Architecture, Detailed Design, Units, DFA, Safety Analyses,
    Unit Code coverage. The respective necessary test methods and rigor of their application is
    defined in the :need:`wp__verification_plan`.
+
+   In case of externally provided pre-existing software maintained outside of the project,
+   the Module Verification Report also applies as documentation for the Qualification Verification
+   Report. The respective component(s) are verified with the same methods and deviation techniques
+   as mentioned in the :need:`wp__verification_plan`. The report will be filled by the :need:`rl__committer`
+   responsible for integration of the external component and will get support by the :need:`rl__contributor`
+   who proposed the component to the added to the project scope.
 
    The report is valid for ONE version of a module.
 

--- a/process/process_areas/verification/verification_workproducts.rst
+++ b/process/process_areas/verification/verification_workproducts.rst
@@ -102,6 +102,9 @@ Module
      :need:`wp__verification_feat_int_test`, and :need:`wp__verification_comp_int_test`
      with status passed/failed/not_run
 
+   It also serves as SW Component Qualification Verification Report for pre-existing Open Source
+   Projects developed and maintained outside of the project to which this process is applied to.
+
 Component
 *********
 


### PR DESCRIPTION
**What**

The work product "SW component qualification" for preexisting software is referred in the verification report, but not defined in the list of verification artifacts as part of the description. See here: https://eclipse-score.github.io/process_description/main/process_areas/verification/guidance/verification_report_template.html#gd_temp__mod_ver_report

**How**

Added a respective statement that the qualification of 3rd party software is treated in the same way as the module verification and therefore the content of the module verification report is also valid for the software qualification. This is added to the concept, workflow and work products

Resolves: #149