### PR TITLE
Improvement 397 remove create empty puml requirement

### DIFF
--- a/process/process_areas/architecture_design/guidance/architecture_process_reqs.rst
+++ b/process/process_areas/architecture_design/guidance/architecture_process_reqs.rst
@@ -260,13 +260,3 @@ Checks for Architectural Design
    :satisfies: wf__cr_mt_featarch, wf__cr_mt_comparch
 
    It shall be checked if all SW components which are mentioned in the dynamic architecture are defined in the static architecture.
-
-.. gd_req:: Building Blocks Dynamic Architecture
-   :id: gd_req__arch_build_blocks_dynamic
-   :status: valid
-   :tags: done_automation
-   :satisfies: wf__cr_mt_featarch, wf__cr_mt_comparch
-
-   It shall be checked if the required architectural building blocks inside the dynamic architecture exists as component in the static architecture.
-
-   For example via tooling or review checklist.


### PR DESCRIPTION
The "nice to have" requirement shall be deleted from the process requirement list. 
See [https://github.com/eclipse-score/process_description/issues/397](https://github.com/eclipse-score/process_description/issues/397).

Background is, that all requirements in the process list are mandatory and a nice to have feature is not mandatory. Additionally many other "nice to have" features are not mentioned. Therefore this is dysbalance.

