### PR TITLE
Improve coverage for test specifcation linking

### DIFF
--- a/process/process_areas/verification/guidance/verification_templates.rst
+++ b/process/process_areas/verification/guidance/verification_templates.rst
@@ -20,7 +20,9 @@ Verification Templates
 .. gd_temp:: Verification Specification Template
    :id: gd_temp__verification_specification
    :status: valid
-   :complies: std_req__iso26262__software_942, std_req__iso26262__software_943, std_req__iso26262__software_1042, std_req__iso26262__software_1043, std_req__iso26262__software_1044, std_req__iso26262__support_9421, std_req__iso26262__support_9422
+   :complies: std_req__iso26262__software_942, std_req__iso26262__software_943,
+              std_req__iso26262__software_1042, std_req__iso26262__software_1043, std_req__iso26262__software_1044,
+              std_req__iso26262__support_9421, std_req__iso26262__support_9422
 
    The sections below are seen as typical ways when writing tests and their specification.
    Their usage differs based on the selected testing framework and the implementation language of the module(s).


### PR DESCRIPTION
The test specification got improved by adding a `gd_temp_*` identifier after the templates had been moved from process requirements to the specification section. 