### PR TITLE
Add missing coverage statement for detailed design

### DIFF
--- a/process/process_areas/verification/guidance/verification_plan_template.rst
+++ b/process/process_areas/verification/guidance/verification_plan_template.rst
@@ -150,6 +150,8 @@ Verification Plan Template
          coverage goals (e.g. by :need:`wp__verification_sw_unit_test`, :need:`wp__verification_comp_int_test`, and
          :need:`wp__sw_implementation_inspection`).
 
+         The confirmation or any deviation of the coverage percentage value is documented in this section.
+
          Coverage of architectural design
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
Aligns the possibility to get a lower coverage value on arguing why this is possible.