### PR TITLE
fix outdated linking (static views does not implement something)

### DIFF
--- a/process/folder_templates/modules/module_name/component_name/docs/architecture/index.rst
+++ b/process/folder_templates/modules/module_name/component_name/docs/architecture/index.rst
@@ -82,7 +82,6 @@ The components are designed to cover the expectations from the feature architect
    :security: YES
    :safety: ASIL_B
    :status: invalid
-   :implements: logic_arc_int__feature_name__interface_name1
    :fulfils: comp_req__component_name__some_title
    :includes: comp_arc_sta__component_name__2
 
@@ -126,7 +125,6 @@ Internal Components
    :safety: ASIL_B
    :security: YES
    :fulfils: comp_req__component_name__some_title
-   :implements: logic_arc_int__feature_name__interface_name1
 
    No architecture but detailed design
 


### PR DESCRIPTION
fix outdated linking (static views does not implement something)

This is a cleanup for the changed component modeling (comp_arc_sta divided in comp and static view)