### PR TITLE
Update needs_role_need_template to use {title} so :need: links render titles without IDs

### DIFF
--- a/process/conf.py
+++ b/process/conf.py
@@ -31,3 +31,6 @@ extensions = [
     "sphinxcontrib.plantuml",
     "score_sphinx_bundle",
 ]
+
+# :need:`{title}` is used in the needs templates to display the title of the need
+needs_role_need_template = "{title}"


### PR DESCRIPTION
Update needs_role_need_template to use {title} so :need links render only the title (no ({id})), so long requirement IDs no longer appear in the HTML even if they exceed 45 characters.

Issue: [https://github.com/eclipse-score/process_description/issues/242](url)