### PR TITLE
Add devcontainer configuration for process description

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,4 @@
+{
+    "name": "eclipse-s-core",
+    "image": "ghcr.io/eclipse-score/devcontainer:v1.1.0"
+}


### PR DESCRIPTION
In the past the devcontainer was not working out of the box in the process description for me.
Now, I copied the file from `score` repo into `process_description` and tried e.g. `bazel run //:docs`. It runs out of the box.

It makes sense that others take a look, if it works for you as well.

This is meant as a proposal as I thought it could be worth to align to the standard S-CORE container.