### PR TITLE
Add initial Dockerfile and devcontainer configuration

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,15 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+# Use Dockerfile to get dependabot version bumps after new image is released
+FROM ghcr.io/eclipse-score/devcontainer:v1.3.0

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,6 @@
+{
+    "name": "eclipse-s-core",
+    "build": {
+        "dockerfile": "Dockerfile"
+    }
+}


### PR DESCRIPTION
In the past the devcontainer was not working out of the box in the process description.

Now, the copied file from `score` repo into `process_description` and trying  e.g. `bazel run //:docs` runs out of the box.

It makes sense that others take a look, if it works for you as well.

This is meant as a proposal as it could be worth to align to the standard S-CORE container.

Links to #637
Original source: https://github.com/etas-contrib/score_process_description/tree/pahmann/devcontainer