### PR TITLE
Update status to valid for merged Requirements and Documents

### DIFF
--- a/process/general_concepts/score_review_concept.rst
+++ b/process/general_concepts/score_review_concept.rst
@@ -197,7 +197,7 @@ Process Requirements
 
 .. gd_req:: Version for inspected architecture
    :id: gd_req__general_architecture_version
-   :status: draft
+   :status: valid
    :tags: general
    :complies: std_req__iso26262__support_6433, std_req__iso26262__software_7414
    :satisfies: wf__mr_vy_arch

--- a/process/process_areas/change_management/guidance/change_management_reqs.rst
+++ b/process/process_areas/change_management/guidance/change_management_reqs.rst
@@ -118,7 +118,7 @@ Change Request Attributes
 
 .. gd_req:: Change Request attribute: Affected Work Products
    :id: gd_req__change_attr_affected_wp
-   :status: draft
+   :status: valid
    :tags: attribute, mandatory
    :satisfies: wf__change_create_cr, wf__change_analyze_cr, wf__change_implement_monitor_cr, wf__change_close_cr
    :complies: std_req__aspice_40__SUP-10-BP4, std_req__iso26262__support_8412, std_req__iso26262__support_8422, std_req__iso26262__support_8452, std_req__iso26262__support_8453

--- a/process/process_areas/implementation/guidance/software_development_template.rst
+++ b/process/process_areas/implementation/guidance/software_development_template.rst
@@ -17,7 +17,7 @@ Software Development Plan Template
 
 .. gd_temp:: Software Development Plan Template
    :id: gd_temp__software_development_plan
-   :status: draft
+   :status: valid
    :complies: std_req__iso26262__software_541, std_req__iso26262__software_543
 
 Purpose

--- a/process/process_areas/problem_resolution/guidance/problem_resolution_template.rst
+++ b/process/process_areas/problem_resolution/guidance/problem_resolution_template.rst
@@ -19,7 +19,7 @@ Problem Report Template
 
 .. gd_temp:: Problem Template
    :id: gd_temp__problem_template
-   :status: draft
+   :status: valid
    :complies: std_req__aspice_40__SUP-9-BP1, std_req__aspice_40__SUP-9-BP2, std_req__aspice_40__SUP-9-BP3, std_req__aspice_40__SUP-9-BP4, std_req__aspice_40__iic-15-12, std_req__aspice_40__iic-15-55
 
 This template defines the content to be implemented in the selected Issue Tracking System

--- a/process/process_areas/process_management/process_management_workproducts.rst
+++ b/process/process_areas/process_management/process_management_workproducts.rst
@@ -19,7 +19,7 @@ Here only project specific work products are listed, which are generic for the p
 
 .. workproduct:: Policies
    :id: wp__policies
-   :status: draft
+   :status: valid
    :tags: doc_lifecycle_model_2
    :complies: std_wp__iso26262__management_551
 

--- a/process/process_areas/requirements_engineering/requirements_workproducts.rst
+++ b/process/process_areas/requirements_engineering/requirements_workproducts.rst
@@ -73,7 +73,7 @@ Requirements Engineering Work Products
 
 .. workproduct:: Requirements Inspection
    :id: wp__requirements_inspect
-   :status: draft
+   :status: valid
    :complies: std_wp__iso26262__software_653
    :tags: doc_lifecycle_model_2
 

--- a/process/process_areas/security_analysis/guidance/security_analysis_threat_scenario_templates.rst
+++ b/process/process_areas/security_analysis/guidance/security_analysis_threat_scenario_templates.rst
@@ -21,7 +21,7 @@ Security Analysis Threat Scenario Templates
 
 .. gd_temp:: Platform Security Analysis Templates
    :id: gd_temp__plat_threat_scenario
-   :status: draft
+   :status: valid
    :complies:
 
    For the content see here: (tbd)need:`doc__platform_security_analysis`
@@ -31,7 +31,7 @@ Security Analysis Threat Scenario Templates
 
 .. gd_temp:: Feature Security Analysis Templates
    :id: gd_temp__feat_threat_scenario
-   :status: draft
+   :status: valid
    :complies:
 
    For the content see here: (tbd)need:`doc__feature_name_security_analysis`
@@ -40,7 +40,7 @@ Security Analysis Threat Scenario Templates
 
 .. gd_temp:: Component Security Analysis Templates
    :id: gd_temp__comp_threat_scenario
-   :status: draft
+   :status: valid
    :complies:
 
    For the content see here: (tbd) `Component Security Analysis Template <https://eclipse-score.github.io/module_template/main/score/component_example/docs/index.html>`__

--- a/process/process_areas/security_analysis/guidance/security_analysis_threat_templates.rst
+++ b/process/process_areas/security_analysis/guidance/security_analysis_threat_templates.rst
@@ -21,7 +21,7 @@ Security Analysis Threat Templates
 
 .. gd_temp:: Feature Threat Template
    :id: gd_temp__feat_sec_ana_threat
-   :status: draft
+   :status: valid
    :complies:
 
       For the content see here: (tbd)need:`doc__feature_name_threat`
@@ -30,7 +30,7 @@ Security Analysis Threat Templates
 
 .. gd_temp:: Component Threat Template
    :id: gd_temp__comp_sec_ana_threat
-   :status: draft
+   :status: valid
    :complies:
 
       For the content see here: (tbd) `Component Threat Template <https://eclipse-score.github.io/module_template/main/score/component_example/docs/index.html>`__

--- a/process/process_areas/security_analysis/security_analysis_workflow.rst
+++ b/process/process_areas/security_analysis/security_analysis_workflow.rst
@@ -41,7 +41,7 @@ Security analysis is used as an umbrella term.
 
 .. workflow:: Analyse Feature Architecture
    :id: wf__analyse_sec_featarch
-   :status: draft
+   :status: valid
    :tags: security_analysis
    :responsible: rl__security_engineer
    :approved_by: rl__security_manager
@@ -55,7 +55,7 @@ Security analysis is used as an umbrella term.
 
 .. workflow:: Analyse Component Architecture
    :id: wf__analyse_sec_comparch
-   :status: draft
+   :status: valid
    :tags: security_analysis
    :responsible: rl__security_engineer
    :approved_by: rl__security_manager
@@ -69,7 +69,7 @@ Security analysis is used as an umbrella term.
 
 .. workflow:: Monitor Security Analysis
    :id: wf__mr_sec_analyses
-   :status: draft
+   :status: valid
    :tags: security_analysis
    :responsible: rl__security_engineer
    :approved_by: rl__security_manager
@@ -83,7 +83,7 @@ Security analysis is used as an umbrella term.
 
 .. workflow:: Verify Security Analysis
    :id: wf__vy_sec_analyses
-   :status: draft
+   :status: valid
    :tags: security_analysis
    :responsible: rl__security_engineer
    :approved_by: rl__security_manager

--- a/process/process_areas/security_analysis/security_analysis_workproducts.rst
+++ b/process/process_areas/security_analysis/security_analysis_workproducts.rst
@@ -28,7 +28,7 @@ Security Analysis Work Products
 
 .. workproduct:: Feature Security Analysis
    :id: wp__feature_security_analysis
-   :status: draft
+   :status: valid
    :tags: doc_lifecycle_model_2
    :complies: std_wp__isosae21434__development_1055, std_wp__isosae21434__assessment_15332, std_wp__isosae21434__assessment_15431, std_wp__isosae21434__assessment_15631, std_wp__isosae21434__assessment_15731, std_wp__isosae21434__assessment_15831, std_wp__isosae21434__assessment_15931
 
@@ -45,7 +45,7 @@ Security Analysis Work Products
 
 .. workproduct:: Component Security Analysis
    :id: wp__sw_component_security_analysis
-   :status: draft
+   :status: valid
    :tags: doc_lifecycle_model_2
    :complies: std_wp__isosae21434__development_1055, std_wp__isosae21434__assessment_15332, std_wp__isosae21434__assessment_15431, std_wp__isosae21434__assessment_15631, std_wp__isosae21434__assessment_15731, std_wp__isosae21434__assessment_15831, std_wp__isosae21434__assessment_15931
 

--- a/process/process_areas/security_management/security_management_roles.rst
+++ b/process/process_areas/security_management/security_management_roles.rst
@@ -18,7 +18,7 @@ Roles
 
 .. role:: Security Manager
    :id: rl__security_manager
-   :status: draft
+   :status: valid
    :tags: security_management
    :contains: rl__committer
 

--- a/process/process_areas/security_management/security_management_workproducts.rst
+++ b/process/process_areas/security_management/security_management_workproducts.rst
@@ -131,7 +131,7 @@ Security Management Work Products
 
 .. workproduct:: Platform Software Bill of Material (SBOM)
    :id: wp__sw_platform_sbom
-   :status: draft
+   :status: valid
    :tags: doc_lifecycle_model_2
    :complies: std_wp__isosae21434__continual_8631
 
@@ -140,7 +140,7 @@ Security Management Work Products
 
 .. workproduct:: Module Software Bill of Material (SBOM)
    :id: wp__sw_module_sbom
-   :status: draft
+   :status: valid
    :tags: doc_lifecycle_model_2
    :complies: std_wp__isosae21434__continual_8631
 

--- a/process/process_areas/verification/guidance/verification_process_reqs.rst
+++ b/process/process_areas/verification/guidance/verification_process_reqs.rst
@@ -145,7 +145,7 @@ Process Requirements
 
 .. gd_req:: Verification Documentation Checks Extended
     :id: gd_req__verification_checks_extended
-    :status: draft
+    :status: valid
     :tags: verification
     :satisfies: wf__verification_unit_test, wf__verification_comp_int_test, wf__verification_feat_int_test, wf__verification_platform_int_test
     :complies:


### PR DESCRIPTION
Due to the new check the links are checked to avoid that valid requirements or documents are linked to invalid or draft ones. For the processes all elements shall be valid so I changed the status, except of folder_templates.