### PR TITLE
add versioning of requirements

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -42,3 +42,8 @@ python.toolchain(
 #
 ###############################################################################
 bazel_dep(name = "score_docs_as_code", version = "4.4.1")
+git_override(
+    module_name = "score_docs_as_code",
+    commit = "4090f017f935899b15ea3d0b2649b359ee6a72d8",
+    remote = "https://github.com/eclipse-score/docs-as-code.git",
+)

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -286,8 +286,6 @@
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_shell/0.4.1/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/score_devcontainer/1.7.0/MODULE.bazel": "f9a5971fbd05f0ed14e7a373dbf58af72a5c58d081537a75c314daaf61c92ae9",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/score_devcontainer/1.7.0/source.json": "a3f55522fd9f63fae7a92f3cb5f91c25ae7474a39e9f9c633f0cf797fc0ca8e5",
-    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/score_docs_as_code/4.4.1/MODULE.bazel": "982f05f4680219ec0e05fd111554abfd5ae6f6473d6bef661f7c82eb2c2f8cb1",
-    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/score_docs_as_code/4.4.1/source.json": "4e119a06848b64f99619b21693e4a7eff30e02051a9997e5fbf5f8d21b2012d3",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/stardoc/0.5.1/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/stardoc/0.5.3/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/stardoc/0.5.6/MODULE.bazel": "not found",

--- a/process/folder_templates/platform/docs/release/release_note.rst
+++ b/process/folder_templates/platform/docs/release/release_note.rst
@@ -20,9 +20,10 @@ Platform Release Note
 .. document:: Platform Release Note
    :id: doc__platform_release_note
    :status: draft
+   :version: 1
    :safety: ASIL_B
    :security: NO
-   :realizes: wp__platform_sw_release_note
+   :realizes: wp__platform_sw_release_note[version==1]
    :tags: template
 
    .. attention::

--- a/process/folder_templates/platform/docs/safety_mgt/platform_dfa.rst
+++ b/process/folder_templates/platform/docs/safety_mgt/platform_dfa.rst
@@ -19,9 +19,10 @@ Platform DFA (Dependent Failure Analysis)
 .. document:: Platform DFA
    :id: doc__platform_dfa
    :status: draft
+   :version: 1
    :safety: ASIL_B
    :security: NO
-   :realizes: wp__platform_dfa
+   :realizes: wp__platform_dfa[version==1]
    :tags: template
 
 .. note:: The platform DFA is only performed once at platform level to analyse the dependencies between the features of the platform.
@@ -268,6 +269,7 @@ For all identified applicable failure initiators, the DFA is performed in the fo
        :mitigation_issue: <ID from Issue Tracker>
        :sufficient: <yes|no>
        :status: <valid|invalid>
+       :version: 1
 .. note::   Argument is inside the 'content'. Therefore content is mandatory.
 
 .. attention::

--- a/process/folder_templates/platform/docs/safety_mgt/platform_safety_analysis_fdr.rst
+++ b/process/folder_templates/platform/docs/safety_mgt/platform_safety_analysis_fdr.rst
@@ -19,9 +19,10 @@ Platform Safety Analysis Formal Review Report
 .. document:: Platform Safety Analysis Formal Review Report
    :id: doc__platform_safety_analysis_fdr
    :status: draft
+   :version: 1
    :safety: ASIL_B
    :security: YES
-   :realizes: wp__fdr_reports
+   :realizes: wp__fdr_reports[version==1]
    :tags: template
 
 

--- a/process/folder_templates/platform/docs/safety_mgt/platform_safety_manual.rst
+++ b/process/folder_templates/platform/docs/safety_mgt/platform_safety_manual.rst
@@ -20,9 +20,10 @@ Platform Safety Manual
 .. document:: Platform Safety Manual
    :id: doc__platform_safety_manual
    :status: draft
+   :version: 1
    :safety: ASIL_B
    :security: NO
-   :realizes: wp__platform_safety_manual
+   :realizes: wp__platform_safety_manual[version==1]
    :tags: template
 
 .. attention::

--- a/process/folder_templates/platform/docs/safety_mgt/platform_safety_package_fdr.rst
+++ b/process/folder_templates/platform/docs/safety_mgt/platform_safety_package_fdr.rst
@@ -20,9 +20,10 @@ Platform Safety Package Formal Review Report
 .. document:: Platform Safety Package Formal Review
    :id: doc__platform_safety_package_fdr
    :status: draft
+   :version: 1
    :safety: ASIL_B
    :security: NO
-   :realizes: wp__fdr_reports
+   :realizes: wp__fdr_reports[version==1]
    :tags: template
 
 

--- a/process/folder_templates/platform/docs/safety_mgt/platform_safety_plan.rst
+++ b/process/folder_templates/platform/docs/safety_mgt/platform_safety_plan.rst
@@ -20,9 +20,10 @@ Platform Safety Planning
 .. document:: Platform Safety Plan
    :id: doc__platform_safety_plan
    :status: draft
+   :version: 1
    :safety: ASIL_B
    :security: NO
-   :realizes: wp__platform_safety_plan
+   :realizes: wp__platform_safety_plan[version==1]
    :tags: template
 
 .. attention::

--- a/process/folder_templates/platform/docs/safety_mgt/platform_safety_plan_fdr.rst
+++ b/process/folder_templates/platform/docs/safety_mgt/platform_safety_plan_fdr.rst
@@ -20,9 +20,10 @@ Platform Safety Plan Formal Review Report
 .. document:: Platform Safety Plan Formal Review
    :id: doc__platform_safety_plan_fdr
    :status: draft
+   :version: 1
    :safety: ASIL_B
    :security: NO
-   :realizes: wp__fdr_reports
+   :realizes: wp__fdr_reports[version==1]
    :tags: template
 
 

--- a/process/folder_templates/platform/docs/security_mgt/platform_security_analysis.rst
+++ b/process/folder_templates/platform/docs/security_mgt/platform_security_analysis.rst
@@ -19,9 +19,10 @@ Platform Security Analysis
 .. document:: Platform Security Analysis
    :id: doc__platform_security_analysis
    :status: draft
+   :version: 1
    :safety: ASIL_B
    :security: YES
-   :realizes: wp__platform_security_analysis
+   :realizes: wp__platform_security_analysis[version==1]
    :tags: template
 
 

--- a/process/folder_templates/platform/docs/security_mgt/platform_security_analysis_fdr.rst
+++ b/process/folder_templates/platform/docs/security_mgt/platform_security_analysis_fdr.rst
@@ -19,9 +19,10 @@ Platform Security Analysis Checklist
 .. document:: [Your Platform Name] Security Analysis Checklist
    :id: doc__platform_name_security_analysis_fdr
    :status: draft
+   :version: 1
    :safety: ASIL_B
    :security: YES
-   :realizes: wp__fdr_reports
+   :realizes: wp__fdr_reports[version==1]
    :tags: template
 
 .. attention::

--- a/process/folder_templates/platform/docs/security_mgt/platform_security_manual.rst
+++ b/process/folder_templates/platform/docs/security_mgt/platform_security_manual.rst
@@ -20,9 +20,10 @@ Platform Security Manual
 .. document:: Platform Security Manual
    :id: doc__platform_security_manual
    :status: draft
+   :version: 1
    :safety: ASIL_B
    :security: YES
-   :realizes: wp__platform_security_manual
+   :realizes: wp__platform_security_manual[version==1]
    :tags: template
 
 Introduction/Scope

--- a/process/folder_templates/platform/docs/security_mgt/platform_security_package_fdr.rst
+++ b/process/folder_templates/platform/docs/security_mgt/platform_security_package_fdr.rst
@@ -19,9 +19,10 @@ Platform Security Package Checklist
 .. document:: [Your Platform Name] Security Package Checklist
    :id: doc__platform_name_security_package_fdr
    :status: draft
+   :version: 1
    :safety: ASIL_B
    :security: YES
-   :realizes: wp__fdr_reports
+   :realizes: wp__fdr_reports[version==1]
    :tags: template
 
 .. attention::

--- a/process/folder_templates/platform/docs/security_mgt/platform_security_plan.rst
+++ b/process/folder_templates/platform/docs/security_mgt/platform_security_plan.rst
@@ -20,9 +20,10 @@ Platform Security Planning
 .. document:: Platform Security Plan
    :id: doc__platform_security_plan
    :status: draft
+   :version: 1
    :safety: ASIL_B
    :security: YES
-   :realizes: wp__platform_security_plan
+   :realizes: wp__platform_security_plan[version==1]
    :tags: template
 
 .. attention::

--- a/process/folder_templates/platform/docs/security_mgt/platform_security_plan_fdr.rst
+++ b/process/folder_templates/platform/docs/security_mgt/platform_security_plan_fdr.rst
@@ -19,9 +19,10 @@ Platform Security Plan Formal Review Report
 .. document:: [Your Platform Name] Security Analysis Checklist
    :id: doc__platform_name_security_plan_fdr
    :status: draft
+   :version: 1
    :safety: ASIL_B
    :security: YES
-   :realizes: wp__fdr_reports
+   :realizes: wp__fdr_reports[version==1]
    :tags: template
 
 .. attention::

--- a/process/folder_templates/platform/docs/verification/platform_verification_report.rst
+++ b/process/folder_templates/platform/docs/verification/platform_verification_report.rst
@@ -20,9 +20,10 @@ Platform Verification Report
 .. document:: Platform Verification Report
    :id: doc__platform_verification_report
    :status: draft
+   :version: 1
    :safety: ASIL_B
    :security: YES
-   :realizes: wp__verification_platform_ver_report
+   :realizes: wp__verification_platform_ver_report[version==1]
    :tags: template
 
 .. attention::

--- a/process/folder_templates/platform/features/feature_name/architecture/index.rst
+++ b/process/folder_templates/platform/features/feature_name/architecture/index.rst
@@ -23,9 +23,10 @@ Feature Architecture
 .. document:: [Your Feature Name] Architecture
    :id: doc__feature_name_architecture
    :status: draft
+   :version: 1
    :safety: ASIL_B
    :security: NO
-   :realizes: wp__feature_arch
+   :realizes: wp__feature_arch[version==1]
    :tags: template
 
 .. attention::
@@ -93,6 +94,7 @@ Logical Interfaces
       :security: YES
       :safety: ASIL_B
       :status: invalid
+      :version: 1
       :fulfils: feat_req__feature_name__some_title
 
       General Interface Description
@@ -108,6 +110,7 @@ Logical Interfaces
       :security: YES
       :safety: ASIL_B
       :status: invalid
+      :version: 1
       :included_by: logic_arc_int__feature_name__interface_name1
 
       General Operation Description

--- a/process/folder_templates/platform/features/feature_name/index.rst
+++ b/process/folder_templates/platform/features/feature_name/index.rst
@@ -22,9 +22,10 @@
 .. document:: [Your Feature Name]
    :id: doc__feature_name
    :status: draft
+   :version: 1
    :safety: ASIL_B
    :security: YES
-   :realizes: wp__feat_request
+   :realizes: wp__feat_request[version==1]
    :tags: template
 
 .. attention::
@@ -58,6 +59,7 @@ Abstract
       :security: YES
       :safety: ASIL_B
       :status: invalid
+      :version: 1
       :includes: logic_arc_int__feature_name__interface_name1
 
       General Feature Description

--- a/process/folder_templates/platform/features/feature_name/requirements/chklst_req_inspection.rst
+++ b/process/folder_templates/platform/features/feature_name/requirements/chklst_req_inspection.rst
@@ -16,9 +16,10 @@
 .. document:: [Your Feature Name] Requirements Inspection Checklist
    :id: doc__feature_name_req_inspection
    :status: draft
+   :version: 1
    :safety: ASIL_B
    :security: YES
-   :realizes: wp__requirements_inspect
+   :realizes: wp__requirements_inspect[version==1]
    :tags: template
 
 .. attention::

--- a/process/folder_templates/platform/features/feature_name/requirements/index.rst
+++ b/process/folder_templates/platform/features/feature_name/requirements/index.rst
@@ -18,9 +18,10 @@ Feature Requirements
 .. document:: [Your Feature Name] Requirements
    :id: doc__feature_name_requirements
    :status: draft
+   :version: 1
    :safety: ASIL_B
    :security: NO
-   :realizes: wp__requirements_feat
+   :realizes: wp__requirements_feat[version==1]
    :tags: template
 
 .. attention::
@@ -45,6 +46,7 @@ Feature Requirements
       :valid_from: v0.0.1
       :valid_until: v1.0.1
       :status: invalid
+      :version: 1
       :satisfied_by: feat__feature_name
 
       The Feature shall do xyz to the user to bring him to this condition at this time.
@@ -59,6 +61,7 @@ Feature Requirements
       :security: NO
       :safety: ASIL_B
       :status: invalid
+      :version: 1
 
       The Feature User shall do xyz to use the feature safely.
 

--- a/process/folder_templates/platform/requirements/stakeholder/chklst_req_inspection.rst
+++ b/process/folder_templates/platform/requirements/stakeholder/chklst_req_inspection.rst
@@ -16,9 +16,10 @@
 .. document:: Stakeholder Requirements Inspection Checklist
    :id: doc__stakeholder_req_inspection
    :status: draft
+   :version: 1
    :safety: ASIL_B
    :security: YES
-   :realizes: wp__requirements_inspect
+   :realizes: wp__requirements_inspect[version==1]
    :tags: template
 
 .. attention::

--- a/process/folder_templates/platform/requirements/stakeholder/index.rst
+++ b/process/folder_templates/platform/requirements/stakeholder/index.rst
@@ -18,9 +18,10 @@ Stakeholder Requirements
 .. document:: Platform Requirements
    :id: doc__platform_name_requirements
    :status: draft
+   :version: 1
    :safety: ASIL_B
    :security: YES
-   :realizes: wp__requirements_feat
+   :realizes: wp__requirements_feat[version==1]
    :tags: template
 
 .. attention::
@@ -43,6 +44,7 @@ Stakeholder Requirements
       :valid_from: v0.0.1
       :valid_until: v1.0.1
       :status: invalid
+      :version: 1
 
       The platform shall ...
 
@@ -54,6 +56,7 @@ Stakeholder Requirements
       :security: YES
       :safety: ASIL_B
       :status: invalid
+      :version: 1
 
       The Platform User shall do xyz to use the platform safely.
 

--- a/process/folder_templates/tools/tool_verification_report_template.rst
+++ b/process/folder_templates/tools/tool_verification_report_template.rst
@@ -20,11 +20,12 @@ Tool Verification Report Template
 .. doc_tool:: [Your Tool Name]
    :id: doc_tool__tool_name_version
    :status: draft
+   :version: 1
    :tool_version: vX.Y.Z
    :tcl: LOW
    :safety_affected: YES
    :security_affected: YES
-   :realizes: wp__tool_verification_report
+   :realizes: wp__tool_verification_report[version==1]
    :tags: template, tool_management
 
 .. attention::

--- a/process/general_concepts/score_building_blocks_concept.rst
+++ b/process/general_concepts/score_building_blocks_concept.rst
@@ -20,6 +20,7 @@ Building blocks concept
 .. doc_concept:: Building Block Concept
    :id: doc_concept__general_building_blocks
    :status: valid
+   :version: 1
    :tags: process_management
 
 .. attention::

--- a/process/general_concepts/score_lifecycle_concept.rst
+++ b/process/general_concepts/score_lifecycle_concept.rst
@@ -20,6 +20,7 @@ Lifecycle concept
 .. doc_concept:: Lifecycle Concept
    :id: doc_concept__general_lifecycle
    :status: valid
+   :version: 1
    :tags: process_management
 
 Contributions to the project are driven by feature/component requests.

--- a/process/general_concepts/score_review_concept.rst
+++ b/process/general_concepts/score_review_concept.rst
@@ -20,6 +20,7 @@ Review and Inspection Concept
 .. doc_concept:: Work product Inspections Concept
    :id: doc_concept__wp_inspections
    :status: valid
+   :version: 1
 
 Inspection Definition
 ^^^^^^^^^^^^^^^^^^^^^
@@ -185,9 +186,10 @@ Process Requirements
 .. gd_req:: Version for inspected requirements
    :id: gd_req__general_requirements_version
    :status: valid
+   :version: 1
    :tags: prio_1_automation, general
-   :complies: std_req__iso26262__support_6433, std_req__iso26262__software_7414
-   :satisfies: wf__monitor_verify_requirements
+   :complies: std_req__iso26262__support_6433[version==1], std_req__iso26262__software_7414[version==1]
+   :satisfies: wf__monitor_verify_requirements[version==1]
 
    The version of a requirement shall not change by an inspection.
 
@@ -198,9 +200,10 @@ Process Requirements
 .. gd_req:: Version for inspected architecture
    :id: gd_req__general_architecture_version
    :status: valid
+   :version: 1
    :tags: general
-   :complies: std_req__iso26262__support_6433, std_req__iso26262__software_7414
-   :satisfies: wf__mr_vy_arch
+   :complies: std_req__iso26262__support_6433[version==1], std_req__iso26262__software_7414[version==1]
+   :satisfies: wf__mr_vy_arch[version==1]
 
    The version of architecture element shall not change by an inspection.
 
@@ -213,9 +216,10 @@ Process Requirements
 .. gd_req:: Checklist templates in pull requests
    :id: gd_req__general_checklist_templates
    :status: valid
+   :version: 1
    :tags: prio_2_automation, general
-   :complies: std_req__iso26262__support_6433, std_req__iso26262__software_7414, std_req__iso26262__software_942
-   :satisfies: wf__monitor_verify_requirements, wf__mr_vy_arch
+   :complies: std_req__iso26262__support_6433[version==1], std_req__iso26262__software_7414[version==1], std_req__iso26262__software_942[version==1]
+   :satisfies: wf__monitor_verify_requirements[version==1], wf__mr_vy_arch[version==1]
 
    For every pull request that modifies a work product subject to inspection,
    a pull‑request template containing the applicable inspection checklist items shall be provided.
@@ -225,17 +229,19 @@ Process Requirements
 .. gd_req:: Status Set Check
    :id: gd_req__general_status_set_check
    :status: valid
+   :version: 1
    :tags: prio_2_automation, general
-   :complies: std_req__iso26262__support_6433, std_req__iso26262__software_7414
-   :satisfies: wf__monitor_verify_requirements, wf__mr_vy_arch
+   :complies: std_req__iso26262__support_6433[version==1], std_req__iso26262__software_7414[version==1]
+   :satisfies: wf__monitor_verify_requirements[version==1], wf__mr_vy_arch[version==1]
 
    It shall be checked that only a PR with the inspection checklist filled out can set a status to valid(inspected).
 
 .. gd_req:: Status Reset Check
    :id: gd_req__general_status_reset_check
    :status: valid
+   :version: 1
    :tags: prio_2_automation, general
-   :complies: std_req__iso26262__support_6433, std_req__iso26262__software_7414
-   :satisfies: wf__monitor_verify_requirements, wf__mr_vy_arch
+   :complies: std_req__iso26262__support_6433[version==1], std_req__iso26262__software_7414[version==1]
+   :satisfies: wf__monitor_verify_requirements[version==1], wf__mr_vy_arch[version==1]
 
    It shall be checked that the status is reset to valid whenever a requirement is modified (changes version).

--- a/process/general_concepts/score_traceability_concept.rst
+++ b/process/general_concepts/score_traceability_concept.rst
@@ -20,6 +20,7 @@ Traceability concept
 .. doc_concept:: Traceability Concept
    :id: doc_concept__general_traceability
    :status: valid
+   :version: 1
    :tags: process_management
 
 .. attention::

--- a/process/introduction/index.rst
+++ b/process/introduction/index.rst
@@ -20,6 +20,7 @@ Introduction
 .. doc_concept:: Process Meta Model
    :id: doc_concept__process_meta_model
    :status: valid
+   :version: 1
    :tags: process_management
 
 .. toctree::

--- a/process/process_areas/architecture_design/architecture_concept.rst
+++ b/process/process_areas/architecture_design/architecture_concept.rst
@@ -18,6 +18,7 @@ Concept Description
 .. doc_concept:: Architecture Process
    :id: doc_concept__arch_process
    :status: valid
+   :version: 1
 
 In this section a concept for the architecture design will be discussed.
 
@@ -431,6 +432,7 @@ The following section links to the rendered feature example that is now maintain
       :security: YES
       :safety: ASIL_B
       :status: invalid
+      :version: 1
       :includes: logic_arc_int__feature_name__interface_name
       :consists_of: comp__component_name
 
@@ -439,6 +441,7 @@ The following section links to the rendered feature example that is now maintain
       :security: YES
       :safety: QM
       :status: valid
+      :version: 1
       :includes: logic_arc_int__example_feature__archex_logical_interface_1, logic_arc_int__example_feature__archex_logical_interface_2
       :fulfils: feat_req__example_feature__archdes_example_req
       :belongs_to: feat__example_feature
@@ -462,6 +465,7 @@ The rendered component examples are maintained in the
    .. comp_arc_sta:: Static View - Rendered Example
       :id: comp_arc_sta__example_feature__component_getstrt
       :status: valid
+      :version: 1
       :safety: ASIL_B
       :security: NO
       :fulfils: comp_req__example_feature__archex_example_req
@@ -523,6 +527,7 @@ To make *needuml* work we have to replace the *need()* call with a different fun
    .. comp_arc_sta:: Component Architecture Static View - Rendered Example Manually Edited
       :id: comp_arc_sta__example_feature__component_manual_getstrt
       :status: valid
+      :version: 1
       :safety: ASIL_B
       :security: NO
       :uses: logic_arc_int__example_feature__archex_logical_interface_1

--- a/process/process_areas/architecture_design/architecture_getstrt.rst
+++ b/process/process_areas/architecture_design/architecture_getstrt.rst
@@ -20,6 +20,7 @@ Getting Started
 .. doc_getstrt:: Architecture Design Process
    :id: doc_getstrt__arch_process
    :status: valid
+   :version: 1
 
 This document describes the steps to create the architectural design of a system. It provides an overview of the necessary activities and their sequence to effectively design both the feature architecture and the component architecture.
 

--- a/process/process_areas/architecture_design/architecture_workflow.rst
+++ b/process/process_areas/architecture_design/architecture_workflow.rst
@@ -22,56 +22,60 @@ For a detailed explanation of workflows and their role within the process model,
 .. workflow:: Create/Maintain Platform architecture
    :id: wf__cr_mt_platarch
    :status: valid
+   :version: 1
    :tags: architecture_design
-   :responsible: rl__contributor
-   :approved_by: rl__committer
-   :supported_by: rl__safety_manager, rl__security_manager
-   :input: wp__requirements_stkh, wp__issue_track_system
-   :output: wp__platform_arch
-   :contains: gd_guidl__arch_design
-   :has: doc_concept__arch_process, doc_getstrt__arch_process
+   :responsible: rl__contributor[version==1]
+   :approved_by: rl__committer[version==1]
+   :supported_by: rl__safety_manager[version==1], rl__security_manager[version==1]
+   :input: wp__requirements_stkh[version==1], wp__issue_track_system[version==1]
+   :output: wp__platform_arch[version==1]
+   :contains: gd_guidl__arch_design[version==1]
+   :has: doc_concept__arch_process[version==1], doc_getstrt__arch_process[version==1]
 
    The platform architecture is created and maintained.
 
 .. workflow:: Create/Maintain Feature architecture
    :id: wf__cr_mt_featarch
    :status: valid
+   :version: 1
    :tags: architecture_design
-   :responsible: rl__contributor
-   :approved_by: rl__committer
-   :supported_by: rl__safety_manager, rl__security_manager
-   :input: wp__requirements_feat, wp__issue_track_system
-   :output: wp__feature_arch
-   :contains: gd_guidl__arch_design, gd_temp__arch_feature
-   :has: doc_concept__arch_process, doc_getstrt__arch_process
+   :responsible: rl__contributor[version==1]
+   :approved_by: rl__committer[version==1]
+   :supported_by: rl__safety_manager[version==1], rl__security_manager[version==1]
+   :input: wp__requirements_feat[version==1], wp__issue_track_system[version==1]
+   :output: wp__feature_arch[version==1]
+   :contains: gd_guidl__arch_design[version==1], gd_temp__arch_feature[version==1]
+   :has: doc_concept__arch_process[version==1], doc_getstrt__arch_process[version==1]
 
    The feature architectures are created and maintained.
 
 .. workflow:: Create/Maintain Components architecture
    :id: wf__cr_mt_comparch
    :status: valid
+   :version: 1
    :tags: architecture_design
-   :responsible: rl__contributor
-   :approved_by: rl__committer
-   :supported_by: rl__safety_manager, rl__security_manager
-   :input: wp__feature_arch, wp__requirements_comp, wp__issue_track_system
-   :output: wp__component_arch
-   :contains: gd_guidl__arch_design, gd_temp__arch_comp
-   :has: doc_concept__arch_process, doc_getstrt__arch_process
+   :responsible: rl__contributor[version==1]
+   :approved_by: rl__committer[version==1]
+   :supported_by: rl__safety_manager[version==1], rl__security_manager[version==1]
+   :input: wp__feature_arch[version==1], wp__requirements_comp[version==1], wp__issue_track_system[version==1]
+   :output: wp__component_arch[version==1]
+   :contains: gd_guidl__arch_design[version==1], gd_temp__arch_comp[version==1]
+   :has: doc_concept__arch_process[version==1], doc_getstrt__arch_process[version==1]
 
    The component architectures are created and maintained.
 
 .. workflow:: Monitor/Verify Architecture
    :id: wf__mr_vy_arch
    :status: valid
+   :version: 1
    :tags: architecture_design
-   :responsible: rl__committer
-   :approved_by: rl__committer
-   :supported_by: rl__safety_manager, rl__security_manager
-   :input: wp__feature_arch, wp__component_arch
-   :output: wp__issue_track_system, wp__sw_arch_verification
-   :contains: gd_guidl__arch_design, gd_chklst__arch_inspection_checklist
-   :has: doc_concept__arch_process, doc_getstrt__arch_process
+   :responsible: rl__committer[version==1]
+   :approved_by: rl__committer[version==1]
+   :supported_by: rl__safety_manager[version==1], rl__security_manager[version==1]
+   :input: wp__feature_arch[version==1], wp__component_arch[version==1]
+   :output: wp__issue_track_system[version==1], wp__sw_arch_verification[version==1]
+   :contains: gd_guidl__arch_design[version==1], gd_chklst__arch_inspection_checklist[version==1]
+   :has: doc_concept__arch_process[version==1], doc_getstrt__arch_process[version==1]
 
    The architecture designs are monitored and verified.
 

--- a/process/process_areas/architecture_design/architecture_workproducts.rst
+++ b/process/process_areas/architecture_design/architecture_workproducts.rst
@@ -20,7 +20,8 @@ Architecture Work Products
 .. workproduct:: Platform Architecture
    :id: wp__platform_arch
    :status: valid
-   :complies: std_wp__iso26262__software_751, std_wp__isosae21434__development_1051, std_req__aspice_40__iic-04-04
+   :version: 1
+   :complies: std_wp__iso26262__software_751[version==1], std_wp__isosae21434__development_1051[version==1], std_req__aspice_40__iic-04-04[version==1]
    :tags: doc_lifecycle_model_3
 
    Platform Architecture describes the overall software structure with the belonging features, modules and their logical interfaces, i.e. top-level decomposition of the platform into features and their interactions
@@ -30,7 +31,8 @@ Architecture Work Products
 .. workproduct:: Feature Architecture
    :id: wp__feature_arch
    :status: valid
-   :complies: std_wp__iso26262__software_751, std_wp__isosae21434__development_1051, std_req__aspice_40__iic-04-04
+   :version: 1
+   :complies: std_wp__iso26262__software_751[version==1], std_wp__isosae21434__development_1051[version==1], std_req__aspice_40__iic-04-04[version==1]
    :tags: doc_lifecycle_model_3
 
    Feature Architecture linked to Feature Requirements, i.e. interaction of components
@@ -44,7 +46,11 @@ Architecture Work Products
 .. workproduct:: Component Architecture
    :id: wp__component_arch
    :status: valid
-   :complies: std_wp__iso26262__software_751, std_wp__isopas8926__4523, std_wp__isosae21434__development_1051, std_req__aspice_40__iic-04-04
+   :version: 1
+   :complies: std_wp__iso26262__software_751[version==1],
+              std_wp__isopas8926__4523[version==1],
+              std_wp__isosae21434__development_1051[version==1],
+              std_req__aspice_40__iic-04-04[version==1]
    :tags: doc_lifecycle_model_3
 
    Component Architecture linked to Component Requirements
@@ -58,7 +64,8 @@ Architecture Work Products
 .. workproduct:: Architecture Verification
    :id: wp__sw_arch_verification
    :status: valid
-   :complies: std_wp__iso26262__software_754
+   :version: 1
+   :complies: std_wp__iso26262__software_754[version==1]
    :tags: doc_lifecycle_model_2
 
    Depends on architecture guideline and tooling.

--- a/process/process_areas/architecture_design/guidance/architecture_guideline.rst
+++ b/process/process_areas/architecture_design/guidance/architecture_guideline.rst
@@ -20,7 +20,12 @@ Architecture Guideline
 .. gd_guidl:: Architectural Design Guideline
    :id: gd_guidl__arch_design
    :status: valid
-   :complies: std_req__isopas8926__44411, std_req__isopas8926__44412, std_req__iso26262__software_743, std_req__iso26262__software_744, std_req__iso26262__software_745
+   :version: 1
+   :complies: std_req__isopas8926__44411[version==1],
+              std_req__isopas8926__44412[version==1],
+              std_req__iso26262__software_743[version==1],
+              std_req__iso26262__software_744[version==1],
+              std_req__iso26262__software_745[version==1]
 
 The guideline focuses on the steps which need to be performed in order to create the architectural design. The concept behind those steps is described in the :need:`[[title]] <doc_concept__arch_process>`.
 

--- a/process/process_areas/architecture_design/guidance/architecture_inspection_checklist.rst
+++ b/process/process_areas/architecture_design/guidance/architecture_inspection_checklist.rst
@@ -20,8 +20,16 @@ Architecture Inspection Checklist Template
 .. gd_chklst:: Architecture Inspection Checklist Template
     :id: gd_chklst__arch_inspection_checklist
     :status: valid
+    :version: 1
     :tags: architecture_design
-    :complies: std_req__iso26262__software_647, std_req__iso26262__software_743, std_req__iso26262__software_749, std_req__iso26262__software_7413, std_req__aspice_40__iic-15-51, std_req__aspice_40__SWE-2-BP4, std_req__aspice_40__iic-13-51, std_req__aspice_40__SWE-2-BP5
+    :complies: std_req__iso26262__software_647[version==1],
+               std_req__iso26262__software_743[version==1],
+               std_req__iso26262__software_749[version==1],
+               std_req__iso26262__software_7413[version==1],
+               std_req__aspice_40__iic-15-51[version==1],
+               std_req__aspice_40__SWE-2-BP4[version==1],
+               std_req__aspice_40__iic-13-51[version==1],
+               std_req__aspice_40__SWE-2-BP5[version==1]
 
     For the content see here:
 

--- a/process/process_areas/architecture_design/guidance/architecture_process_reqs.rst
+++ b/process/process_areas/architecture_design/guidance/architecture_process_reqs.rst
@@ -23,18 +23,20 @@ Architectural Model
 .. gd_req:: Architecture Modeling
    :id: gd_req__arch_model
    :status: valid
+   :version: 1
    :tags: manual_prio_1
-   :complies: std_req__iso26262__support_6431, std_req__iso26262__support_6432
-   :satisfies: wf__cr_mt_featarch, wf__cr_mt_comparch
+   :complies: std_req__iso26262__support_6431[version==1], std_req__iso26262__support_6432[version==1]
+   :satisfies: wf__cr_mt_featarch[version==1], wf__cr_mt_comparch[version==1]
 
    For architecture design a model based approach should be used. The model shall consist of different architectural elements.
 
 .. gd_req:: Hierarchical structure of architectural elements
    :id: gd_req__arch_hierarchical_structure
    :status: valid
+   :version: 1
    :tags: done_automation
-   :complies: std_req__iso26262__support_6431, std_req__iso26262__support_6432, std_req__iso26262__software_743
-   :satisfies: wf__cr_mt_featarch, wf__cr_mt_comparch
+   :complies: std_req__iso26262__support_6431[version==1], std_req__iso26262__support_6432[version==1], std_req__iso26262__software_743[version==1]
+   :satisfies: wf__cr_mt_featarch[version==1], wf__cr_mt_comparch[version==1]
 
    The architectural elements shall be hierarchically structured on two levels:
 
@@ -44,9 +46,13 @@ Architectural Model
 .. gd_req:: Structuring of the architectural elements
    :id: gd_req__arch_build_blocks
    :status: valid
+   :version: 1
    :tags: done_automation
-   :complies: std_req__iso26262__support_6431, std_req__iso26262__support_6432, std_req__aspice_40__iic-01-03, std_req__aspice_40__iic-01-50
-   :satisfies: wf__cr_mt_featarch, wf__cr_mt_comparch
+   :complies: std_req__iso26262__support_6431[version==1],
+              std_req__iso26262__support_6432[version==1],
+              std_req__aspice_40__iic-01-03[version==1],
+              std_req__aspice_40__iic-01-50[version==1]
+   :satisfies: wf__cr_mt_featarch[version==1], wf__cr_mt_comparch[version==1]
 
    Following architectural elements shall be defined on the respective hierarchical level:
 
@@ -74,9 +80,10 @@ Architectural Model
 .. gd_req:: Correlations of the architectural building blocks
    :id: gd_req__arch_build_blocks_corr
    :status: valid
+   :version: 1
    :tags: done_automation
-   :complies: std_req__iso26262__support_6431, std_req__iso26262__support_6432
-   :satisfies: wf__cr_mt_featarch, wf__cr_mt_comparch
+   :complies: std_req__iso26262__support_6431[version==1], std_req__iso26262__support_6432[version==1]
+   :satisfies: wf__cr_mt_featarch[version==1], wf__cr_mt_comparch[version==1]
 
    For modeling the viewpoints following relations shall be used:
 
@@ -93,9 +100,13 @@ Architectural Views
 .. gd_req:: Architecture Viewpoints
    :id: gd_req__arch_viewpoints
    :status: valid
+   :version: 1
    :tags: manual_prio_1
-   :complies: std_req__iso26262__support_6432, std_req__iso26262__software_742, std_req__aspice_40__SWE-2-BP1, std_req__aspice_40__SWE-2-BP2
-   :satisfies: wf__cr_mt_featarch, wf__cr_mt_comparch
+   :complies: std_req__iso26262__support_6432[version==1],
+              std_req__iso26262__software_742[version==1],
+              std_req__aspice_40__SWE-2-BP1[version==1],
+              std_req__aspice_40__SWE-2-BP2[version==1]
+   :satisfies: wf__cr_mt_featarch[version==1], wf__cr_mt_comparch[version==1]
 
    The architecture shall be shown on following views on each architectural level:
 
@@ -111,9 +122,10 @@ Attributes of Architectural Elements
 .. gd_req:: Architecture attribute: UID
    :id: gd_req__arch_attribute_uid
    :status: valid
+   :version: 1
    :tags: manual_prio_1, attribute, mandatory
-   :complies: std_req__iso26262__support_6425, std_req__iso26262__support_6432
-   :satisfies: wf__cr_mt_featarch, wf__cr_mt_comparch
+   :complies: std_req__iso26262__support_6425[version==1], std_req__iso26262__support_6432[version==1]
+   :satisfies: wf__cr_mt_featarch[version==1], wf__cr_mt_comparch[version==1]
 
    Each architectural element shall have a unique ID. It shall be in a format which is also human readable and consists of
 
@@ -126,8 +138,9 @@ Attributes of Architectural Elements
 .. gd_req:: Architecture attribute: security
    :id: gd_req__arch_attr_security
    :status: valid
+   :version: 1
    :tags: manual_prio_1, attribute, mandatory
-   :satisfies: wf__cr_mt_featarch, wf__cr_mt_comparch
+   :satisfies: wf__cr_mt_featarch[version==1], wf__cr_mt_comparch[version==1]
 
    Each architectural element shall have a security relevance identifier:
 
@@ -137,9 +150,10 @@ Attributes of Architectural Elements
 .. gd_req:: Architecture attribute: safety
    :id: gd_req__arch_attr_safety
    :status: valid
+   :version: 1
    :tags: manual_prio_1, attribute, mandatory
-   :complies: std_req__iso26262__support_6421, std_req__iso26262__support_6425, std_req__iso26262__software_746
-   :satisfies: wf__cr_mt_featarch, wf__cr_mt_comparch
+   :complies: std_req__iso26262__support_6421[version==1], std_req__iso26262__support_6425[version==1], std_req__iso26262__software_746[version==1]
+   :satisfies: wf__cr_mt_featarch[version==1], wf__cr_mt_comparch[version==1]
 
    Each architectural element shall have a automotive safety integrity level (ASIL) identifier:
 
@@ -149,9 +163,10 @@ Attributes of Architectural Elements
 .. gd_req:: Architecture attribute: status
    :id: gd_req__arch_attr_status
    :status: valid
+   :version: 1
    :tags: manual_prio_1, attribute, mandatory
-   :complies: std_req__iso26262__support_6425
-   :satisfies: wf__cr_mt_featarch, wf__cr_mt_comparch
+   :complies: std_req__iso26262__support_6425[version==1]
+   :satisfies: wf__cr_mt_featarch[version==1], wf__cr_mt_comparch[version==1]
 
    Each architectural element shall have a status:
 
@@ -164,9 +179,10 @@ Traceability to Requirements and AoU
 .. gd_req:: Architecture attribute: fulfils
    :id: gd_req__arch_attr_fulfils
    :status: valid
+   :version: 1
    :tags: manual_prio_1, attribute
-   :complies: std_req__iso26262__support_6425, std_req__aspice_40__SWE-2-BP4
-   :satisfies: wf__cr_mt_featarch, wf__cr_mt_comparch
+   :complies: std_req__iso26262__support_6425[version==1], std_req__aspice_40__SWE-2-BP4[version==1]
+   :satisfies: wf__cr_mt_featarch[version==1], wf__cr_mt_comparch[version==1]
 
    Architectural views (feature/comp_arc_sta, feature/comp_arc_dyn) and interfaces (logic/real_arc_int)
    should be linked to a requirement on the corresponding level.
@@ -179,18 +195,20 @@ Traceability to Requirements and AoU
 .. gd_req:: Architecture attribute: fulfils (AoU)
    :id: gd_req__arch_attr_fulfils_aou
    :status: valid
+   :version: 1
    :tags: manual_prio_1, attribute
-   :complies: std_req__iso26262__support_6425, std_req__aspice_40__SWE-2-BP4
-   :satisfies: wf__cr_mt_featarch, wf__cr_mt_comparch
+   :complies: std_req__iso26262__support_6425[version==1], std_req__aspice_40__SWE-2-BP4[version==1]
+   :satisfies: wf__cr_mt_featarch[version==1], wf__cr_mt_comparch[version==1]
 
    Architectural elements (feat_arc_sta, comp) shall be linked to AoUs if the element fulfills these.
 
 .. gd_req:: Architecture traceability
    :id: gd_req__arch_traceability
    :status: valid
+   :version: 1
    :tags: manual_prio_1
-   :complies: std_req__iso26262__support_6432, std_req__aspice_40__SWE-2-BP4
-   :satisfies: wf__cr_mt_featarch, wf__cr_mt_comparch
+   :complies: std_req__iso26262__support_6432[version==1], std_req__aspice_40__SWE-2-BP4[version==1]
+   :satisfies: wf__cr_mt_featarch[version==1], wf__cr_mt_comparch[version==1]
 
    Requirements shall be satisfied by an architectural element on the corresponding level.
 
@@ -208,8 +226,9 @@ Checks for Architectural Design
 .. gd_req:: Check of Architecture mandatory attributes
    :id: gd_req__arch_attr_mandatory
    :status: valid
+   :version: 1
    :tags: prio_1_automation, attribute, check
-   :satisfies: wf__cr_mt_featarch, wf__cr_mt_comparch
+   :satisfies: wf__cr_mt_featarch[version==1], wf__cr_mt_comparch[version==1]
 
    It shall be checked if all mandatory attributes for each architectural element are provided by the user. For all elements following attributes shall be mandatory:
 
@@ -222,34 +241,38 @@ Checks for Architectural Design
 .. gd_req:: Check of Architecture linkage metamodel
    :id: gd_req__arch_linkage_safety
    :status: valid
+   :version: 1
    :tags: prio_1_automation, attribute, check
-   :satisfies: wf__cr_mt_featarch, wf__cr_mt_comparch
-   :complies: std_req__aspice_40__SWE-2-BP4
+   :satisfies: wf__cr_mt_featarch[version==1], wf__cr_mt_comparch[version==1]
+   :complies: std_req__aspice_40__SWE-2-BP4[version==1]
 
    It shall be checked that every valid safety architectural element is linked according to the defined model :need:`gd_req__arch_build_blocks_corr`.
 
 .. gd_req:: Check of Architecture linkage safety
    :id: gd_req__arch_linkage_safety_trace
    :status: valid
+   :version: 1
    :tags: prio_1_automation, attribute, check
-   :satisfies: wf__cr_mt_featarch, wf__cr_mt_comparch
-   :complies: std_req__iso26262__software_746, std_req__iso26262__software_748
+   :satisfies: wf__cr_mt_featarch[version==1], wf__cr_mt_comparch[version==1]
+   :complies: std_req__iso26262__software_746[version==1], std_req__iso26262__software_748[version==1]
 
    It shall be checked that valid safety architectural elements (Safety!=QM) can only be linked against valid safety architectural elements.
 
 .. gd_req:: Check of Architecture linkage security
    :id: gd_req__arch_linkage_security_trace
    :status: valid
+   :version: 1
    :tags: prio_2_automation, attribute, check
-   :satisfies: wf__cr_mt_featarch, wf__cr_mt_comparch
+   :satisfies: wf__cr_mt_featarch[version==1], wf__cr_mt_comparch[version==1]
 
    It shall be checked that security relevant architectural elements (Security==YES) can only be linked against security relevant architectural elements.
 
 .. gd_req:: Check of Architecture linkage requirement
    :id: gd_req__arch_linkage_requirement
    :status: valid
+   :version: 1
    :tags: prio_1_automation, attribute, check
-   :satisfies: wf__cr_mt_featarch, wf__cr_mt_comparch
+   :satisfies: wf__cr_mt_featarch[version==1], wf__cr_mt_comparch[version==1]
 
    It shall be checked that each architectural element (safety!=QM) is linked against at least one safety requirement (safety!=QM).
    It shall be checked that architectural elements with safety=QM are not linked against safety requirements (safety!=QM).
@@ -257,8 +280,9 @@ Checks for Architectural Design
 .. gd_req:: Check of Architecture linkage requirement type
    :id: gd_req__arch_linkage_requirement_type
    :status: valid
+   :version: 1
    :tags: prio_3_automation, attribute, check
-   :satisfies: wf__cr_mt_featarch, wf__cr_mt_comparch
+   :satisfies: wf__cr_mt_featarch[version==1], wf__cr_mt_comparch[version==1]
 
    It shall be checked that requirements of a respective type can only be linked to architectural elements according to following traceability:
 
@@ -268,8 +292,9 @@ Checks for Architectural Design
 .. gd_req:: Check of Architecture linkage to AoU
    :id: gd_req__arch_linkage_aou
    :status: valid
+   :version: 1
    :tags: prio_2_automation, attribute, check
-   :satisfies: wf__cr_mt_featarch, wf__cr_mt_comparch
+   :satisfies: wf__cr_mt_featarch[version==1], wf__cr_mt_comparch[version==1]
 
    It shall be checked that architectural static view (feature/comp_arc_sta) are not linked to its own AoU
    ("own" means the AoU linked as "mitigated_by" to the Safety/Security Analysis linked via "violates" to the element,
@@ -278,15 +303,17 @@ Checks for Architectural Design
 .. gd_req:: Check of Architecture consistency interfaces in modules
    :id: gd_req__arch_consistency_interf
    :status: valid
+   :version: 1
    :tags: prio_2_automation, model, check
-   :satisfies: wf__cr_mt_featarch, wf__cr_mt_comparch
+   :satisfies: wf__cr_mt_featarch[version==1], wf__cr_mt_comparch[version==1]
 
    It shall be checked if any interface referred by the features (link from Feature to Logical Arc. Interfaces must be defined and exists) is matched by an "implements" link in the Module (from component to Logical Arc. Interface). Additionally it shall be checked if the feature architecture are linked against at least one logical architectural interface.
 
 .. gd_req:: Check of Architecture consistency in dynamic architecture
    :id: gd_req__arch_consistency_dynamic
    :status: valid
+   :version: 1
    :tags: prio_3_automation, model, check
-   :satisfies: wf__cr_mt_featarch, wf__cr_mt_comparch
+   :satisfies: wf__cr_mt_featarch[version==1], wf__cr_mt_comparch[version==1]
 
    It shall be checked if all SW components which are mentioned in the dynamic architecture views are defined in the static architecture.

--- a/process/process_areas/architecture_design/guidance/component_architecture_template.rst
+++ b/process/process_areas/architecture_design/guidance/component_architecture_template.rst
@@ -18,8 +18,13 @@ Component Architecture Template
 .. gd_temp:: Component Architecture Templates
    :id: gd_temp__arch_comp
    :status: valid
+   :version: 1
    :tags: architecture_design
-   :complies: std_req__iso26262__software_741, std_req__iso26262__software_742, std_req__iso26262__software_743, std_req__iso26262__software_744, std_req__aspice_40__iic-04-04
+   :complies: std_req__iso26262__software_741[version==1],
+              std_req__iso26262__software_742[version==1],
+              std_req__iso26262__software_743[version==1],
+              std_req__iso26262__software_744[version==1],
+              std_req__aspice_40__iic-04-04[version==1]
 
    For the content see the
    `module template documentation <https://eclipse-score.github.io/module_template/component_architecture_template.html>`__.

--- a/process/process_areas/architecture_design/guidance/feature_architecture_template.rst
+++ b/process/process_areas/architecture_design/guidance/feature_architecture_template.rst
@@ -18,6 +18,10 @@ Feature Architecture Template
 .. gd_temp:: Feature Architecture Templates
     :id: gd_temp__arch_feature
     :status: valid
-    :complies: std_req__iso26262__software_741, std_req__iso26262__software_742, std_req__iso26262__software_743, std_req__aspice_40__iic-04-04
+    :version: 1
+    :complies: std_req__iso26262__software_741[version==1],
+               std_req__iso26262__software_742[version==1],
+               std_req__iso26262__software_743[version==1],
+               std_req__aspice_40__iic-04-04[version==1]
 
     For the content see here: :ref:`feature_architecture_template`

--- a/process/process_areas/change_management/change_management_concept.rst
+++ b/process/process_areas/change_management/change_management_concept.rst
@@ -18,6 +18,7 @@ Concept Description
 .. doc_concept:: Concept Description
    :id: doc_concept__change_process
    :status: valid
+   :version: 1
    :tags: change_management
 
 In this section a concept for the Change Management will be discussed. Inputs for this concepts

--- a/process/process_areas/change_management/change_management_getstrt.rst
+++ b/process/process_areas/change_management/change_management_getstrt.rst
@@ -18,6 +18,7 @@ Getting Started
 .. doc_getstrt:: Getting Started on Change Management
    :id: doc_getstrt__change_process
    :status: valid
+   :version: 1
    :tags: change_management
 
 This document describes the steps to create a change request, and further to analyze,

--- a/process/process_areas/change_management/change_management_workflow.rst
+++ b/process/process_areas/change_management/change_management_workflow.rst
@@ -22,14 +22,23 @@ For a detailed explanation of workflows and their role within the process model,
 .. workflow:: Create Change Request
    :id: wf__change_create_cr
    :status: valid
+   :version: 1
    :tags: change_management
-   :responsible: rl__contributor
-   :approved_by: rl__architecture_community
-   :supported_by: rl__platform_team
-   :input: wp__policies, wp__issue_track_system, wp__feat_request, wp__cmpt_request
-   :output: wp__issue_track_system, wp__feat_request, wp__cmpt_request
-   :contains: gd_guidl__change_change_request, gd_temp__change_feature_request, gd_temp__change_component_request, gd_temp__change_impact_analysis, gd_temp__component_classification, gd_temp__change_decision_record
-   :has: doc_concept__change_process, doc_getstrt__change_process
+   :responsible: rl__contributor[version==1]
+   :approved_by: rl__architecture_community[version==1]
+   :supported_by: rl__platform_team[version==1]
+   :input: wp__policies[version==1],
+           wp__issue_track_system[version==1],
+           wp__feat_request[version==1],
+           wp__cmpt_request[version==1]
+   :output: wp__issue_track_system[version==1], wp__feat_request[version==1], wp__cmpt_request[version==1]
+   :contains: gd_guidl__change_change_request[version==1],
+              gd_temp__change_feature_request[version==1],
+              gd_temp__change_component_request[version==1],
+              gd_temp__change_impact_analysis[version==1],
+              gd_temp__component_classification[version==1],
+              gd_temp__change_decision_record[version==1]
+   :has: doc_concept__change_process[version==1], doc_getstrt__change_process[version==1]
 
    The Change Request is created.
 
@@ -41,14 +50,23 @@ For a detailed explanation of workflows and their role within the process model,
 .. workflow:: Analyze Change Request
    :id: wf__change_analyze_cr
    :status: valid
+   :version: 1
    :tags: change_management
-   :responsible: rl__architecture_community
-   :approved_by: rl__project_lead
-   :supported_by: rl__platform_team
-   :input: wp__policies, wp__issue_track_system, wp__feat_request, wp__cmpt_request
-   :output: wp__issue_track_system, wp__feat_request, wp__cmpt_request
-   :contains: gd_guidl__change_change_request, gd_temp__change_feature_request, gd_temp__change_component_request, gd_temp__change_impact_analysis, gd_temp__component_classification, gd_temp__change_decision_record
-   :has: doc_concept__change_process, doc_getstrt__change_process
+   :responsible: rl__architecture_community[version==1]
+   :approved_by: rl__project_lead[version==1]
+   :supported_by: rl__platform_team[version==1]
+   :input: wp__policies[version==1],
+           wp__issue_track_system[version==1],
+           wp__feat_request[version==1],
+           wp__cmpt_request[version==1]
+   :output: wp__issue_track_system[version==1], wp__feat_request[version==1], wp__cmpt_request[version==1]
+   :contains: gd_guidl__change_change_request[version==1],
+              gd_temp__change_feature_request[version==1],
+              gd_temp__change_component_request[version==1],
+              gd_temp__change_impact_analysis[version==1],
+              gd_temp__component_classification[version==1],
+              gd_temp__change_decision_record[version==1]
+   :has: doc_concept__change_process[version==1], doc_getstrt__change_process[version==1]
 
    The Change Request is analyzed.
 
@@ -64,14 +82,20 @@ For a detailed explanation of workflows and their role within the process model,
 .. workflow:: Implement and Monitor Change Request
    :id: wf__change_implement_monitor_cr
    :status: valid
+   :version: 1
    :tags: change_management
-   :responsible: rl__delivery_team, rl__platform_team
-   :approved_by:  rl__delivery_team, rl__platform_team
-   :supported_by: rl__project_lead
-   :input: wp__issue_track_system, wp__feat_request, wp__cmpt_request
-   :output: wp__issue_track_system, wp__feat_request, wp__cmpt_request
-   :contains: gd_guidl__change_change_request, gd_temp__change_feature_request, gd_temp__change_component_request, gd_temp__change_impact_analysis, gd_temp__component_classification, gd_temp__change_decision_record
-   :has: doc_concept__change_process, doc_getstrt__change_process
+   :responsible: rl__delivery_team[version==1], rl__platform_team[version==1]
+   :approved_by: rl__delivery_team[version==1], rl__platform_team[version==1]
+   :supported_by: rl__project_lead[version==1]
+   :input: wp__issue_track_system[version==1], wp__feat_request[version==1], wp__cmpt_request[version==1]
+   :output: wp__issue_track_system[version==1], wp__feat_request[version==1], wp__cmpt_request[version==1]
+   :contains: gd_guidl__change_change_request[version==1],
+              gd_temp__change_feature_request[version==1],
+              gd_temp__change_component_request[version==1],
+              gd_temp__change_impact_analysis[version==1],
+              gd_temp__component_classification[version==1],
+              gd_temp__change_decision_record[version==1]
+   :has: doc_concept__change_process[version==1], doc_getstrt__change_process[version==1]
 
    The Change Request is implemented and monitored.
 
@@ -97,14 +121,20 @@ For a detailed explanation of workflows and their role within the process model,
 .. workflow:: Close Change Request
    :id: wf__change_close_cr
    :status: valid
+   :version: 1
    :tags: change_management
-   :responsible: rl__delivery_team, rl__platform_team
-   :approved_by: rl__delivery_team, rl__platform_team
-   :supported_by: rl__project_lead
-   :input: wp__issue_track_system, wp__feat_request, wp__cmpt_request
-   :output: wp__issue_track_system, wp__feat_request, wp__cmpt_request
-   :contains: gd_guidl__change_change_request, gd_temp__change_feature_request, gd_temp__change_component_request, gd_temp__change_impact_analysis, gd_temp__component_classification, gd_temp__change_decision_record
-   :has: doc_concept__change_process, doc_getstrt__change_process
+   :responsible: rl__delivery_team[version==1], rl__platform_team[version==1]
+   :approved_by: rl__delivery_team[version==1], rl__platform_team[version==1]
+   :supported_by: rl__project_lead[version==1]
+   :input: wp__issue_track_system[version==1], wp__feat_request[version==1], wp__cmpt_request[version==1]
+   :output: wp__issue_track_system[version==1], wp__feat_request[version==1], wp__cmpt_request[version==1]
+   :contains: gd_guidl__change_change_request[version==1],
+              gd_temp__change_feature_request[version==1],
+              gd_temp__change_component_request[version==1],
+              gd_temp__change_impact_analysis[version==1],
+              gd_temp__component_classification[version==1],
+              gd_temp__change_decision_record[version==1]
+   :has: doc_concept__change_process[version==1], doc_getstrt__change_process[version==1]
 
    The Change Request is closed.
 

--- a/process/process_areas/change_management/change_management_workproducts.rst
+++ b/process/process_areas/change_management/change_management_workproducts.rst
@@ -18,18 +18,33 @@ Change Management Work Products
 .. workproduct:: Platform Change Management Plan
    :id: wp__chm_plan
    :status: valid
+   :version: 1
    :tags: doc_lifecycle_model_2
-   :complies: std_wp__iso26262__support_851
+   :complies: std_wp__iso26262__support_851[version==1]
 
    Change Management Plan (Part of the Platform Management Plan)
 
 .. workproduct:: Issue tracking system
    :id: wp__issue_track_system
    :status: valid
+   :version: 1
    :tags: doc_lifecycle_model_1
-   :complies: std_wp__iso26262__management_554, std_wp__iso26262__management_652, std_wp__iso26262__support_852, std_wp__iso26262__support_853, std_wp__iso26262__support_854, std_wp__isopas8926__4527,
-              std_req__aspice_40__iic-13-16, std_req__aspice_40__iic-13-07, std_req__aspice_40__iic-14-02, std_req__aspice_40__iic-15-55, std_req__aspice_40__iic-15-12, std_req__aspice_40__iic-14-01,
-              std_wp__isosae21434__continual_8333, std_wp__isosae21434__continual_8431, std_wp__isosae21434__continual_8531, std_wp__isosae21434__continual_8631
+   :complies: std_wp__iso26262__management_554[version==1],
+              std_wp__iso26262__management_652[version==1],
+              std_wp__iso26262__support_852[version==1],
+              std_wp__iso26262__support_853[version==1],
+              std_wp__iso26262__support_854[version==1],
+              std_wp__isopas8926__4527[version==1],
+              std_req__aspice_40__iic-13-16[version==1],
+              std_req__aspice_40__iic-13-07[version==1],
+              std_req__aspice_40__iic-14-02[version==1],
+              std_req__aspice_40__iic-15-55[version==1],
+              std_req__aspice_40__iic-15-12[version==1],
+              std_req__aspice_40__iic-14-01[version==1],
+              std_wp__isosae21434__continual_8333[version==1],
+              std_wp__isosae21434__continual_8431[version==1],
+              std_wp__isosae21434__continual_8531[version==1],
+              std_wp__isosae21434__continual_8631[version==1]
 
    | - Change request
    | - Change request plan
@@ -45,8 +60,9 @@ Change Management Work Products
 .. workproduct:: Feature Request
    :id: wp__feat_request
    :status: valid
+   :version: 1
    :tags: doc_lifecycle_model_2
-   :complies: std_wp__iso26262__support_852, std_wp__iso26262__support_853, std_req__aspice_40__iic-13-16
+   :complies: std_wp__iso26262__support_852[version==1], std_wp__iso26262__support_853[version==1], std_req__aspice_40__iic-13-16[version==1]
 
    | - Feature request for a new feature or a feature modification
    |
@@ -56,8 +72,9 @@ Change Management Work Products
 .. workproduct:: Component Request
    :id: wp__cmpt_request
    :status: valid
+   :version: 1
    :tags: doc_lifecycle_model_2
-   :complies: std_wp__iso26262__support_852, std_wp__iso26262__support_853, std_req__aspice_40__iic-13-16
+   :complies: std_wp__iso26262__support_852[version==1], std_wp__iso26262__support_853[version==1], std_req__aspice_40__iic-13-16[version==1]
 
    | - Component request for a new component or a component modification
    |

--- a/process/process_areas/change_management/guidance/change_management_checklist.rst
+++ b/process/process_areas/change_management/guidance/change_management_checklist.rst
@@ -20,8 +20,12 @@ Checklists
 .. gd_chklst:: Change Request Review Checklist
    :id: gd_chklst__change_cr_review
    :status: valid
+   :version: 1
    :tags: change_management
-   :complies: std_req__aspice_40__SUP-10-BP1, std_req__aspice_40__SUP-10-BP3, std_req__aspice_40__SUP-10-BP5, std_req__aspice_40__iic-13-51
+   :complies: std_req__aspice_40__SUP-10-BP1[version==1],
+              std_req__aspice_40__SUP-10-BP3[version==1],
+              std_req__aspice_40__SUP-10-BP5[version==1],
+              std_req__aspice_40__iic-13-51[version==1]
 
    | **1. Purpose**
    | The purpose of this checklist is to collect the topics to be checked during a Change Request from any contributor.

--- a/process/process_areas/change_management/guidance/change_management_component_template.rst
+++ b/process/process_areas/change_management/guidance/change_management_component_template.rst
@@ -20,6 +20,16 @@ Component Template
 .. gd_temp:: Component Request Template
    :id: gd_temp__change_component_request
    :status: valid
-   :complies: std_req__aspice_40__SUP-10-BP1, std_req__aspice_40__SUP-10-BP2, std_req__aspice_40__SUP-10-BP3, std_req__aspice_40__SUP-10-BP5, std_req__aspice_40__iic-18-57, std_req__iso26262__support_8422, std_req__iso26262__support_8431, std_req__iso26262__support_8432, std_req__aspice_40__iic-13-16, std_req__aspice_40__iic-14-02
+   :version: 1
+   :complies: std_req__aspice_40__SUP-10-BP1[version==1],
+              std_req__aspice_40__SUP-10-BP2[version==1],
+              std_req__aspice_40__SUP-10-BP3[version==1],
+              std_req__aspice_40__SUP-10-BP5[version==1],
+              std_req__aspice_40__iic-18-57[version==1],
+              std_req__iso26262__support_8422[version==1],
+              std_req__iso26262__support_8431[version==1],
+              std_req__iso26262__support_8432[version==1],
+              std_req__aspice_40__iic-13-16[version==1],
+              std_req__aspice_40__iic-14-02[version==1]
 
    for the content see `Component Request Template <https://eclipse-score.github.io/module_template/main/score/component_example/docs/index.html>`__

--- a/process/process_areas/change_management/guidance/change_management_decision_record_template.rst
+++ b/process/process_areas/change_management/guidance/change_management_decision_record_template.rst
@@ -20,7 +20,8 @@ Decision Record Template
 .. gd_temp:: Decision Record Template
    :id: gd_temp__change_decision_record
    :status: valid
-   :complies: std_req__aspice_40__SWE-2-BP3, std_req__aspice_40__iic-17-00
+   :version: 1
+   :complies: std_req__aspice_40__SWE-2-BP3[version==1], std_req__aspice_40__iic-17-00[version==1]
 
 This template is used to create new Decision Records (DRs) in the project.
 
@@ -33,6 +34,7 @@ In each DR file, include the following sections:
    .. dec_rec:: <Title>
       :id: dec_rec__<Platform|Feature|Component>__<Title>
       :status: <proposed|accepted|deprecated|rejected|superseded>
+      :version: 1
       :affects: <link>
 
       <Description>

--- a/process/process_areas/change_management/guidance/change_management_feature_template.rst
+++ b/process/process_areas/change_management/guidance/change_management_feature_template.rst
@@ -20,6 +20,18 @@ Feature Template
 .. gd_temp:: Feature Request Template
    :id: gd_temp__change_feature_request
    :status: valid
-   :complies: std_req__aspice_40__SUP-10-BP1, std_req__aspice_40__SUP-10-BP2, std_req__aspice_40__SUP-10-BP3, std_req__aspice_40__SUP-10-BP5, std_req__aspice_40__iic-18-57, std_req__iso26262__support_8422, std_req__iso26262__support_8431, std_req__iso26262__support_8432, std_req__iso26262__management_644, std_req__isopas8926__4431, std_req__aspice_40__iic-13-16, std_req__aspice_40__iic-14-02
+   :version: 1
+   :complies: std_req__aspice_40__SUP-10-BP1[version==1],
+              std_req__aspice_40__SUP-10-BP2[version==1],
+              std_req__aspice_40__SUP-10-BP3[version==1],
+              std_req__aspice_40__SUP-10-BP5[version==1],
+              std_req__aspice_40__iic-18-57[version==1],
+              std_req__iso26262__support_8422[version==1],
+              std_req__iso26262__support_8431[version==1],
+              std_req__iso26262__support_8432[version==1],
+              std_req__iso26262__management_644[version==1],
+              std_req__isopas8926__4431[version==1],
+              std_req__aspice_40__iic-13-16[version==1],
+              std_req__aspice_40__iic-14-02[version==1]
 
    for the content see :need:`doc__feature_name`

--- a/process/process_areas/change_management/guidance/change_management_guideline.rst
+++ b/process/process_areas/change_management/guidance/change_management_guideline.rst
@@ -18,8 +18,13 @@ Guideline
 .. gd_guidl:: Change Request Guideline
    :id: gd_guidl__change_change_request
    :status: valid
+   :version: 1
    :tags: change_management
-   :complies: std_req__iso26262__support_8414, std_req__iso26262__support_8432, std_req__iso26262__support_8442, std_req__iso26262__support_8451, std_req__aspice_40__iic-13-07
+   :complies: std_req__iso26262__support_8414[version==1],
+              std_req__iso26262__support_8432[version==1],
+              std_req__iso26262__support_8442[version==1],
+              std_req__iso26262__support_8451[version==1],
+              std_req__aspice_40__iic-13-07[version==1]
 
 
 This document describes the general guidances for Change Management based on the concept which is defined :need:`[[title]]<doc_concept__change_process>`.
@@ -290,7 +295,8 @@ Tailoring
 .. gd_guidl:: Change Management Requirements Tailored
    :id: gd_guidl__change_req_tailored
    :status: valid
-   :complies: std_req__isopas8926__44441, std_req__isopas8926__44442, std_req__isopas8926__44443
+   :version: 1
+   :complies: std_req__isopas8926__44441[version==1], std_req__isopas8926__44442[version==1], std_req__isopas8926__44443[version==1]
 
    This part of the guideline links to all the requirements which are not fulfilled by the
    change management process. Make sure these are tailored out in the change management plan

--- a/process/process_areas/change_management/guidance/change_management_impact_analysis_template.rst
+++ b/process/process_areas/change_management/guidance/change_management_impact_analysis_template.rst
@@ -20,7 +20,16 @@ Impact Analysis Template
 .. gd_temp:: Impact Analysis Template
    :id: gd_temp__change_impact_analysis
    :status: valid
-   :complies: std_req__aspice_40__SUP-10-BP2, std_req__aspice_40__iic-18-57, std_req__iso26262__support_8431, std_req__iso26262__support_8432, std_req__isopas8926__44612, std_req__isopas8926__4462, std_req__iso26262__management_644, std_req__isopas8926__4431, std_req__iso26262__management_6452
+   :version: 1
+   :complies: std_req__aspice_40__SUP-10-BP2[version==1],
+              std_req__aspice_40__iic-18-57[version==1],
+              std_req__iso26262__support_8431[version==1],
+              std_req__iso26262__support_8432[version==1],
+              std_req__isopas8926__44612[version==1],
+              std_req__isopas8926__4462[version==1],
+              std_req__iso26262__management_644[version==1],
+              std_req__isopas8926__4431[version==1],
+              std_req__iso26262__management_6452[version==1]
 
 Type of Change Request
 ----------------------

--- a/process/process_areas/change_management/guidance/change_management_reqs.rst
+++ b/process/process_areas/change_management/guidance/change_management_reqs.rst
@@ -23,18 +23,36 @@ Change Request Attributes
 .. gd_req:: Change Request attribute: UID
    :id: gd_req__change_attr_uid
    :status: valid
+   :version: 1
    :tags: done_automation, attribute, mandatory
-   :satisfies: wf__change_create_cr, wf__change_analyze_cr, wf__change_implement_monitor_cr, wf__change_close_cr
-   :complies: std_req__aspice_40__SUP-10-BP1, std_req__iso26262__support_8411, std_req__iso26262__support_8421, std_req__iso26262__support_8432, std_req__iso26262__support_8453
+   :satisfies: wf__change_create_cr[version==1],
+               wf__change_analyze_cr[version==1],
+               wf__change_implement_monitor_cr[version==1],
+               wf__change_close_cr[version==1]
+   :complies: std_req__aspice_40__SUP-10-BP1[version==1],
+              std_req__iso26262__support_8411[version==1],
+              std_req__iso26262__support_8421[version==1],
+              std_req__iso26262__support_8432[version==1],
+              std_req__iso26262__support_8453[version==1]
 
    Each Change Request shall have a unique ID. It shall be in an integer number.
 
 .. gd_req:: Change Request attribute: status
    :id: gd_req__change_attr_status
    :status: valid
+   :version: 1
    :tags: done_automation, attribute, mandatory
-   :satisfies: wf__change_create_cr, wf__change_analyze_cr, wf__change_implement_monitor_cr, wf__change_close_cr
-   :complies: std_req__aspice_40__SUP-10-BP3, std_req__aspice_40__SUP-10-BP5, std_req__aspice_40__SUP-10-BP6, std_req__iso26262__support_8411, std_req__iso26262__support_8422, std_req__iso26262__support_8432, std_req__iso26262__support_8442
+   :satisfies: wf__change_create_cr[version==1],
+               wf__change_analyze_cr[version==1],
+               wf__change_implement_monitor_cr[version==1],
+               wf__change_close_cr[version==1]
+   :complies: std_req__aspice_40__SUP-10-BP3[version==1],
+              std_req__aspice_40__SUP-10-BP5[version==1],
+              std_req__aspice_40__SUP-10-BP6[version==1],
+              std_req__iso26262__support_8411[version==1],
+              std_req__iso26262__support_8422[version==1],
+              std_req__iso26262__support_8432[version==1],
+              std_req__iso26262__support_8442[version==1]
 
    Each Change Request shall have a status:
 
@@ -47,18 +65,32 @@ Change Request Attributes
 .. gd_req:: Change Request attribute: title
    :id: gd_req__change_attr_title
    :status: valid
+   :version: 1
    :tags: manual_prio_1, attribute, mandatory
-   :satisfies: wf__change_create_cr, wf__change_analyze_cr, wf__change_implement_monitor_cr, wf__change_close_cr
-   :complies: std_req__aspice_40__SUP-10-BP1, std_req__iso26262__support_8411, std_req__iso26262__support_8422
+   :satisfies: wf__change_create_cr[version==1],
+               wf__change_analyze_cr[version==1],
+               wf__change_implement_monitor_cr[version==1],
+               wf__change_close_cr[version==1]
+   :complies: std_req__aspice_40__SUP-10-BP1[version==1], std_req__iso26262__support_8411[version==1], std_req__iso26262__support_8422[version==1]
 
    Reason for the Change Request
 
 .. gd_req:: Change Request attribute: description
    :id: gd_req__change_attr_impact_description
    :status: valid
+   :version: 1
    :tags: manual_prio_1, attribute, mandatory
-   :satisfies: wf__change_create_cr, wf__change_analyze_cr, wf__change_implement_monitor_cr, wf__change_close_cr
-   :complies: std_req__aspice_40__SUP-10-BP2, std_req__iso26262__support_8411, std_req__iso26262__support_8422, std_req__iso26262__support_8431, std_req__iso26262__support_8432, std_req__iso26262__support_8452, std_req__iso26262__support_8453
+   :satisfies: wf__change_create_cr[version==1],
+               wf__change_analyze_cr[version==1],
+               wf__change_implement_monitor_cr[version==1],
+               wf__change_close_cr[version==1]
+   :complies: std_req__aspice_40__SUP-10-BP2[version==1],
+              std_req__iso26262__support_8411[version==1],
+              std_req__iso26262__support_8422[version==1],
+              std_req__iso26262__support_8431[version==1],
+              std_req__iso26262__support_8432[version==1],
+              std_req__iso26262__support_8452[version==1],
+              std_req__iso26262__support_8453[version==1]
 
    Exact description of the Change Request, including impact analysis on functional safety,
    security, implementation (schedule, risks, resources) verification (measures defined).
@@ -66,9 +98,13 @@ Change Request Attributes
 .. gd_req:: Change Request attribute: safety
    :id: gd_req__change_attr_impact_safety
    :status: valid
+   :version: 1
    :tags: prio_1_automation, attribute, mandatory
-   :satisfies: wf__change_create_cr, wf__change_analyze_cr, wf__change_implement_monitor_cr, wf__change_close_cr
-   :complies: std_req__aspice_40__SUP-10-BP2, std_req__iso26262__support_8422
+   :satisfies: wf__change_create_cr[version==1],
+               wf__change_analyze_cr[version==1],
+               wf__change_implement_monitor_cr[version==1],
+               wf__change_close_cr[version==1]
+   :complies: std_req__aspice_40__SUP-10-BP2[version==1], std_req__iso26262__support_8422[version==1]
 
    Each Change Request shall have a automotive safety integrity level (ASIL) identifier:
 
@@ -78,9 +114,13 @@ Change Request Attributes
 .. gd_req:: Change Request attribute: security
    :id: gd_req__change_attr_impact_security
    :status: valid
+   :version: 1
    :tags: prio_2_automation, attribute, mandatory
-   :satisfies: wf__change_create_cr, wf__change_analyze_cr, wf__change_implement_monitor_cr, wf__change_close_cr
-   :complies: std_req__aspice_40__SUP-10-BP2, std_req__iso26262__support_8422
+   :satisfies: wf__change_create_cr[version==1],
+               wf__change_analyze_cr[version==1],
+               wf__change_implement_monitor_cr[version==1],
+               wf__change_close_cr[version==1]
+   :complies: std_req__aspice_40__SUP-10-BP2[version==1], std_req__iso26262__support_8422[version==1]
 
    Each Change Request shall have a security relevance identifier:
 
@@ -90,9 +130,13 @@ Change Request Attributes
 .. gd_req:: Change Request attribute: Types
    :id: gd_req__change_attr_types
    :status: valid
+   :version: 1
    :tags: prio_1_automation, attribute, mandatory
-   :satisfies: wf__change_create_cr, wf__change_analyze_cr, wf__change_implement_monitor_cr, wf__change_close_cr
-   :complies: std_req__aspice_40__SUP-10-BP1
+   :satisfies: wf__change_create_cr[version==1],
+               wf__change_analyze_cr[version==1],
+               wf__change_implement_monitor_cr[version==1],
+               wf__change_close_cr[version==1]
+   :complies: std_req__aspice_40__SUP-10-BP1[version==1]
 
       * Feature
       * Feature Modification
@@ -119,18 +163,30 @@ Change Request Attributes
 .. gd_req:: Change Request attribute: Affected Work Products
    :id: gd_req__change_attr_affected_wp
    :status: valid
+   :version: 1
    :tags: attribute, mandatory
-   :satisfies: wf__change_create_cr, wf__change_analyze_cr, wf__change_implement_monitor_cr, wf__change_close_cr
-   :complies: std_req__aspice_40__SUP-10-BP4, std_req__iso26262__support_8412, std_req__iso26262__support_8422, std_req__iso26262__support_8452, std_req__iso26262__support_8453
+   :satisfies: wf__change_create_cr[version==1],
+               wf__change_analyze_cr[version==1],
+               wf__change_implement_monitor_cr[version==1],
+               wf__change_close_cr[version==1]
+   :complies: std_req__aspice_40__SUP-10-BP4[version==1],
+              std_req__iso26262__support_8412[version==1],
+              std_req__iso26262__support_8422[version==1],
+              std_req__iso26262__support_8452[version==1],
+              std_req__iso26262__support_8453[version==1]
 
    Links to the work products affected by the Change Request
 
 .. gd_req:: Change Request attribute: Milestone
    :id: gd_req__change_attr_milestone
    :status: valid
+   :version: 1
    :tags: done_automation, attribute, mandatory
-   :satisfies: wf__change_create_cr, wf__change_analyze_cr, wf__change_implement_monitor_cr, wf__change_close_cr
-   :complies: std_req__aspice_40__SUP-10-BP6, std_req__iso26262__support_8413
+   :satisfies: wf__change_create_cr[version==1],
+               wf__change_analyze_cr[version==1],
+               wf__change_implement_monitor_cr[version==1],
+               wf__change_close_cr[version==1]
+   :complies: std_req__aspice_40__SUP-10-BP6[version==1], std_req__iso26262__support_8413[version==1]
 
    Milestone until the Change Request must be implemented (used for prioritization)
 
@@ -143,9 +199,13 @@ Change Request Checks
 .. gd_req:: Change Requests mandatory attributes provided
    :id: gd_req__change_attr_mandatory
    :status: valid
+   :version: 1
    :tags: prio_2_automation, attribute, check
-   :satisfies: wf__change_create_cr, wf__change_analyze_cr, wf__change_implement_monitor_cr, wf__change_close_cr
-   :complies: std_req__aspice_40__iic-13-51
+   :satisfies: wf__change_create_cr[version==1],
+               wf__change_analyze_cr[version==1],
+               wf__change_implement_monitor_cr[version==1],
+               wf__change_close_cr[version==1]
+   :complies: std_req__aspice_40__iic-13-51[version==1]
 
    It shall be checked if all mandatory attributes for each Change Request
    is provided by the user. For all requirements following attributes shall be mandatory:
@@ -165,9 +225,13 @@ Change Request Traceability Impact Analysis Tool
 .. gd_req:: Change Requests Impact Analysis Tool
    :id: gd_req__change_tool_impact_analysis
    :status: valid
+   :version: 1
    :tags: prio_3_automation, check, tool
-   :satisfies: wf__change_create_cr, wf__change_analyze_cr, wf__change_implement_monitor_cr, wf__change_close_cr
-   :complies: std_req__aspice_40__iic-13-51
+   :satisfies: wf__change_create_cr[version==1],
+               wf__change_analyze_cr[version==1],
+               wf__change_implement_monitor_cr[version==1],
+               wf__change_close_cr[version==1]
+   :complies: std_req__aspice_40__iic-13-51[version==1]
 
    It shall be reported, which work products and elements are affected by adding a new
    feature or component or by a modification of an existing feature or component.

--- a/process/process_areas/configuration_management/configuration_concept.rst
+++ b/process/process_areas/configuration_management/configuration_concept.rst
@@ -18,6 +18,7 @@ Concept Description
 .. doc_concept:: Configuration Management Concept
    :id: doc_concept__configuration_process
    :status: valid
+   :version: 1
 
 In this section a concept for the configuration management will be discussed.
 Inputs for this concepts are mainly the requirements of ISO26262 "Part 8: Supporting Processes"

--- a/process/process_areas/configuration_management/configuration_getstrt.rst
+++ b/process/process_areas/configuration_management/configuration_getstrt.rst
@@ -18,6 +18,7 @@ Getting Started
 .. doc_getstrt:: Configuration Management Get Started
    :id: doc_getstrt__configuration_process
    :status: valid
+   :version: 1
 
 In case you are appointed as a :need:`rl__project_lead` in the project:
 

--- a/process/process_areas/configuration_management/configuration_workproducts.rst
+++ b/process/process_areas/configuration_management/configuration_workproducts.rst
@@ -18,7 +18,8 @@ Configuration Management Work Products
 .. workproduct:: Platform Configuration Management Plan
    :id: wp__config_mgt_plan
    :status: valid
+   :version: 1
    :tags: doc_lifecycle_model_2
-   :complies: std_wp__iso26262__support_751
+   :complies: std_wp__iso26262__support_751[version==1]
 
    Config Management Plan (Part of the Platform Management Plan, :need:`wp__platform_mgmt`)

--- a/process/process_areas/configuration_management/guidance/configuration_process_req.rst
+++ b/process/process_areas/configuration_management/guidance/configuration_process_req.rst
@@ -18,9 +18,14 @@ Configuration Management Process Requirements
 .. gd_req:: Unique Id
    :id: gd_req__configuration_uid
    :status: valid
+   :version: 1
    :tags: done_automation, config_mgt
-   :complies: std_req__iso26262__support_745, std_req__aspice_40__SUP-8-BP8
-   :satisfies: wf__monitor_verify_requirements, wf__mr_vy_arch, wf__mr_saf_analyses_dfa, wf__vy_saf_analyses_dfa, wf__platform_mr_im_platform_mgmt_plan
+   :complies: std_req__iso26262__support_745[version==1], std_req__aspice_40__SUP-8-BP8[version==1]
+   :satisfies: wf__monitor_verify_requirements[version==1],
+               wf__mr_vy_arch[version==1],
+               wf__mr_saf_analyses_dfa[version==1],
+               wf__vy_saf_analyses_dfa[version==1],
+               wf__platform_mr_im_platform_mgmt_plan[version==1]
 
    The Docs-as-Code tool shall check that the Id's of the configuration items (documented in doc-as-code) are unique.
 
@@ -29,9 +34,10 @@ Configuration Management Process Requirements
 .. gd_req:: Permanent Storage
    :id: gd_req__config_workproducts_storage
    :status: valid
+   :version: 1
    :tags: prio_3_automation, config_mgt
-   :complies: std_req__iso26262__support_745, std_req__aspice_40__SUP-8-BP8
-   :satisfies: wf__rel_platform_rel_note, wf__rel_mod_rel_note
+   :complies: std_req__iso26262__support_745[version==1], std_req__aspice_40__SUP-8-BP8[version==1]
+   :satisfies: wf__rel_platform_rel_note[version==1], wf__rel_mod_rel_note[version==1]
 
    At least every platform release shall be stored permanently as a collection of text documents
    (docs and code) including the used OSS tooling on project owned servers.
@@ -42,9 +48,10 @@ Configuration Management Process Requirements
 .. gd_req:: Storage of pull requests documentation
    :id: gd_req__config_pull_request_storage
    :status: valid
+   :version: 1
    :tags: prio_2_automation, config_mgt
-   :complies: std_req__iso26262__support_6433, std_req__iso26262__software_7414
-   :satisfies: wf__monitor_verify_requirements, wf__mr_vy_arch
+   :complies: std_req__iso26262__support_6433[version==1], std_req__iso26262__software_7414[version==1]
+   :satisfies: wf__monitor_verify_requirements[version==1], wf__mr_vy_arch[version==1]
 
    The content of pull requests (conversation, commits, files changed) shall be stored permanently
    for every release.
@@ -54,9 +61,10 @@ Configuration Management Process Requirements
 .. gd_req:: Baseline Differences
    :id: gd_req__config_baseline_diff
    :status: valid
+   :version: 1
    :tags: prio_2_automation, config_mgt
-   :complies: std_req__iso26262__support_741
-   :satisfies: wf__rel_platform_rel_note, wf__rel_mod_rel_note
+   :complies: std_req__iso26262__support_741[version==1]
+   :satisfies: wf__rel_platform_rel_note[version==1], wf__rel_mod_rel_note[version==1]
 
    It shall be possible to show the differences between two baselines.
 
@@ -65,9 +73,10 @@ Configuration Management Process Requirements
 .. gd_req::  Document attributes
    :id: gd_req__config_consistent_attributes
    :status: valid
+   :version: 1
    :tags: prio_2_automation
-   :complies: std_req__aspice_40__SUP-8-BP3, std_req__aspice_40__SUP-8-BP4
-   :satisfies: wf__platform_cr_mt_platform_mgmt_plan
+   :complies: std_req__aspice_40__SUP-8-BP3[version==1], std_req__aspice_40__SUP-8-BP4[version==1]
+   :satisfies: wf__platform_cr_mt_platform_mgmt_plan[version==1]
 
    It shall be prohibited to override any mandatory attribute value of an docs-as-code element.
 
@@ -77,8 +86,9 @@ Configuration Management Process Requirements
 .. gd_req::  Global tags extension
    :id: gd_req__config_global_tags
    :status: valid
+   :version: 1
    :tags: prio_3_automation
-   :satisfies: wf__platform_cr_mt_platform_mgmt_plan
+   :satisfies: wf__platform_cr_mt_platform_mgmt_plan[version==1]
 
    It shall be possible to define global tags with the docs-as-code tool, which can be used for filtering and reporting.
 

--- a/process/process_areas/configuration_management/guidance/configuration_templates.rst
+++ b/process/process_areas/configuration_management/guidance/configuration_templates.rst
@@ -20,9 +20,26 @@ Template Configuration Management Plan
 .. gd_temp:: Configuration Management Plan Template
    :id: gd_temp__config_mgt_plan
    :status: valid
-   :complies: std_req__iso26262__support_741, std_req__iso26262__support_742, std_req__iso26262__support_743, std_req__iso26262__support_744, std_req__iso26262__support_745,
-              std_req__aspice_40__SUP-8-BP1, std_req__aspice_40__SUP-8-BP2, std_req__aspice_40__SUP-8-BP3, std_req__aspice_40__SUP-8-BP4, std_req__aspice_40__SUP-8-BP5, std_req__aspice_40__SUP-8-BP6, std_req__aspice_40__SUP-8-BP8,
-              std_req__aspice_40__iic-13-08, std_req__aspice_40__iic-18-53, std_req__aspice_40__iic-01-52, std_req__aspice_40__iic-16-03, std_req__aspice_40__iic-14-01, std_req__aspice_40__iic-15-56, std_req__aspice_40__iic-06-52
+   :version: 1
+   :complies: std_req__iso26262__support_741[version==1],
+              std_req__iso26262__support_742[version==1],
+              std_req__iso26262__support_743[version==1],
+              std_req__iso26262__support_744[version==1],
+              std_req__iso26262__support_745[version==1],
+              std_req__aspice_40__SUP-8-BP1[version==1],
+              std_req__aspice_40__SUP-8-BP2[version==1],
+              std_req__aspice_40__SUP-8-BP3[version==1],
+              std_req__aspice_40__SUP-8-BP4[version==1],
+              std_req__aspice_40__SUP-8-BP5[version==1],
+              std_req__aspice_40__SUP-8-BP6[version==1],
+              std_req__aspice_40__SUP-8-BP8[version==1],
+              std_req__aspice_40__iic-13-08[version==1],
+              std_req__aspice_40__iic-18-53[version==1],
+              std_req__aspice_40__iic-01-52[version==1],
+              std_req__aspice_40__iic-16-03[version==1],
+              std_req__aspice_40__iic-14-01[version==1],
+              std_req__aspice_40__iic-15-56[version==1],
+              std_req__aspice_40__iic-06-52[version==1]
 
 Purpose
 +++++++

--- a/process/process_areas/documentation_management/documentation_concept.rst
+++ b/process/process_areas/documentation_management/documentation_concept.rst
@@ -18,6 +18,7 @@ Concept
 .. doc_concept:: Documentation Management Concept
    :id: doc_concept__documentation_process
    :status: valid
+   :version: 1
 
 In this section a concept for the documentation management will be discussed.
 Inputs for this concepts are mainly the requirements of ISO26262 "Part 2: Management of functional safety"

--- a/process/process_areas/documentation_management/documentation_getstrt.rst
+++ b/process/process_areas/documentation_management/documentation_getstrt.rst
@@ -18,6 +18,7 @@ Getting Started
 .. doc_getstrt:: Documentation Management Get Started
    :id: doc_getstrt__documentation_process
    :status: valid
+   :version: 1
 
 This document describes how to get started with documentation management in the project.
 

--- a/process/process_areas/documentation_management/documentation_workproducts.rst
+++ b/process/process_areas/documentation_management/documentation_workproducts.rst
@@ -18,8 +18,9 @@ Documentation Management Work Products
 .. workproduct:: Documentation Management Plan
    :id: wp__document_mgt_plan
    :status: valid
+   :version: 1
    :tags: doc_lifecycle_model_2
-   :complies: std_wp__iso26262__support_1051, std_wp__iso26262__support_1052, std_req__aspice_40__iic-01-52
+   :complies: std_wp__iso26262__support_1051[version==1], std_wp__iso26262__support_1052[version==1], std_req__aspice_40__iic-01-52[version==1]
 
    Document Management Plan (Part of the Platform Management Plan)
 

--- a/process/process_areas/documentation_management/guidance/documentation_checklist.rst
+++ b/process/process_areas/documentation_management/guidance/documentation_checklist.rst
@@ -18,7 +18,8 @@ Checklists
 .. gd_chklst:: Documentation Review Checklist
    :id: gd_chklst__documentation_review
    :status: valid
-   :complies: std_req__iso26262__support_1045
+   :version: 1
+   :complies: std_req__iso26262__support_1045[version==1]
 
    | **1. Purpose**
    | The purpose of this checklist is to collect the formal topics to be checked during a

--- a/process/process_areas/documentation_management/guidance/documentation_guideline.rst
+++ b/process/process_areas/documentation_management/guidance/documentation_guideline.rst
@@ -18,7 +18,13 @@ Guideline
 .. gd_guidl:: Documentation
    :id: gd_guidl__documentation
    :status: valid
-   :complies: std_req__iso26262__support_1041, std_req__iso26262__support_1042, std_req__iso26262__support_1043, std_req__iso26262__support_1044, std_req__iso26262__support_1045, std_req__iso26262__support_1046
+   :version: 1
+   :complies: std_req__iso26262__support_1041[version==1],
+              std_req__iso26262__support_1042[version==1],
+              std_req__iso26262__support_1043[version==1],
+              std_req__iso26262__support_1044[version==1],
+              std_req__iso26262__support_1045[version==1],
+              std_req__iso26262__support_1046[version==1]
 
 The planning for the documents is part of the :need:`wp__document_mgt_plan` within the Platform Management Plan.
 This plan includes the configuration item list containing all work products created in the project

--- a/process/process_areas/documentation_management/guidance/documentation_process_reqs.rst
+++ b/process/process_areas/documentation_management/guidance/documentation_process_reqs.rst
@@ -20,9 +20,10 @@ Document Management Process Requirements
 .. gd_req:: Document Types
    :id: gd_req__doc_types
    :status: valid
+   :version: 1
    :tags: done_automation
-   :satisfies: wf__platform_cr_mt_platform_mgmt_plan
-   :complies: std_req__iso26262__support_1043
+   :satisfies: wf__platform_cr_mt_platform_mgmt_plan[version==1]
+   :complies: std_req__iso26262__support_1043[version==1]
 
    There are the following document types:
 
@@ -52,9 +53,10 @@ Document Management Process Requirements
 .. gd_req:: Document attributes
    :id: gd_req__doc_attributes_manual
    :status: valid
+   :version: 1
    :tags: manual_prio_1
-   :satisfies: wf__platform_cr_mt_platform_mgmt_plan
-   :complies: std_req__iso26262__support_1043
+   :satisfies: wf__platform_cr_mt_platform_mgmt_plan[version==1]
+   :complies: std_req__iso26262__support_1043[version==1]
 
    Generic documents shall have the following mandatory manual attributes:
 
@@ -71,9 +73,10 @@ Document Management Process Requirements
 .. gd_req:: Document attribute: status
    :id: gd_req__doc_attr_status
    :status: valid
+   :version: 1
    :tags: manual_prio_1, attribute, mandatory
-   :satisfies: wf__platform_cr_mt_platform_mgmt_plan
-   :complies: std_req__iso26262__support_1044
+   :satisfies: wf__platform_cr_mt_platform_mgmt_plan[version==1]
+   :complies: std_req__iso26262__support_1044[version==1]
 
    Each document, shall have a status depending on the document lifecycle models below:
 
@@ -86,9 +89,10 @@ Document Management Process Requirements
 .. gd_req:: Document Author
    :id: gd_req__doc_author
    :status: valid
+   :version: 1
    :tags: done_automation
-   :satisfies: wf__platform_cr_mt_platform_mgmt_plan
-   :complies: std_req__iso26262__support_1045
+   :satisfies: wf__platform_cr_mt_platform_mgmt_plan[version==1]
+   :complies: std_req__iso26262__support_1045[version==1]
 
    The version management tool shall document and report (be able to show) the authorship of a document.
    I.e. for each change of a document the author of the changes is stored.
@@ -96,9 +100,10 @@ Document Management Process Requirements
 .. gd_req:: Document Reviewer
    :id: gd_req__doc_reviewer
    :status: valid
+   :version: 1
    :tags: done_automation
-   :satisfies: wf__platform_cr_mt_platform_mgmt_plan
-   :complies: std_req__iso26262__support_1043
+   :satisfies: wf__platform_cr_mt_platform_mgmt_plan[version==1]
+   :complies: std_req__iso26262__support_1043[version==1]
 
    The version management tool shall document and report (be able to show) the reviewers of a document.
    I.e. for each change of a document the reviewers of the change are stored.
@@ -106,9 +111,10 @@ Document Management Process Requirements
 .. gd_req:: Document Approver
    :id: gd_req__doc_approver
    :status: valid
+   :version: 1
    :tags: done_automation
-   :satisfies: wf__platform_cr_mt_platform_mgmt_plan
-   :complies: std_req__iso26262__support_1045
+   :satisfies: wf__platform_cr_mt_platform_mgmt_plan[version==1]
+   :complies: std_req__iso26262__support_1045[version==1]
 
    The version management tool shall document and report (be able to show) the approver of a document.
    I.e. for each change of a document the approver of the change is stored,

--- a/process/process_areas/documentation_management/guidance/documentation_templates.rst
+++ b/process/process_areas/documentation_management/guidance/documentation_templates.rst
@@ -20,7 +20,8 @@ Documentation Templates
 .. gd_temp:: Documentation Template
    :id: gd_temp__documentation
    :status: valid
-   :complies: std_req__iso26262__support_1045
+   :version: 1
+   :complies: std_req__iso26262__support_1045[version==1]
 
    | .. document:: <Document Name>
    |    :id: doc__<Document Name>

--- a/process/process_areas/implementation/guidance/detailed_design_template.rst
+++ b/process/process_areas/implementation/guidance/detailed_design_template.rst
@@ -19,6 +19,12 @@ Detailed Design Template
 .. gd_temp:: Detailed Design Templates
    :id: gd_temp__detailed_design
    :status: valid
-   :complies: std_req__iso26262__software_542, std_req__iso26262__support_641, std_req__iso26262__support_6421, std_req__iso26262__support_6425, std_req__iso26262__software_744, std_req__aspice_40__iic-04-05
+   :version: 1
+   :complies: std_req__iso26262__software_542[version==1],
+              std_req__iso26262__support_641[version==1],
+              std_req__iso26262__support_6421[version==1],
+              std_req__iso26262__support_6425[version==1],
+              std_req__iso26262__software_744[version==1],
+              std_req__aspice_40__iic-04-05[version==1]
 
    For the content see here: `Detailed Design Template <https://eclipse-score.github.io/module_template/main/score/component_example/docs/detailed_design/index.html>`__

--- a/process/process_areas/implementation/guidance/implementation_checklist.rst
+++ b/process/process_areas/implementation/guidance/implementation_checklist.rst
@@ -19,8 +19,15 @@ Implementation Inspection Checklist
 .. gd_chklst:: Implementation Inspection Checklist Template
     :id: gd_chklst__impl_inspection_checklist
     :status: valid
+    :version: 1
     :tags: implementation
-    :complies: std_req__iso26262__software_543, std_req__iso26262__software_941, std_req__iso26262__software_942, std_req__iso26262__software_748, std_req__aspice_40__SWE-3-BP5, std_req__aspice_40__iic-13-51, std_req__aspice_40__iic-13-52
+    :complies: std_req__iso26262__software_543[version==1],
+               std_req__iso26262__software_941[version==1],
+               std_req__iso26262__software_942[version==1],
+               std_req__iso26262__software_748[version==1],
+               std_req__aspice_40__SWE-3-BP5[version==1],
+               std_req__aspice_40__iic-13-51[version==1],
+               std_req__aspice_40__iic-13-52[version==1]
 
     For the content see here:
 

--- a/process/process_areas/implementation/guidance/implementation_guideline.rst
+++ b/process/process_areas/implementation/guidance/implementation_guideline.rst
@@ -18,7 +18,11 @@ Guideline
 .. gd_guidl:: Implementation Guideline
    :id: gd_guidl__implementation
    :status: valid
-   :complies: std_req__iso26262__software_744, std_req__iso26262__software_841, std_req__iso26262__software_842, std_req__aspice_40__iic-11-05
+   :version: 1
+   :complies: std_req__iso26262__software_744[version==1],
+              std_req__iso26262__software_841[version==1],
+              std_req__iso26262__software_842[version==1],
+              std_req__aspice_40__iic-11-05[version==1]
 
 This document describes the general guidance for implementation based on the concept which is defined :need:`[[title]]<doc_concept__imp_concept>`.
 An example of a Detailed Design is maintained in the

--- a/process/process_areas/implementation/guidance/implementation_process_reqs.rst
+++ b/process/process_areas/implementation/guidance/implementation_process_reqs.rst
@@ -18,9 +18,13 @@ Process Requirements
 .. gd_req:: Static Diagram for Unit Interactions
    :id: gd_req__impl_static_diagram
    :status: valid
+   :version: 1
    :tags: manual_prio_1, mandatory
-   :satisfies: wf__sw_detailed_design
-   :complies: std_req__iso26262__software_843, std_req__iso26262__software_844, std_req__iso26262__software_845, std_req__aspice_40__SWE-3-BP1
+   :satisfies: wf__sw_detailed_design[version==1]
+   :complies: std_req__iso26262__software_843[version==1],
+              std_req__iso26262__software_844[version==1],
+              std_req__iso26262__software_845[version==1],
+              std_req__aspice_40__SWE-3-BP1[version==1]
 
    The static diagram shall represent the unit and their relationships using UML notations.
 
@@ -30,9 +34,13 @@ Diagram Attributes
 .. gd_req:: Diagram attribute: UID
    :id: gd_req__impl_diagram_uid
    :status: valid
+   :version: 1
    :tags: manual_prio_1, attribute, mandatory
-   :satisfies: wf__sw_detailed_design
-   :complies: std_req__iso26262__software_843, std_req__iso26262__software_844, std_req__iso26262__software_845, std_req__aspice_40__SWE-3-BP2
+   :satisfies: wf__sw_detailed_design[version==1]
+   :complies: std_req__iso26262__software_843[version==1],
+              std_req__iso26262__software_844[version==1],
+              std_req__iso26262__software_845[version==1],
+              std_req__aspice_40__SWE-3-BP2[version==1]
 
    Each diagram shall have a unique ID. It shall consist of three parts:
 
@@ -45,9 +53,14 @@ Diagram Attributes
 .. gd_req:: Diagram attribute: title
    :id: gd_req__impl_diagram_title
    :status: valid
+   :version: 1
    :tags: manual_prio_1 attribute, mandatory
-   :satisfies: wf__sw_detailed_design
-   :complies: std_req__iso26262__software_843, std_req__iso26262__software_844, std_req__iso26262__software_845, std_req__aspice_40__SWE-3-BP3, std_req__aspice_40__SWE-3-BP4
+   :satisfies: wf__sw_detailed_design[version==1]
+   :complies: std_req__iso26262__software_843[version==1],
+              std_req__iso26262__software_844[version==1],
+              std_req__iso26262__software_845[version==1],
+              std_req__aspice_40__SWE-3-BP3[version==1],
+              std_req__aspice_40__SWE-3-BP4[version==1]
 
    The title of the diagram shall provide a short summary of the description, but is not an "additional" requirement.
 
@@ -56,8 +69,9 @@ Diagram Attributes
 .. gd_req:: Diagram attribute: security
    :id: gd_req__impl_diagram_security
    :status: valid
+   :version: 1
    :tags: manual_prio_2, attribute, mandatory
-   :satisfies: wf__sw_detailed_design
+   :satisfies: wf__sw_detailed_design[version==1]
 
    Each diagram shall have a security relevance identifier:
 
@@ -67,9 +81,10 @@ Diagram Attributes
 .. gd_req:: Diagram attribute: safety
    :id: gd_req__impl_diagram_safety
    :status: valid
+   :version: 1
    :tags: manual_prio_1, attribute, mandatory
-   :complies: std_req__iso26262__support_6421, std_req__iso26262__support_6425
-   :satisfies: wf__sw_detailed_design
+   :complies: std_req__iso26262__support_6421[version==1], std_req__iso26262__support_6425[version==1]
+   :satisfies: wf__sw_detailed_design[version==1]
 
    Each diagram shall have a automotive safety integrity level (ASIL) identifier:
 
@@ -79,9 +94,10 @@ Diagram Attributes
 .. gd_req:: Diagram attribute: status
    :id: gd_req__impl_diagram_status
    :status: valid
+   :version: 1
    :tags: manual_prio_1, attribute, mandatory
-   :complies: std_req__iso26262__support_6421, std_req__iso26262__support_6425
-   :satisfies: wf__sw_detailed_design
+   :complies: std_req__iso26262__support_6421[version==1], std_req__iso26262__support_6425[version==1]
+   :satisfies: wf__sw_detailed_design[version==1]
 
    Each diagram shall have a status:
 
@@ -91,9 +107,10 @@ Diagram Attributes
 .. gd_req:: Diagram attribute: description
    :id: gd_req__impl_diagram_description
    :status: valid
+   :version: 1
    :tags: manual_prio_1, attribute, mandatory
-   :complies: std_req__iso26262__support_6421, std_req__iso26262__support_6425
-   :satisfies: wf__sw_detailed_design
+   :complies: std_req__iso26262__support_6421[version==1], std_req__iso26262__support_6425[version==1]
+   :satisfies: wf__sw_detailed_design[version==1]
 
    Each diagram shall have a description. The description shall provide a needarch or image of the diagram.
 
@@ -105,63 +122,70 @@ Diagram Linkage
 .. gd_req:: Diagram Linkage check Component Requirement
    :id: gd_req__impl_diagram_check_req
    :status: valid
+   :version: 1
    :tags: prio_2_automation, attribute, automated
-   :complies: std_req__iso26262__support_6421, std_req__iso26262__support_6425, std_req__aspice_40__iic-13-51
-   :satisfies: wf__sw_detailed_design
+   :complies: std_req__iso26262__support_6421[version==1], std_req__iso26262__support_6425[version==1], std_req__aspice_40__iic-13-51[version==1]
+   :satisfies: wf__sw_detailed_design[version==1]
 
    Each diagram shall be linked to the corresponding component requirement via the attribute implements.
 
 .. gd_req:: Diagram Linkage Component Requirement
    :id: gd_req__impl_diagram_linkage_req
    :status: valid
+   :version: 1
    :tags: prio_2_automation, attribute, automated
-   :complies: std_req__iso26262__support_6421, std_req__iso26262__support_6425
-   :satisfies: wf__sw_detailed_design
+   :complies: std_req__iso26262__support_6421[version==1], std_req__iso26262__support_6425[version==1]
+   :satisfies: wf__sw_detailed_design[version==1]
 
    Each diagram shall be automatically linked (inverse direction) to the corresponding component requirement via the "implemented by" linkage.
 
 .. gd_req:: Diagram Linkage check Component Architecture
    :id: gd_req__impl_diagram_check_arch
    :status: valid
+   :version: 1
    :tags: prio_2_automation, attribute, automated
-   :complies: std_req__iso26262__support_6421, std_req__iso26262__support_6425, std_req__aspice_40__iic-13-51
-   :satisfies: wf__sw_detailed_design
+   :complies: std_req__iso26262__support_6421[version==1], std_req__iso26262__support_6425[version==1], std_req__aspice_40__iic-13-51[version==1]
+   :satisfies: wf__sw_detailed_design[version==1]
 
    Each diagram shall be linked to the corresponding component architecture via the attribute satisfies.
 
 .. gd_req:: Diagram Linkage Component Architecture
    :id: gd_req__impl_diagram_linkage_arch
    :status: valid
+   :version: 1
    :tags: prio_2_automation, attribute, automated
-   :complies: std_req__iso26262__support_6421, std_req__iso26262__support_6425
-   :satisfies: wf__sw_detailed_design
+   :complies: std_req__iso26262__support_6421[version==1], std_req__iso26262__support_6425[version==1]
+   :satisfies: wf__sw_detailed_design[version==1]
 
    Each diagram shall be automatically linked (inverse direction) to the corresponding component architecture via the "satisfied by" linkage.
 
 .. gd_req:: Diagram Linkage check Component ID
    :id: gd_req__impl_diagram_check_id
    :status: valid
+   :version: 1
    :tags: prio_2_automation, attribute, automated
-   :complies: std_req__iso26262__support_6421, std_req__iso26262__support_6425
-   :satisfies: wf__sw_detailed_design
+   :complies: std_req__iso26262__support_6421[version==1], std_req__iso26262__support_6425[version==1]
+   :satisfies: wf__sw_detailed_design[version==1]
 
    Each diagram shall be linked to the corresponding component id via the attribute belongs_to.
 
 .. gd_req:: Diagram Linkage Component ID
    :id: gd_req__impl_diagram_linkage_id
    :status: valid
+   :version: 1
    :tags: prio_2_automation, attribute, automated
-   :complies: std_req__iso26262__support_6421, std_req__iso26262__support_6425
-   :satisfies: wf__sw_detailed_design
+   :complies: std_req__iso26262__support_6421[version==1], std_req__iso26262__support_6425[version==1]
+   :satisfies: wf__sw_detailed_design[version==1]
 
    Each diagram shall be automatically linked (inverse direction) to the corresponding component id via the "belongs by" linkage.
 
 .. gd_req:: Diagram Linkage includes
    :id: gd_req__impl_diagram_check_includes
    :status: valid
+   :version: 1
    :tags: prio_2_automation, attribute, automated
-   :complies: std_req__iso26262__support_6421, std_req__iso26262__support_6425
-   :satisfies: wf__sw_detailed_design
+   :complies: std_req__iso26262__support_6421[version==1], std_req__iso26262__support_6425[version==1]
+   :satisfies: wf__sw_detailed_design[version==1]
 
    Each diagram shall be linked to the corresponding
    - SW Unit
@@ -171,9 +195,10 @@ Diagram Linkage
 .. gd_req:: Diagram Linkage includes
    :id: gd_req__impl_diagram_linkage_includes
    :status: valid
+   :version: 1
    :tags: prio_2_automation, attribute, automated
-   :complies: std_req__iso26262__support_6421, std_req__iso26262__support_6425
-   :satisfies: wf__sw_detailed_design
+   :complies: std_req__iso26262__support_6421[version==1], std_req__iso26262__support_6425[version==1]
+   :satisfies: wf__sw_detailed_design[version==1]
 
    Each diagram shall be automatically linked (inverse direction) to the corresponding
    - SW Unit
@@ -186,9 +211,10 @@ Diagram Checks
 .. gd_req:: Diagram mandatory attributes provided
    :id: gd_req__impl_diagram_mandatory
    :status: valid
+   :version: 1
    :tags: prio_2_automation, attribute, check
-   :complies: std_req__iso26262__support_6421, std_req__iso26262__support_6425
-   :satisfies: wf__sw_detailed_design
+   :complies: std_req__iso26262__support_6421[version==1], std_req__iso26262__support_6425[version==1]
+   :satisfies: wf__sw_detailed_design[version==1]
 
    It shall be checked if all mandatory attributes for each diagram are provided by the user. For all diagrams following attributes shall be mandatory:
 
@@ -204,9 +230,10 @@ Unit Attributes
 .. gd_req:: Unit attribute: UID
    :id: gd_req__impl_unit_uid
    :status: valid
+   :version: 1
    :tags: manual_prio_1, attribute, mandatory
-   :satisfies: wf__sw_detailed_design
-   :complies: std_req__iso26262__software_843, std_req__aspice_40__SWE-3-BP1
+   :satisfies: wf__sw_detailed_design[version==1]
+   :complies: std_req__iso26262__software_843[version==1], std_req__aspice_40__SWE-3-BP1[version==1]
 
    Each unit shall have a unique ID. It shall consist of three parts:
 
@@ -219,9 +246,10 @@ Unit Attributes
 .. gd_req:: Unit attribute: description
    :id: gd_req__impl_unit_description
    :status: valid
+   :version: 1
    :tags: manual_prio_1, attribute, mandatory
-   :complies: std_req__iso26262__support_6421, std_req__iso26262__support_6425
-   :satisfies: wf__sw_detailed_design
+   :complies: std_req__iso26262__support_6421[version==1], std_req__iso26262__support_6425[version==1]
+   :satisfies: wf__sw_detailed_design[version==1]
 
    Each unit shall have a description.
 
@@ -231,18 +259,20 @@ Unit Linkage
 .. gd_req:: Unit Linkage check Component ID
    :id: gd_req__impl_unit_check_id
    :status: valid
+   :version: 1
    :tags: prio_2_automation, attribute, automated
-   :complies: std_req__iso26262__support_6421, std_req__iso26262__support_6425
-   :satisfies: wf__sw_detailed_design
+   :complies: std_req__iso26262__support_6421[version==1], std_req__iso26262__support_6425[version==1]
+   :satisfies: wf__sw_detailed_design[version==1]
 
    Each unit shall be linked to the corresponding component id via the attribute belongs_to.
 
 .. gd_req:: Unit Linkage Component ID
    :id: gd_req__impl_unit_linkage_id
    :status: valid
+   :version: 1
    :tags: prio_2_automation, attribute, automated
-   :complies: std_req__iso26262__support_6421, std_req__iso26262__support_6425
-   :satisfies: wf__sw_detailed_design
+   :complies: std_req__iso26262__support_6421[version==1], std_req__iso26262__support_6425[version==1]
+   :satisfies: wf__sw_detailed_design[version==1]
 
    Each unit shall be automatically linked (inverse direction) to the corresponding component id via the "belongs by" linkage.
 
@@ -252,9 +282,10 @@ Interface Attributes
 .. gd_req:: Interface attribute: UID
    :id: gd_req__impl_interface_uid
    :status: valid
+   :version: 1
    :tags: manual_prio_1, attribute, mandatory
-   :satisfies: wf__sw_detailed_design
-   :complies: std_req__iso26262__software_843, std_req__aspice_40__SWE-3-BP1
+   :satisfies: wf__sw_detailed_design[version==1]
+   :complies: std_req__iso26262__software_843[version==1], std_req__aspice_40__SWE-3-BP1[version==1]
 
    Each interface shall have a unique ID. It shall consist of three parts:
 
@@ -267,9 +298,10 @@ Interface Attributes
 .. gd_req:: Interface attribute: description
    :id: gd_req__impl_interface_description
    :status: valid
+   :version: 1
    :tags: manual_prio_1, attribute, mandatory
-   :complies: std_req__iso26262__support_6421, std_req__iso26262__support_6425
-   :satisfies: wf__sw_detailed_design
+   :complies: std_req__iso26262__support_6421[version==1], std_req__iso26262__support_6425[version==1]
+   :satisfies: wf__sw_detailed_design[version==1]
 
    Each interface shall have a description.
 
@@ -279,36 +311,40 @@ Interface Linkage
 .. gd_req:: Interface Linkage check SW Unit ID
    :id: gd_req__impl_interface_check_id
    :status: valid
+   :version: 1
    :tags: prio_2_automation, attribute, automated
-   :complies: std_req__iso26262__support_6421, std_req__iso26262__support_6425
-   :satisfies: wf__sw_detailed_design
+   :complies: std_req__iso26262__support_6421[version==1], std_req__iso26262__support_6425[version==1]
+   :satisfies: wf__sw_detailed_design[version==1]
 
    Each interface shall be linked to the corresponding SW Unit id via the attribute belongs_to.
 
 .. gd_req:: Interface Linkage SW Unit ID
    :id: gd_req__impl_interface_linkage_id
    :status: valid
+   :version: 1
    :tags: prio_2_automation, attribute, automated
-   :complies: std_req__iso26262__support_6421, std_req__iso26262__support_6425
-   :satisfies: wf__sw_detailed_design
+   :complies: std_req__iso26262__support_6421[version==1], std_req__iso26262__support_6425[version==1]
+   :satisfies: wf__sw_detailed_design[version==1]
 
    Each interface shall be automatically linked (inverse direction) to the corresponding SW Unit id via the "belongs by" linkage.
 
 .. gd_req:: Interface Linkage check Architecture
    :id: gd_req__impl_interface_check_req
    :status: valid
+   :version: 1
    :tags: prio_2_automation, attribute, automated
-   :complies: std_req__iso26262__support_6421, std_req__iso26262__support_6425
-   :satisfies: wf__sw_detailed_design
+   :complies: std_req__iso26262__support_6421[version==1], std_req__iso26262__support_6425[version==1]
+   :satisfies: wf__sw_detailed_design[version==1]
 
    Each interface shall be linked to the corresponding architecture via the attribute implements.
 
 .. gd_req:: Interface Linkage Architecture
    :id: gd_req__impl_interface_linkage_req
    :status: valid
+   :version: 1
    :tags: prio_2_automation, attribute, automated
-   :complies: std_req__iso26262__support_6421, std_req__iso26262__support_6425
-   :satisfies: wf__sw_detailed_design
+   :complies: std_req__iso26262__support_6421[version==1], std_req__iso26262__support_6425[version==1]
+   :satisfies: wf__sw_detailed_design[version==1]
 
    Each interface shall be automatically linked (inverse direction) to the corresponding architecture via the "implemented by" linkage.
 
@@ -318,9 +354,10 @@ Dependency Analysis
 .. gd_req:: Dependency Analysis
    :id: gd_req__impl_dependency_analysis
    :status: valid
+   :version: 1
    :tags: prio_2_automation
-   :satisfies: wf__sw_verify_implementation
-   :complies: std_req__iso26262__software_942
+   :satisfies: wf__sw_verify_implementation[version==1]
+   :complies: std_req__iso26262__software_942[version==1]
 
    For each component a dependency tree view shall be created to support design inspection and Safety Analysis.
    It shall show the libraries used by the component (i.e. which libraries are linked to the component, defined as CI build tool target) up to the leaves of the tree.
@@ -336,8 +373,9 @@ Complexity Analyses
 .. gd_req:: Design Complexity Analysis
    :id: gd_req__impl_complexity_analysis
    :status: valid
+   :version: 1
    :tags: prio_3_automation, model, check
-   :complies: std_req__iso26262__software_743, std_req__aspice_40__SWE-3-BP3
+   :complies: std_req__iso26262__software_743[version==1], std_req__aspice_40__SWE-3-BP3[version==1]
 
    A complexity analysis for the components shall be performed by automated tool support. It shall consider appropriate code metrics like lines of code, cyclomatic complexity, number of public interfaces, number of parameters and so on. The results of the analysis shall be documented in the SW Verification Report. As default an exceeds of the following limits shall be reported for the complexity measures (ASIL B / QM):
 

--- a/process/process_areas/implementation/guidance/software_development_template.rst
+++ b/process/process_areas/implementation/guidance/software_development_template.rst
@@ -18,7 +18,8 @@ Software Development Plan Template
 .. gd_temp:: Software Development Plan Template
    :id: gd_temp__software_development_plan
    :status: valid
-   :complies: std_req__iso26262__software_541, std_req__iso26262__software_543
+   :version: 1
+   :complies: std_req__iso26262__software_541[version==1], std_req__iso26262__software_543[version==1]
 
 Purpose
 +++++++

--- a/process/process_areas/implementation/implementation_concept.rst
+++ b/process/process_areas/implementation/implementation_concept.rst
@@ -18,6 +18,7 @@ Concept Description
 .. doc_concept:: Concept Description
    :id: doc_concept__imp_concept
    :status: valid
+   :version: 1
    :tags: implementation
 
 In this section a concept for the implementation will be discussed. Inputs for this concepts are

--- a/process/process_areas/implementation/implementation_getstrt.rst
+++ b/process/process_areas/implementation/implementation_getstrt.rst
@@ -18,6 +18,7 @@ Getting Started
 .. doc_getstrt:: Getting Started on Implementation
    :id: doc_getstrt__imp_getstrt
    :status: valid
+   :version: 1
    :tags: Implementation
 
 This document describes the steps which need to be done to document detailed design and implement the code.

--- a/process/process_areas/implementation/implementation_workflow.rst
+++ b/process/process_areas/implementation/implementation_workflow.rst
@@ -22,13 +22,14 @@ For a detailed explanation of workflows and their role within the process model,
 .. workflow:: Create/Maintain Software Development Plan
    :id: wf__sw_development_plan
    :status: valid
+   :version: 1
    :tags: implementation
-   :responsible: rl__committer
-   :approved_by: rl__project_lead
-   :input: wp__platform_mgmt
-   :output: wp__sw_development_plan
-   :contains: gd_temp__software_development_plan
-   :has: doc_concept__imp_concept, doc_getstrt__imp_getstrt
+   :responsible: rl__committer[version==1]
+   :approved_by: rl__project_lead[version==1]
+   :input: wp__platform_mgmt[version==1]
+   :output: wp__sw_development_plan[version==1]
+   :contains: gd_temp__software_development_plan[version==1]
+   :has: doc_concept__imp_concept[version==1], doc_getstrt__imp_getstrt[version==1]
 
    The Software Development Plan shall describe
      - Design and programming language selection
@@ -38,13 +39,14 @@ For a detailed explanation of workflows and their role within the process model,
 .. workflow:: Create/Maintain Implementation
    :id: wf__sw_detailed_design
    :status: valid
+   :version: 1
    :tags: implementation
-   :responsible: rl__contributor
-   :approved_by: rl__committer
-   :input: wp__requirements_comp, wp__component_arch, wp__sw_development_plan
-   :output: wp__sw_implementation
-   :contains: gd_temp__detailed_design
-   :has: doc_concept__imp_concept, doc_getstrt__imp_getstrt
+   :responsible: rl__contributor[version==1]
+   :approved_by: rl__committer[version==1]
+   :input: wp__requirements_comp[version==1], wp__component_arch[version==1], wp__sw_development_plan[version==1]
+   :output: wp__sw_implementation[version==1]
+   :contains: gd_temp__detailed_design[version==1]
+   :has: doc_concept__imp_concept[version==1], doc_getstrt__imp_getstrt[version==1]
 
    The implementation is created, consisting of
      - Detailed Design
@@ -54,13 +56,14 @@ For a detailed explanation of workflows and their role within the process model,
 .. workflow:: Verify Implementation
    :id: wf__sw_verify_implementation
    :status: valid
+   :version: 1
    :tags: implementation
-   :responsible: rl__committer
-   :approved_by: rl__committer
-   :input: wp__sw_implementation, wp__sw_development_plan
-   :output: wp__issue_track_system, wp__sw_implementation_inspection, wp__verification_module_ver_report
-   :contains: gd_chklst__impl_inspection_checklist
-   :has: doc_concept__imp_concept, doc_getstrt__imp_getstrt
+   :responsible: rl__committer[version==1]
+   :approved_by: rl__committer[version==1]
+   :input: wp__sw_implementation[version==1], wp__sw_development_plan[version==1]
+   :output: wp__issue_track_system[version==1], wp__sw_implementation_inspection[version==1], wp__verification_module_ver_report[version==1]
+   :contains: gd_chklst__impl_inspection_checklist[version==1]
+   :has: doc_concept__imp_concept[version==1], doc_getstrt__imp_getstrt[version==1]
 
    The Implementation Verification of the Detailed Design and Code consists of the following topics
      - Detailed Design and Code Inspection

--- a/process/process_areas/implementation/implementation_workproducts.rst
+++ b/process/process_areas/implementation/implementation_workproducts.rst
@@ -18,8 +18,13 @@ Implementation Work Products
 .. workproduct:: Implementation
    :id: wp__sw_implementation
    :status: valid
+   :version: 1
    :tags: doc_lifecycle_model_3
-   :complies: std_wp__iso26262__software_851, std_wp__iso26262__software_852, std_wp__iso26262__software_app_c_53, std_req__aspice_40__iic-04-05, std_req__aspice_40__iic-11-05,
+   :complies: std_wp__iso26262__software_851[version==1],
+              std_wp__iso26262__software_852[version==1],
+              std_wp__iso26262__software_app_c_53[version==1],
+              std_req__aspice_40__iic-04-05[version==1],
+              std_req__aspice_40__iic-11-05[version==1]
 
    Implementation includes source code and detailed design (e.g. in form of comments or linked graphical representations) and SW configuration (e.g. #ifdef)
    The "how to" is described in the SW Development Plan guidelines
@@ -27,16 +32,18 @@ Implementation Work Products
 .. workproduct:: Implementation Inspection
    :id: wp__sw_implementation_inspection
    :status: valid
+   :version: 1
    :tags: doc_lifecycle_model_2
-   :complies: std_wp__iso26262__software_952
+   :complies: std_wp__iso26262__software_952[version==1]
 
    Github review with integrated inspection checklist, only valid Detailed Design and Code get merged
 
 .. workproduct:: Software Development Plan
    :id: wp__sw_development_plan
    :status: valid
+   :version: 1
    :tags: doc_lifecycle_model_2
-   :complies: std_wp__iso26262__software_551, std_wp__iso26262__software_app_c_58, std_wp__isosae21434__development_1053
+   :complies: std_wp__iso26262__software_551[version==1], std_wp__iso26262__software_app_c_58[version==1], std_wp__isosae21434__development_1053[version==1]
 
    Process description of SW development including
    - selection of design and programming language

--- a/process/process_areas/platform_management/guidance/platform_management_guideline.rst
+++ b/process/process_areas/platform_management/guidance/platform_management_guideline.rst
@@ -18,7 +18,18 @@ Guideline
 .. gd_guidl:: Working model
    :id: gd_guidl__platform_mgmt_plan
    :status: valid
-   :complies: std_req__aspice_40__MAN-3-BP1, std_req__aspice_40__MAN-3-BP2, std_req__aspice_40__MAN-3-BP3, std_req__aspice_40__MAN-3-BP4, std_req__aspice_40__MAN-3-BP5, std_req__aspice_40__MAN-3-BP6, std_req__aspice_40__MAN-3-BP7, std_req__aspice_40__MAN-3-BP8, std_req__aspice_40__MAN-3-BP9, std_req__aspice_40__MAN-3-BP10, std_req__aspice_40__iic-15-06
+   :version: 1
+   :complies: std_req__aspice_40__MAN-3-BP1[version==1],
+              std_req__aspice_40__MAN-3-BP2[version==1],
+              std_req__aspice_40__MAN-3-BP3[version==1],
+              std_req__aspice_40__MAN-3-BP4[version==1],
+              std_req__aspice_40__MAN-3-BP5[version==1],
+              std_req__aspice_40__MAN-3-BP6[version==1],
+              std_req__aspice_40__MAN-3-BP7[version==1],
+              std_req__aspice_40__MAN-3-BP8[version==1],
+              std_req__aspice_40__MAN-3-BP9[version==1],
+              std_req__aspice_40__MAN-3-BP10[version==1],
+              std_req__aspice_40__iic-15-06[version==1]
 
 This document describes the general guidances for Platform Management based on the concept which is defined :need:`[[title]]<doc_concept__platform_process>`.
 
@@ -123,8 +134,17 @@ Tailoring
 .. gd_guidl:: Platform Management Plan Requirements Tailored
    :id: gd_guidl__platform_mgmt_plan_req_tailored
    :status: valid
-   :complies: std_req__aspice_40__MAN-5-BP1, std_req__aspice_40__MAN-5-BP2, std_req__aspice_40__MAN-5-BP3, std_req__aspice_40__MAN-5-BP4, std_req__aspice_40__MAN-5-BP5, std_req__aspice_40__MAN-5-BP6, std_req__aspice_40__MAN-5-BP7,
-              std_req__aspice_40__iic-15-09, std_req__aspice_40__iic-15-51, std_req__aspice_40__iic-08-55
+   :version: 1
+   :complies: std_req__aspice_40__MAN-5-BP1[version==1],
+              std_req__aspice_40__MAN-5-BP2[version==1],
+              std_req__aspice_40__MAN-5-BP3[version==1],
+              std_req__aspice_40__MAN-5-BP4[version==1],
+              std_req__aspice_40__MAN-5-BP5[version==1],
+              std_req__aspice_40__MAN-5-BP6[version==1],
+              std_req__aspice_40__MAN-5-BP7[version==1],
+              std_req__aspice_40__iic-15-09[version==1],
+              std_req__aspice_40__iic-15-51[version==1],
+              std_req__aspice_40__iic-08-55[version==1]
 
    This part of the guideline links to all the requirements which are not fulfilled by the
    platform management plan process. Make sure these are tailored out in the corresponding sub-plans

--- a/process/process_areas/platform_management/guidance/platform_management_template.rst
+++ b/process/process_areas/platform_management/guidance/platform_management_template.rst
@@ -20,7 +20,16 @@ Platform Management Template
 .. gd_temp:: Platform Management Plan Template
    :id: gd_temp__platform_mgmt_plan
    :status: valid
-   :complies: std_req__iso26262__management_6464, std_req__aspice_40__MAN-3-BP1, std_req__aspice_40__iic-08-53, std_req__aspice_40__iic-08-56, std_req__aspice_40__iic-08-62, std_req__aspice_40__iic-08-56, std_req__aspice_40__iic-10-52, std_req__aspice_40__iic-14-10, std_req__aspice_40__iic-14-50
+   :version: 1
+   :complies: std_req__iso26262__management_6464[version==1],
+              std_req__aspice_40__MAN-3-BP1[version==1],
+              std_req__aspice_40__iic-08-53[version==1],
+              std_req__aspice_40__iic-08-56[version==1],
+              std_req__aspice_40__iic-08-62[version==1],
+              std_req__aspice_40__iic-08-56[version==1],
+              std_req__aspice_40__iic-10-52[version==1],
+              std_req__aspice_40__iic-14-10[version==1],
+              std_req__aspice_40__iic-14-50[version==1]
 
 .. attention::
     Remove everything above when copying and filling the template.
@@ -33,6 +42,7 @@ Platform Management Template
 ' .. document:: [Your Project Name]
      :id: doc__platform_mgt_plan
      :status: draft
+     :version: 1
      :safety: ASIL_B
      :tags: platform_management
 

--- a/process/process_areas/platform_management/platform_management_concept.rst
+++ b/process/process_areas/platform_management/platform_management_concept.rst
@@ -18,6 +18,7 @@ Concept Description
 .. doc_concept:: Concept Description
    :id: doc_concept__platform_process
    :status: valid
+   :version: 1
    :tags: platform_management
 
 In this section a concept for the Platform Management will be discussed. Inputs for this concepts

--- a/process/process_areas/platform_management/platform_management_getstrt.rst
+++ b/process/process_areas/platform_management/platform_management_getstrt.rst
@@ -18,6 +18,7 @@ Getting Started
 .. doc_getstrt:: Getting Started on Platform/Project Management
    :id: doc_getstrt__platform_process
    :status: valid
+   :version: 1
    :tags: platform_management
 
 In case you want to manage contributions to <Project> consider to:

--- a/process/process_areas/platform_management/platform_management_workflow.rst
+++ b/process/process_areas/platform_management/platform_management_workflow.rst
@@ -22,14 +22,25 @@ For a detailed explanation of workflows and their role within the process model,
 .. workflow:: Create/Maintain Platform Management Plan
    :id: wf__platform_cr_mt_platform_mgmt_plan
    :status: valid
+   :version: 1
    :tags: platform_management
-   :responsible: rl__project_lead
-   :approved_by: rl__process_community
-   :supported_by: rl__safety_manager, rl__security_manager, rl__quality_manager
-   :input: wp__policies, wp__issue_track_system
-   :output: wp__platform_mgmt, wp__project_mgt, wp__document_mgt_plan, wp__config_mgt_plan, wp__prm_plan, wp__tlm_plan, wp__chm_plan
-   :contains: gd_temp__platform_mgmt_plan, gd_guidl__platform_mgmt_plan, gd_guidl__documentation, gd_chklst__documentation_review, gd_temp__documentation
-   :has: doc_concept__platform_process, doc_getstrt__platform_process
+   :responsible: rl__project_lead[version==1]
+   :approved_by: rl__process_community[version==1]
+   :supported_by: rl__safety_manager[version==1], rl__security_manager[version==1], rl__quality_manager[version==1]
+   :input: wp__policies[version==1], wp__issue_track_system[version==1]
+   :output: wp__platform_mgmt[version==1],
+            wp__project_mgt[version==1],
+            wp__document_mgt_plan[version==1],
+            wp__config_mgt_plan[version==1],
+            wp__prm_plan[version==1],
+            wp__tlm_plan[version==1],
+            wp__chm_plan[version==1]
+   :contains: gd_temp__platform_mgmt_plan[version==1],
+              gd_guidl__platform_mgmt_plan[version==1],
+              gd_guidl__documentation[version==1],
+              gd_chklst__documentation_review[version==1],
+              gd_temp__documentation[version==1]
+   :has: doc_concept__platform_process[version==1], doc_getstrt__platform_process[version==1]
 
    The Platform Management Plan shall include the plans as defined by the
    :ref:`Platform Management Plan Template <platform_templates>`.
@@ -40,14 +51,21 @@ For a detailed explanation of workflows and their role within the process model,
 .. workflow:: Monitor/Improve Platform Management Plan
    :id: wf__platform_mr_im_platform_mgmt_plan
    :status: valid
+   :version: 1
    :tags: platform_management
-   :responsible: rl__project_lead
-   :approved_by: rl__process_community
-   :supported_by: rl__safety_manager, rl__security_manager, rl__quality_manager
-   :input: wp__platform_mgmt, wp__project_mgt, wp__document_mgt_plan, wp__config_mgt_plan
-   :output: wp__issue_track_system
-   :contains: gd_temp__platform_mgmt_plan, gd_guidl__platform_mgmt_plan, gd_guidl__documentation, gd_chklst__documentation_review
-   :has: doc_concept__platform_process, doc_getstrt__platform_process
+   :responsible: rl__project_lead[version==1]
+   :approved_by: rl__process_community[version==1]
+   :supported_by: rl__safety_manager[version==1], rl__security_manager[version==1], rl__quality_manager[version==1]
+   :input: wp__platform_mgmt[version==1],
+           wp__project_mgt[version==1],
+           wp__document_mgt_plan[version==1],
+           wp__config_mgt_plan[version==1]
+   :output: wp__issue_track_system[version==1]
+   :contains: gd_temp__platform_mgmt_plan[version==1],
+              gd_guidl__platform_mgmt_plan[version==1],
+              gd_guidl__documentation[version==1],
+              gd_chklst__documentation_review[version==1]
+   :has: doc_concept__platform_process[version==1], doc_getstrt__platform_process[version==1]
 
    The :need:`Project Lead <rl__project_lead>` is responsible for the monitoring and reporting
    of the work products and activities against the platform management plan.

--- a/process/process_areas/platform_management/platform_management_workproducts.rst
+++ b/process/process_areas/platform_management/platform_management_workproducts.rst
@@ -18,6 +18,7 @@ Platform Management Work Products
 .. workproduct:: Platform Management Plan
    :id: wp__platform_mgmt
    :status: valid
+   :version: 1
    :tags: doc_lifecycle_model_2
    :complies:
 
@@ -34,8 +35,14 @@ Platform Management Work Products
 .. workproduct:: Project Management Plan
    :id: wp__project_mgt
    :status: valid
+   :version: 1
    :tags: doc_lifecycle_model_2
-   :complies: std_req__aspice_40__iic-08-53, std_req__aspice_40__iic-14-10, std_req__aspice_40__iic-13-52, std_req__aspice_40__iic-18-52, std_req__aspice_40__iic-08-56, std_req__aspice_40__iic-14-50
+   :complies: std_req__aspice_40__iic-08-53[version==1],
+              std_req__aspice_40__iic-14-10[version==1],
+              std_req__aspice_40__iic-13-52[version==1],
+              std_req__aspice_40__iic-18-52[version==1],
+              std_req__aspice_40__iic-08-56[version==1],
+              std_req__aspice_40__iic-14-50[version==1]
 
    Project Management Plan (Part of the Platform Management Plan)
 

--- a/process/process_areas/problem_resolution/guidance/problem_resolution_checklist.rst
+++ b/process/process_areas/problem_resolution/guidance/problem_resolution_checklist.rst
@@ -20,6 +20,7 @@ Problem Checklist
 .. gd_chklst:: Problem Review Checklist
    :id: gd_chklst__problem_cr_review
    :status: valid
+   :version: 1
    :tags: problem_resolution
    :complies:
 

--- a/process/process_areas/problem_resolution/guidance/problem_resolution_guideline.rst
+++ b/process/process_areas/problem_resolution/guidance/problem_resolution_guideline.rst
@@ -18,7 +18,15 @@ Guideline
 .. gd_guidl:: Problem Resolution Guideline
    :id: gd_guidl__problem_problem
    :status: valid
-   :complies: std_req__iso26262__management_5431, std_req__iso26262__management_5433, std_req__iso26262__management_5434, std_req__iso26262__management_5435, std_req__aspice_40__SUP-9-BP1, std_req__aspice_40__SUP-9-BP5, std_req__aspice_40__SUP-9-BP6, std_req__aspice_40__SUP-9-BP7
+   :version: 1
+   :complies: std_req__iso26262__management_5431[version==1],
+              std_req__iso26262__management_5433[version==1],
+              std_req__iso26262__management_5434[version==1],
+              std_req__iso26262__management_5435[version==1],
+              std_req__aspice_40__SUP-9-BP1[version==1],
+              std_req__aspice_40__SUP-9-BP5[version==1],
+              std_req__aspice_40__SUP-9-BP6[version==1],
+              std_req__aspice_40__SUP-9-BP7[version==1]
 
 This document describes the general guidances for Problem Resolution based on the concept which is defined :need:`[[title]]<doc_concept__problem_process>`.
 

--- a/process/process_areas/problem_resolution/guidance/problem_resolution_reqs.rst
+++ b/process/process_areas/problem_resolution/guidance/problem_resolution_reqs.rst
@@ -25,18 +25,26 @@ Problem Attributes
 .. gd_req:: Problem attribute: UID
    :id: gd_req__problem_attr_uid
    :status: valid
+   :version: 1
    :tags: done_automation, problem_resolution, attribute, mandatory
-   :satisfies: wf__problem_create_pr, wf__problem_analyze_pr, wf__problem_initiate_monitor_pr, wf__problem_close_pr
-   :complies: std_req__aspice_40__SUP-9-BP1
+   :satisfies: wf__problem_create_pr[version==1],
+               wf__problem_analyze_pr[version==1],
+               wf__problem_initiate_monitor_pr[version==1],
+               wf__problem_close_pr[version==1]
+   :complies: std_req__aspice_40__SUP-9-BP1[version==1]
 
    Each Problem shall have a unique ID. It shall be in an integer number.
 
 .. gd_req:: Problem attribute: status
    :id: gd_req__problem_attr_status
    :status: valid
+   :version: 1
    :tags: manual_prio_1, problem_resolution, attribute, mandatory
-   :satisfies: wf__problem_create_pr, wf__problem_analyze_pr, wf__problem_initiate_monitor_pr, wf__problem_close_pr
-   :complies: std_req__aspice_40__SUP-9-BP1
+   :satisfies: wf__problem_create_pr[version==1],
+               wf__problem_analyze_pr[version==1],
+               wf__problem_initiate_monitor_pr[version==1],
+               wf__problem_close_pr[version==1]
+   :complies: std_req__aspice_40__SUP-9-BP1[version==1]
 
    Each Problem shall have a status:
 
@@ -49,18 +57,26 @@ Problem Attributes
 .. gd_req:: Problem attribute: title
    :id: gd_req__problem_attr_title
    :status: valid
+   :version: 1
    :tags: manual_prio_1, problem_resolution, attribute, mandatory
-   :satisfies: wf__problem_create_pr, wf__problem_analyze_pr, wf__problem_initiate_monitor_pr, wf__problem_close_pr
-   :complies: std_req__aspice_40__SUP-9-BP1
+   :satisfies: wf__problem_create_pr[version==1],
+               wf__problem_analyze_pr[version==1],
+               wf__problem_initiate_monitor_pr[version==1],
+               wf__problem_close_pr[version==1]
+   :complies: std_req__aspice_40__SUP-9-BP1[version==1]
 
    Reason for Problem Report
 
 .. gd_req:: Problem attribute: description
    :id: gd_req__problem_attr_impact_description
    :status: valid
+   :version: 1
    :tags: manual_prio_1, problem_resolution, attribute, mandatory
-   :satisfies: wf__problem_create_pr, wf__problem_analyze_pr, wf__problem_initiate_monitor_pr, wf__problem_close_pr
-   :complies: std_req__aspice_40__SUP-9-BP1, std_req__aspice_40__SUP-9-BP2
+   :satisfies: wf__problem_create_pr[version==1],
+               wf__problem_analyze_pr[version==1],
+               wf__problem_initiate_monitor_pr[version==1],
+               wf__problem_close_pr[version==1]
+   :complies: std_req__aspice_40__SUP-9-BP1[version==1], std_req__aspice_40__SUP-9-BP2[version==1]
 
    Exact description of the Problem, including potential cause and impact of the problem.
 
@@ -72,18 +88,26 @@ Problem Attributes
 .. gd_req:: Problem attribute: analysis results
    :id: gd_req__problem_attr_analysis_results
    :status: valid
+   :version: 1
    :tags: manual_prio_1, problem_resolution, attribute, mandatory
-   :satisfies: wf__problem_create_pr, wf__problem_analyze_pr, wf__problem_initiate_monitor_pr, wf__problem_close_pr
-   :complies: std_req__aspice_40__SUP-9-BP2
+   :satisfies: wf__problem_create_pr[version==1],
+               wf__problem_analyze_pr[version==1],
+               wf__problem_initiate_monitor_pr[version==1],
+               wf__problem_close_pr[version==1]
+   :complies: std_req__aspice_40__SUP-9-BP2[version==1]
 
    Record analysis results (e.g. reason for rejection, safety, security, quality impact) as comments.
 
 .. gd_req:: Problem attribute: stakeholder
    :id: gd_req__problem_attr_stakeholder
    :status: valid
+   :version: 1
    :tags: prio_1_automation, problem_resolution, attribute, mandatory
-   :satisfies: wf__problem_create_pr, wf__problem_analyze_pr, wf__problem_initiate_monitor_pr, wf__problem_close_pr
-   :complies: std_req__aspice_40__SUP-9-BP2, std_req__aspice_40__SUP-9-BP5
+   :satisfies: wf__problem_create_pr[version==1],
+               wf__problem_analyze_pr[version==1],
+               wf__problem_initiate_monitor_pr[version==1],
+               wf__problem_close_pr[version==1]
+   :complies: std_req__aspice_40__SUP-9-BP2[version==1], std_req__aspice_40__SUP-9-BP5[version==1]
 
    Assign responsible stakeholder for analyzing the problem
    Assign responsible stakeholder to resolve the problem
@@ -91,9 +115,13 @@ Problem Attributes
 .. gd_req:: Problem attribute: classification
    :id: gd_req__problem_attr_classification
    :status: valid
+   :version: 1
    :tags: prio_1_automation, problem_resolution, attribute, mandatory
-   :satisfies: wf__problem_create_pr, wf__problem_analyze_pr, wf__problem_initiate_monitor_pr, wf__problem_close_pr
-   :complies: std_req__aspice_40__SUP-9-BP1, std_req__aspice_40__SUP-9-BP2
+   :satisfies: wf__problem_create_pr[version==1],
+               wf__problem_analyze_pr[version==1],
+               wf__problem_initiate_monitor_pr[version==1],
+               wf__problem_close_pr[version==1]
+   :complies: std_req__aspice_40__SUP-9-BP1[version==1], std_req__aspice_40__SUP-9-BP2[version==1]
 
    Each Problem shall have a classification identifier:
 
@@ -105,9 +133,13 @@ Problem Attributes
 .. gd_req:: Problem attribute:: safety affected
    :id: gd_req__problem_attr_safety_affected
    :status: valid
+   :version: 1
    :tags: prio_1_automation, problem_resolution, attribute, mandatory
-   :satisfies: wf__problem_create_pr, wf__problem_analyze_pr, wf__problem_initiate_monitor_pr, wf__problem_close_pr
-   :complies: std_req__aspice_40__SUP-9-BP1
+   :satisfies: wf__problem_create_pr[version==1],
+               wf__problem_analyze_pr[version==1],
+               wf__problem_initiate_monitor_pr[version==1],
+               wf__problem_close_pr[version==1]
+   :complies: std_req__aspice_40__SUP-9-BP1[version==1]
 
    Each Problem shall have a safety relevance identifier:
 
@@ -119,9 +151,13 @@ Problem Attributes
 .. gd_req:: Problem attribute:: security affected
    :id: gd_req__problem_attr_security_affected
    :status: valid
+   :version: 1
    :tags: prio_1_automation, problem_resolution, attribute, mandatory
-   :satisfies: wf__problem_create_pr, wf__problem_analyze_pr, wf__problem_initiate_monitor_pr, wf__problem_close_pr
-   :complies: std_req__aspice_40__SUP-9-BP1
+   :satisfies: wf__problem_create_pr[version==1],
+               wf__problem_analyze_pr[version==1],
+               wf__problem_initiate_monitor_pr[version==1],
+               wf__problem_close_pr[version==1]
+   :complies: std_req__aspice_40__SUP-9-BP1[version==1]
 
    Each Problem shall have a security relevance identifier:
 
@@ -133,9 +169,13 @@ Problem Attributes
 .. gd_req:: Problem attribute: milestone
    :id: gd_req__problem_attr_milestone
    :status: valid
+   :version: 1
    :tags: manual_prio_1, problem_resolution, attribute, mandatory
-   :satisfies: wf__problem_create_pr, wf__problem_analyze_pr, wf__problem_initiate_monitor_pr, wf__problem_close_pr
-   :complies: std_req__aspice_40__SUP-9-BP1, std_req__aspice_40__SUP-9-BP6
+   :satisfies: wf__problem_create_pr[version==1],
+               wf__problem_analyze_pr[version==1],
+               wf__problem_initiate_monitor_pr[version==1],
+               wf__problem_close_pr[version==1]
+   :complies: std_req__aspice_40__SUP-9-BP1[version==1], std_req__aspice_40__SUP-9-BP6[version==1]
 
    Milestone until the Problem must be implemented (used for prioritization)
 
@@ -146,9 +186,13 @@ Problem Resolution Checks
 .. gd_req:: Problem Resolution mandatory attributes provided
    :id: gd_req__problem_check_mandatory
    :status: valid
+   :version: 1
    :tags: prio_2_automation, problem_resolution, attribute, check
-   :satisfies: wf__problem_create_pr, wf__problem_analyze_pr, wf__problem_initiate_monitor_pr, wf__problem_close_pr
-   :complies: std_req__aspice_40__SUP-9-BP1
+   :satisfies: wf__problem_create_pr[version==1],
+               wf__problem_analyze_pr[version==1],
+               wf__problem_initiate_monitor_pr[version==1],
+               wf__problem_close_pr[version==1]
+   :complies: std_req__aspice_40__SUP-9-BP1[version==1]
 
    It shall be checked if all mandatory attributes for each Problem
    is provided by the user. Following attributes shall be mandatory:
@@ -164,9 +208,13 @@ Problem Resolution Checks
 .. gd_req:: Problem Report issues closing constraints
    :id: gd_req__problem_check_closing
    :status: valid
+   :version: 1
    :tags: prio_1_automation, problem_resolution, attribute, check
-   :satisfies: wf__problem_create_pr, wf__problem_analyze_pr, wf__problem_initiate_monitor_pr, wf__problem_close_pr
-   :complies: std_req__aspice_40__SUP-9-BP1
+   :satisfies: wf__problem_create_pr[version==1],
+               wf__problem_analyze_pr[version==1],
+               wf__problem_initiate_monitor_pr[version==1],
+               wf__problem_close_pr[version==1]
+   :complies: std_req__aspice_40__SUP-9-BP1[version==1]
 
    ISSUEs related to Problem Reports shall not automatically closed, if linked ISSUEs or PRs are closed or merged and
    these ISSUEs shall be closed only manually from the :need:`Committer <rl__committer>`.

--- a/process/process_areas/problem_resolution/guidance/problem_resolution_template.rst
+++ b/process/process_areas/problem_resolution/guidance/problem_resolution_template.rst
@@ -20,7 +20,13 @@ Problem Report Template
 .. gd_temp:: Problem Template
    :id: gd_temp__problem_template
    :status: valid
-   :complies: std_req__aspice_40__SUP-9-BP1, std_req__aspice_40__SUP-9-BP2, std_req__aspice_40__SUP-9-BP3, std_req__aspice_40__SUP-9-BP4, std_req__aspice_40__iic-15-12, std_req__aspice_40__iic-15-55
+   :version: 1
+   :complies: std_req__aspice_40__SUP-9-BP1[version==1],
+              std_req__aspice_40__SUP-9-BP2[version==1],
+              std_req__aspice_40__SUP-9-BP3[version==1],
+              std_req__aspice_40__SUP-9-BP4[version==1],
+              std_req__aspice_40__iic-15-12[version==1],
+              std_req__aspice_40__iic-15-55[version==1]
 
 This template defines the content to be implemented in the selected Issue Tracking System
 of the project.

--- a/process/process_areas/problem_resolution/problem_resolution_concept.rst
+++ b/process/process_areas/problem_resolution/problem_resolution_concept.rst
@@ -18,6 +18,7 @@ Concept Description
 .. doc_concept:: Concept Description
    :id: doc_concept__problem_process
    :status: valid
+   :version: 1
    :tags: problem_resolution
 
 In this section a concept for the Problem Resolution will be discussed. Inputs for this concepts

--- a/process/process_areas/problem_resolution/problem_resolution_getstrt.rst
+++ b/process/process_areas/problem_resolution/problem_resolution_getstrt.rst
@@ -18,6 +18,7 @@ Getting Started
 .. doc_getstrt:: Getting Started on Problem Resolution
    :id: doc_getstrt__problem_process
    :status: valid
+   :version: 1
    :tags: problem_resolution
 
 This document describes the steps to create a problem report, and further to analyze,

--- a/process/process_areas/problem_resolution/problem_resolution_workflow.rst
+++ b/process/process_areas/problem_resolution/problem_resolution_workflow.rst
@@ -22,13 +22,17 @@ For a detailed explanation of workflows and their role within the process model,
 .. workflow:: Create Problem Report
    :id: wf__problem_create_pr
    :status: valid
-   :responsible: rl__contributor
-   :approved_by: rl__committer
-   :supported_by: rl__project_lead, rl__safety_manager, rl__security_manager, rl__quality_manager
-   :input: wp__issue_track_system, wp__prm_plan
-   :output: wp__issue_track_system
-   :contains: gd_temp__problem_template, gd_chklst__problem_cr_review, gd_guidl__problem_problem
-   :has: doc_concept__problem_process, doc_getstrt__problem_process
+   :version: 1
+   :responsible: rl__contributor[version==1]
+   :approved_by: rl__committer[version==1]
+   :supported_by: rl__project_lead[version==1],
+                  rl__safety_manager[version==1],
+                  rl__security_manager[version==1],
+                  rl__quality_manager[version==1]
+   :input: wp__issue_track_system[version==1], wp__prm_plan[version==1]
+   :output: wp__issue_track_system[version==1]
+   :contains: gd_temp__problem_template[version==1], gd_chklst__problem_cr_review[version==1], gd_guidl__problem_problem[version==1]
+   :has: doc_concept__problem_process[version==1], doc_getstrt__problem_process[version==1]
 
    The Problem Report is created.
 
@@ -39,13 +43,17 @@ For a detailed explanation of workflows and their role within the process model,
 .. workflow:: Analyze Problem Report
    :id: wf__problem_analyze_pr
    :status: valid
-   :responsible: rl__contributor
-   :approved_by: rl__committer
-   :supported_by: rl__project_lead, rl__safety_manager, rl__security_manager, rl__quality_manager
-   :input: wp__issue_track_system, wp__prm_plan
-   :output: wp__issue_track_system
-   :contains: gd_temp__problem_template, gd_chklst__problem_cr_review, gd_guidl__problem_problem
-   :has: doc_concept__problem_process, doc_getstrt__problem_process
+   :version: 1
+   :responsible: rl__contributor[version==1]
+   :approved_by: rl__committer[version==1]
+   :supported_by: rl__project_lead[version==1],
+                  rl__safety_manager[version==1],
+                  rl__security_manager[version==1],
+                  rl__quality_manager[version==1]
+   :input: wp__issue_track_system[version==1], wp__prm_plan[version==1]
+   :output: wp__issue_track_system[version==1]
+   :contains: gd_temp__problem_template[version==1], gd_chklst__problem_cr_review[version==1], gd_guidl__problem_problem[version==1]
+   :has: doc_concept__problem_process[version==1], doc_getstrt__problem_process[version==1]
 
    The Problem Report is analyzed.
 
@@ -60,13 +68,17 @@ For a detailed explanation of workflows and their role within the process model,
 .. workflow:: Initiate and Monitor Problem Resolution
    :id: wf__problem_initiate_monitor_pr
    :status: valid
-   :responsible: rl__contributor
-   :approved_by: rl__committer
-   :supported_by: rl__project_lead, rl__safety_manager, rl__security_manager, rl__quality_manager
-   :input: wp__issue_track_system, wp__prm_plan
-   :output: wp__issue_track_system
-   :contains: gd_temp__problem_template, gd_chklst__problem_cr_review, gd_guidl__problem_problem
-   :has: doc_concept__problem_process, doc_getstrt__problem_process
+   :version: 1
+   :responsible: rl__contributor[version==1]
+   :approved_by: rl__committer[version==1]
+   :supported_by: rl__project_lead[version==1],
+                  rl__safety_manager[version==1],
+                  rl__security_manager[version==1],
+                  rl__quality_manager[version==1]
+   :input: wp__issue_track_system[version==1], wp__prm_plan[version==1]
+   :output: wp__issue_track_system[version==1]
+   :contains: gd_temp__problem_template[version==1], gd_chklst__problem_cr_review[version==1], gd_guidl__problem_problem[version==1]
+   :has: doc_concept__problem_process[version==1], doc_getstrt__problem_process[version==1]
 
    The Problem Resolution is implemented and monitored.
 
@@ -84,13 +96,14 @@ For a detailed explanation of workflows and their role within the process model,
 .. workflow:: Close Problem Resolution
    :id: wf__problem_close_pr
    :status: valid
-   :responsible: rl__committer
-   :approved_by: rl__project_lead
-   :supported_by: rl__safety_manager, rl__security_manager, rl__quality_manager
-   :input: wp__issue_track_system, wp__prm_plan
-   :output: wp__issue_track_system
-   :contains: gd_temp__problem_template, gd_chklst__problem_cr_review, gd_guidl__problem_problem
-   :has: doc_concept__problem_process, doc_getstrt__problem_process
+   :version: 1
+   :responsible: rl__committer[version==1]
+   :approved_by: rl__project_lead[version==1]
+   :supported_by: rl__safety_manager[version==1], rl__security_manager[version==1], rl__quality_manager[version==1]
+   :input: wp__issue_track_system[version==1], wp__prm_plan[version==1]
+   :output: wp__issue_track_system[version==1]
+   :contains: gd_temp__problem_template[version==1], gd_chklst__problem_cr_review[version==1], gd_guidl__problem_problem[version==1]
+   :has: doc_concept__problem_process[version==1], doc_getstrt__problem_process[version==1]
 
    The Problem Resolution is closed.
 

--- a/process/process_areas/problem_resolution/problem_resolution_workproducts.rst
+++ b/process/process_areas/problem_resolution/problem_resolution_workproducts.rst
@@ -18,7 +18,8 @@ Problem Resolution Work Products
 .. workproduct:: Platform Problem Resolution Plan
    :id: wp__prm_plan
    :status: valid
+   :version: 1
    :tags: doc_lifecycle_model_2
-   :complies: std_wp__iso26262__support_851
+   :complies: std_wp__iso26262__support_851[version==1]
 
    Problem Resolution Plan (Part of the Platform Management Plan)

--- a/process/process_areas/process_management/guidance/process_management_guideline.rst
+++ b/process/process_areas/process_management/guidance/process_management_guideline.rst
@@ -19,10 +19,28 @@ Guideline
 .. gd_guidl:: Process Management Guideline
    :id: gd_guidl__process_management
    :status: valid
+   :version: 1
    :tags: process_management
-   :complies: std_req__iso26262__management_5421, std_req__iso26262__management_5422, std_req__iso26262__management_5426, std_req__aspice_40__gp-311, std_req__aspice_40__iic-10-00, std_req__aspice_40__iic-15-54,
-              std_req__aspice_40__gp-211, std_req__aspice_40__gp-212, std_req__aspice_40__gp-213, std_req__aspice_40__gp-214, std_req__aspice_40__gp-215, std_req__aspice_40__gp-216, std_req__aspice_40__gp-224,
-              std_req__aspice_40__gp-312, std_req__aspice_40__gp-313, std_req__aspice_40__gp-314, std_req__aspice_40__gp-321, std_req__aspice_40__gp-322, std_req__aspice_40__gp-323, std_req__aspice_40__gp-324
+   :complies: std_req__iso26262__management_5421[version==1],
+              std_req__iso26262__management_5422[version==1],
+              std_req__iso26262__management_5426[version==1],
+              std_req__aspice_40__gp-311[version==1],
+              std_req__aspice_40__iic-10-00[version==1],
+              std_req__aspice_40__iic-15-54[version==1],
+              std_req__aspice_40__gp-211[version==1],
+              std_req__aspice_40__gp-212[version==1],
+              std_req__aspice_40__gp-213[version==1],
+              std_req__aspice_40__gp-214[version==1],
+              std_req__aspice_40__gp-215[version==1],
+              std_req__aspice_40__gp-216[version==1],
+              std_req__aspice_40__gp-224[version==1],
+              std_req__aspice_40__gp-312[version==1],
+              std_req__aspice_40__gp-313[version==1],
+              std_req__aspice_40__gp-314[version==1],
+              std_req__aspice_40__gp-321[version==1],
+              std_req__aspice_40__gp-322[version==1],
+              std_req__aspice_40__gp-323[version==1],
+              std_req__aspice_40__gp-324[version==1]
 
 This document describes the general guidances for Process Management based on the concept which is defined :need:`[[title]]<doc_concept__process_management>`.
 
@@ -129,20 +147,56 @@ Tailoring
 .. gd_guidl:: IIC Requirements Tailored
    :id: gd_guidl__iic_req_tailored
    :status: valid
-   :complies: std_req__aspice_40__iic-01-53, std_req__aspice_40__iic-01-54,
-              std_req__aspice_40__iic-02-01,
-              std_req__aspice_40__iic-03-06, std_req__aspice_40__iic-03-51, std_req__aspice_40__iic-03-53,
-              std_req__aspice_40__iic-04-02, std_req__aspice_40__iic-04-51,
-              std_req__aspice_40__iic-06-51,
-              std_req__aspice_40__iic-07-04, std_req__aspice_40__iic-07-05, std_req__aspice_40__iic-07-06, std_req__aspice_40__iic-07-08, std_req__aspice_40__iic-07-51, std_req__aspice_40__iic-07-61, std_req__aspice_40__iic-07-62, std_req__aspice_40__iic-07-63, std_req__aspice_40__iic-07-64,
-              std_req__aspice_40__iic-08-54, std_req__aspice_40__iic-08-61, std_req__aspice_40__iic-08-63, std_req__aspice_40__iic-08-64, std_req__aspice_40__iic-08-65, std_req__aspice_40__iic-08-66,
-              std_req__aspice_40__iic-11-50,
-              std_req__aspice_40__iic-13-06, std_req__aspice_40__iic-13-09, std_req__aspice_40__iic-13-13, std_req__aspice_40__iic-13-14, std_req__aspice_40__iic-13-18, std_req__aspice_40__iic-13-25, std_req__aspice_40__iic-13-50, std_req__aspice_40__iic-13-55,
-              std_req__aspice_40__iic-15-57, std_req__aspice_40__iic-15-58,
-              std_req__aspice_40__iic-16-00, std_req__aspice_40__iic-16-06, std_req__aspice_40__iic-16-50, std_req__aspice_40__iic-16-52,
-              std_req__aspice_40__iic-17-05, std_req__aspice_40__iic-17-55,
-              std_req__aspice_40__iic-18-00, std_req__aspice_40__iic-18-58, std_req__aspice_40__iic-18-59, std_req__aspice_40__iic-18-70, std_req__aspice_40__iic-18-80, std_req__aspice_40__iic-18-81,
-              std_req__aspice_40__iic-19-01, std_req__aspice_40__iic-19-50
+   :version: 1
+   :complies: std_req__aspice_40__iic-01-53[version==1],
+              std_req__aspice_40__iic-01-54[version==1],
+              std_req__aspice_40__iic-02-01[version==1],
+              std_req__aspice_40__iic-03-06[version==1],
+              std_req__aspice_40__iic-03-51[version==1],
+              std_req__aspice_40__iic-03-53[version==1],
+              std_req__aspice_40__iic-04-02[version==1],
+              std_req__aspice_40__iic-04-51[version==1],
+              std_req__aspice_40__iic-06-51[version==1],
+              std_req__aspice_40__iic-07-04[version==1],
+              std_req__aspice_40__iic-07-05[version==1],
+              std_req__aspice_40__iic-07-06[version==1],
+              std_req__aspice_40__iic-07-08[version==1],
+              std_req__aspice_40__iic-07-51[version==1],
+              std_req__aspice_40__iic-07-61[version==1],
+              std_req__aspice_40__iic-07-62[version==1],
+              std_req__aspice_40__iic-07-63[version==1],
+              std_req__aspice_40__iic-07-64[version==1],
+              std_req__aspice_40__iic-08-54[version==1],
+              std_req__aspice_40__iic-08-61[version==1],
+              std_req__aspice_40__iic-08-63[version==1],
+              std_req__aspice_40__iic-08-64[version==1],
+              std_req__aspice_40__iic-08-65[version==1],
+              std_req__aspice_40__iic-08-66[version==1],
+              std_req__aspice_40__iic-11-50[version==1],
+              std_req__aspice_40__iic-13-06[version==1],
+              std_req__aspice_40__iic-13-09[version==1],
+              std_req__aspice_40__iic-13-13[version==1],
+              std_req__aspice_40__iic-13-14[version==1],
+              std_req__aspice_40__iic-13-18[version==1],
+              std_req__aspice_40__iic-13-25[version==1],
+              std_req__aspice_40__iic-13-50[version==1],
+              std_req__aspice_40__iic-13-55[version==1],
+              std_req__aspice_40__iic-15-57[version==1],
+              std_req__aspice_40__iic-15-58[version==1],
+              std_req__aspice_40__iic-16-00[version==1],
+              std_req__aspice_40__iic-16-06[version==1],
+              std_req__aspice_40__iic-16-50[version==1],
+              std_req__aspice_40__iic-16-52[version==1],
+              std_req__aspice_40__iic-17-05[version==1],
+              std_req__aspice_40__iic-17-55[version==1],
+              std_req__aspice_40__iic-18-00[version==1],
+              std_req__aspice_40__iic-18-58[version==1],
+              std_req__aspice_40__iic-18-59[version==1],
+              std_req__aspice_40__iic-18-70[version==1],
+              std_req__aspice_40__iic-18-80[version==1],
+              std_req__aspice_40__iic-18-81[version==1],
+              std_req__aspice_40__iic-19-01[version==1],
+              std_req__aspice_40__iic-19-50[version==1]
 
    This part of the guideline links to all the information item characteristics (IIC) which are not fulfilled by the
    current process description. Make sure these are tailored out in the safety/security/quality plans

--- a/process/process_areas/process_management/guidance/process_management_reqs.rst
+++ b/process/process_areas/process_management/guidance/process_management_reqs.rst
@@ -22,9 +22,10 @@ Process Requirements
 .. gd_req:: Process Model Building Blocks
    :id: gd_req__process_management_build_blocks
    :status: valid
+   :version: 1
    :tags: done_automation, attribute, mandatory
-   :satisfies: wf__cr_mt_process_mgt_strategy, wf__def_app_process_description, wf__mon_imp_process_description
-   :complies: std_req__iso26262__management_5421, std_req__iso26262__management_5422, std_req__aspice_40__gp-311
+   :satisfies: wf__cr_mt_process_mgt_strategy[version==1], wf__def_app_process_description[version==1], wf__mon_imp_process_description[version==1]
+   :complies: std_req__iso26262__management_5421[version==1], std_req__iso26262__management_5422[version==1], std_req__aspice_40__gp-311[version==1]
 
    The process model building blocks are defined. Compare also the process model
    overview here: :ref:`processes_introduction`.
@@ -66,9 +67,10 @@ Process Building Blocks Attributes
 .. gd_req:: Building blocks attributes
    :id: gd_req__process_management_build_blocks_attr
    :status: valid
+   :version: 1
    :tags: manual_prio_1, attribute, mandatory
-   :satisfies: wf__cr_mt_process_mgt_strategy, wf__def_app_process_description, wf__mon_imp_process_description
-   :complies: std_req__iso26262__management_5421, std_req__iso26262__management_5422, std_req__aspice_40__gp-311
+   :satisfies: wf__cr_mt_process_mgt_strategy[version==1], wf__def_app_process_description[version==1], wf__mon_imp_process_description[version==1]
+   :complies: std_req__iso26262__management_5421[version==1], std_req__iso26262__management_5422[version==1], std_req__aspice_40__gp-311[version==1]
 
    Each building block shall have defined attributes as defined here:
    :ref:`process_management_templates`.
@@ -88,9 +90,10 @@ Process Building Blocks Linkage
 .. gd_req:: Building blocks linkage
    :id: gd_req__process_management_build_blocks_link
    :status: valid
+   :version: 1
    :tags: manual_prio_1, attribute, mandatory
-   :satisfies: wf__cr_mt_process_mgt_strategy, wf__def_app_process_description, wf__mon_imp_process_description
-   :complies: std_req__iso26262__management_5421, std_req__iso26262__management_5422, std_req__aspice_40__gp-311
+   :satisfies: wf__cr_mt_process_mgt_strategy[version==1], wf__def_app_process_description[version==1], wf__mon_imp_process_description[version==1]
+   :complies: std_req__iso26262__management_5421[version==1], std_req__iso26262__management_5422[version==1], std_req__aspice_40__gp-311[version==1]
 
    Each building block shall have defined links as defined here:
    :ref:`process_management_templates`.
@@ -102,9 +105,10 @@ Process Building Blocks Checks
 .. gd_req:: Building blocks check
    :id: gd_req__process_management_build_blocks_check
    :status: valid
+   :version: 1
    :tags: done_automation
-   :satisfies: wf__cr_mt_process_mgt_strategy, wf__def_app_process_description, wf__mon_imp_process_description
-   :complies: std_req__iso26262__management_5421, std_req__iso26262__management_5422, std_req__aspice_40__gp-311
+   :satisfies: wf__cr_mt_process_mgt_strategy[version==1], wf__def_app_process_description[version==1], wf__mon_imp_process_description[version==1]
+   :complies: std_req__iso26262__management_5421[version==1], std_req__iso26262__management_5422[version==1], std_req__aspice_40__gp-311[version==1]
 
    It shall be checked, that all attributes defined here
    :ref:`process_management_templates` are provided and correctly linked by the user.

--- a/process/process_areas/process_management/guidance/process_management_templates.rst
+++ b/process/process_areas/process_management/guidance/process_management_templates.rst
@@ -20,44 +20,62 @@ Templates
 .. gd_temp:: Workflow Template
    :id: gd_temp__process_workflow
    :status: valid
+   :version: 1
    :tags: process_management
-   :complies: std_req__iso26262__management_5421, std_req__iso26262__management_5422, std_req__aspice_40__gp-311, std_req__aspice_40__iic-10-00, std_req__aspice_40__iic-10-50, std_req__aspice_40__iic-14-53
+   :complies: std_req__iso26262__management_5421[version==1],
+              std_req__iso26262__management_5422[version==1],
+              std_req__aspice_40__gp-311[version==1],
+              std_req__aspice_40__iic-10-00[version==1],
+              std_req__aspice_40__iic-10-50[version==1],
+              std_req__aspice_40__iic-14-53[version==1]
 
    .. code-block:: rst
 
       .. workflow:: <Title reflecting activity>
          :id: wf__<process area or abbreviation>_<activity>
          :status: <draft|valid>
+         :version: 1
          :tags: <process area or abbreviation>
          :responsible: <defined role:rl__<...>>
          :approved_by: <defined role:rl__<...>>, ..., <defined role:rl__<...>>
          :supported_by: <defined role:rl__<...>>, ..., <defined role:rl__<...>>
          :input: <defined workproduct:wp__<...>>
          :output: <defined workproduct:wp__<...>>
-         :contains: <defined guidances: guideline:gd_guidl__<...>, template:gd_temp__<...>, checklist:gd_chklst__<...>, method:gd_meth__<...>
+         :contains: <defined guidances: guideline:gd_guidl__<...>,
+                    template:gd_temp__<...>,
+                    checklist:gd_chklst__<...>,
+                    method:gd_meth__<...>
          :has: <concept:doc_concept__<...>, getting started:doc_getstrt__<...>>
 
 
 .. gd_temp:: Work Product Template
    :id: gd_temp__process_workproduct
    :status: valid
+   :version: 1
    :tags: process_management
-   :complies: std_req__iso26262__management_5421, std_req__iso26262__management_5422, std_req__aspice_40__gp-311
+   :complies: std_req__iso26262__management_5421[version==1], std_req__iso26262__management_5422[version==1], std_req__aspice_40__gp-311[version==1]
 
    .. code-block:: rst
 
       .. workproduct:: <Title reflecting work product>
          :id: wp__<process area or abbreviation>_<work product>
          :status: <draft|valid>
+         :version: 1
          :tags: <process area or abbreviation>
-         :complies: <standard work product:std_wp__<...>>, ..., <standard work product:std_wp__<...>>, <standard requirement:std_req__aspice_40__iic-<...>>, ..., <std_req__aspice_40__iic-<...>>
+         :complies: <standard work product:std_wp__<...>>,
+                    ...,
+                    <standard work product:std_wp__<...>>,
+                    <standard requirement:std_req__aspice_40__iic-<...>>,
+                    ...,
+                    <std_req__aspice_40__iic-<...>>
 
 
 .. gd_temp:: Role Template
    :id: gd_temp__process_role
    :status: valid
+   :version: 1
    :tags: process_management
-   :complies: std_req__iso26262__management_5421, std_req__iso26262__management_5422, std_req__aspice_40__gp-311
+   :complies: std_req__iso26262__management_5421[version==1], std_req__iso26262__management_5422[version==1], std_req__aspice_40__gp-311[version==1]
 
    .. code-block:: rst
 
@@ -65,12 +83,14 @@ Templates
       .. role:: <Title reflecting role>
          :id: rl__<role>
          :status: <draft|valid>
+         :version: 1
          :tags: <process area or abbreviation>
 
       Team role
       .. role:: <Title reflecting team role>
          :id: rl__<process area or abbreviation>_<team role<>>
          :status: <draft|valid>
+         :version: 1
          :tags: <process area or abbreviation>
          :contains: <role:rl__<...>>, ..., <role:rl__<...>>
 
@@ -78,42 +98,48 @@ Templates
 .. gd_temp:: Getting Started Template
    :id: gd_temp__process_getstrt
    :status: valid
+   :version: 1
    :tags: process_management
-   :complies: std_req__iso26262__management_5421, std_req__iso26262__management_5422, std_req__aspice_40__gp-311
+   :complies: std_req__iso26262__management_5421[version==1], std_req__iso26262__management_5422[version==1], std_req__aspice_40__gp-311[version==1]
 
    .. code-block:: rst
 
       .. doc_getstrt:: <Title reflecting process area getting started>
          :id: doc_getstrt__<process area or abbreviation>
          :status: <draft|valid>
+         :version: 1
          :tags: <process area or abbreviation>
 
 
 .. gd_temp:: Concept Description Template
    :id: gd_temp__process_concept
    :status: valid
+   :version: 1
    :tags: process_management
-   :complies: std_req__iso26262__management_5421, std_req__iso26262__management_5422, std_req__aspice_40__gp-311
+   :complies: std_req__iso26262__management_5421[version==1], std_req__iso26262__management_5422[version==1], std_req__aspice_40__gp-311[version==1]
 
    .. code-block:: rst
 
       .. doc_concept:: <Title reflecting process area concept description>
          :id: doc_concept__<process area or abbreviation>
          :status: <draft|valid>
+         :version: 1
          :tags: <process area or abbreviation>
 
 
 .. gd_temp:: Guideline Template
    :id: gd_temp__process_guideline
    :status: valid
+   :version: 1
    :tags: process_management
-   :complies: std_req__iso26262__management_5421, std_req__iso26262__management_5422, std_req__aspice_40__gp-311
+   :complies: std_req__iso26262__management_5421[version==1], std_req__iso26262__management_5422[version==1], std_req__aspice_40__gp-311[version==1]
 
    .. code-block:: rst
 
       .. gd_guidl:: <Title reflecting process area guideline>
          :id: gd_guidl__<process area or abbreviation>_<...>
          :status: <draft|valid>
+         :version: 1
          :tags: <process area or abbreviation>
          :complies: <standard requirement:std_req__<...>>, ..., <standard requirement:std_req__<...>>
 
@@ -121,14 +147,16 @@ Templates
 .. gd_temp:: Template Template
    :id: gd_temp__process_template
    :status: valid
+   :version: 1
    :tags: process_management
-   :complies: std_req__iso26262__management_5421, std_req__iso26262__management_5422, std_req__aspice_40__gp-311
+   :complies: std_req__iso26262__management_5421[version==1], std_req__iso26262__management_5422[version==1], std_req__aspice_40__gp-311[version==1]
 
    .. code-block:: rst
 
       .. gd_temp:: <Title reflecting process area template>
          :id: gd_temp__<process area or abbreviation>_<...>
          :status: <draft|valid>
+         :version: 1
          :tags: <process area or abbreviation>
          :complies: <standard requirement:std_req__<...>>, ..., <standard requirement:std_req__<...>>
 
@@ -136,14 +164,16 @@ Templates
 .. gd_temp:: Checklist Template
    :id: gd_temp__process_checklist
    :status: valid
+   :version: 1
    :tags: process_management
-   :complies: std_req__iso26262__management_5421, std_req__iso26262__management_5422, std_req__aspice_40__gp-311
+   :complies: std_req__iso26262__management_5421[version==1], std_req__iso26262__management_5422[version==1], std_req__aspice_40__gp-311[version==1]
 
    .. code-block:: rst
 
       .. gd_chklst:: <Title reflecting process area checklist>
          :id: gd_chklst__<process area or abbreviation>_<...>
          :status: <draft|valid>
+         :version: 1
          :tags: <process area or abbreviation>
          :complies: <standard requirement:std_req__<...>>, ..., <standard requirement:std_req__<...>>
 
@@ -151,14 +181,16 @@ Templates
 .. gd_temp:: Method Template
    :id: gd_temp__process_method
    :status: valid
+   :version: 1
    :tags: process_management
-   :complies: std_req__iso26262__management_5421, std_req__iso26262__management_5422, std_req__aspice_40__gp-311
+   :complies: std_req__iso26262__management_5421[version==1], std_req__iso26262__management_5422[version==1], std_req__aspice_40__gp-311[version==1]
 
    .. code-block:: rst
 
       .. gd_method:: <Title reflecting process area method>
          :id: gd_meth__<process area or abbreviation>_<...>
          :status: <draft|valid>
+         :version: 1
          :tags: <process area or abbreviation>
          :complies: <standard requirement:std_req__<...>>, ..., <standard requirement:std_req__<...>>
 
@@ -166,14 +198,16 @@ Templates
 .. gd_temp:: Process Requirement Template
    :id: gd_temp__process_requirement
    :status: valid
+   :version: 1
    :tags: process_management
-   :complies: std_req__iso26262__management_5421, std_req__iso26262__management_5422, std_req__aspice_40__gp-311
+   :complies: std_req__iso26262__management_5421[version==1], std_req__iso26262__management_5422[version==1], std_req__aspice_40__gp-311[version==1]
 
    .. code-block:: rst
 
       .. gd_req:: <Title reflecting process area requirement>
          :id: gd_req__<process area or abbreviation>_<...>
          :status: <draft|valid>
+         :version: 1
          :tags: <process area or abbreviation>
          :satisfies: <defined workflow:wf__<...>>, ..., <defined workflow:wf__<...>>
          :complies: <standard requirement:std_req__<...>>, ..., <standard requirement:std_req__<...>>
@@ -182,42 +216,58 @@ Templates
 .. gd_temp:: Standard Requirement Template
    :id: gd_temp__process_standard_req
    :status: valid
+   :version: 1
    :tags: process_management
-   :complies: std_req__iso26262__management_5421, std_req__iso26262__management_5422, std_req__aspice_40__gp-311
+   :complies: std_req__iso26262__management_5421[version==1], std_req__iso26262__management_5422[version==1], std_req__aspice_40__gp-311[version==1]
 
    .. code-block:: rst
 
       .. std_req:: <Title reflecting standard requirement>
          :id: std_req__<standard>__<...>
          :status: <draft|valid>
+         :version: 1
          :tags: <standard>
 
 
 .. gd_temp:: Standard Work Product Template
    :id: gd_temp__process_standard_wp
    :status: valid
+   :version: 1
    :tags: process_management
-   :complies: std_req__iso26262__management_5421, std_req__iso26262__management_5422, std_req__aspice_40__gp-311, std_req__aspice_40__gp-221, std_req__aspice_40__gp-222, std_req__aspice_40__gp-223
+   :complies: std_req__iso26262__management_5421[version==1],
+              std_req__iso26262__management_5422[version==1],
+              std_req__aspice_40__gp-311[version==1],
+              std_req__aspice_40__gp-221[version==1],
+              std_req__aspice_40__gp-222[version==1],
+              std_req__aspice_40__gp-223[version==1]
 
    .. code-block:: rst
 
       .. std_wp:: <Title reflecting standard work product>
          :id: std_wp__<standard>__<...>
          :status: <draft|valid>
+         :version: 1
          :tags: <standard>
 
 
 .. gd_temp:: Document Template
    :id: gd_temp__process_document
    :status: valid
+   :version: 1
    :tags: process_management
-   :complies: std_req__iso26262__management_5421, std_req__iso26262__management_5422, std_req__aspice_40__gp-311, std_req__aspice_40__gp-221, std_req__aspice_40__gp-222, std_req__aspice_40__gp-223
+   :complies: std_req__iso26262__management_5421[version==1],
+              std_req__iso26262__management_5422[version==1],
+              std_req__aspice_40__gp-311[version==1],
+              std_req__aspice_40__gp-221[version==1],
+              std_req__aspice_40__gp-222[version==1],
+              std_req__aspice_40__gp-223[version==1]
 
    .. code-block:: rst
 
       .. document:: <Title reflecting the deployed work product>
          :id: doc__<work product>
          :status: <draft|valid>
+         :version: 1
          :safety: <QM | ASIL_B>
          :security: <YES|NO>
          :realizes: wp__<work product reference>, ..., wp__<work product reference>

--- a/process/process_areas/process_management/process_management_concept.rst
+++ b/process/process_areas/process_management/process_management_concept.rst
@@ -18,6 +18,7 @@ Concept Description
 .. doc_concept:: Concept Description
    :id: doc_concept__process_management
    :status: valid
+   :version: 1
    :tags: process_management
 
 In this section concepts for the Process Management are discussed. Inputs for these

--- a/process/process_areas/process_management/process_management_getstrt.rst
+++ b/process/process_areas/process_management/process_management_getstrt.rst
@@ -18,6 +18,7 @@ Getting Started
 .. doc_getstrt:: Getting Started on Process Management
    :id: doc_getstrt__process_management
    :status: valid
+   :version: 1
    :tags: process_management
 
 This document describes the steps to create and maintain the process strategy and the

--- a/process/process_areas/process_management/process_management_workflow.rst
+++ b/process/process_areas/process_management/process_management_workflow.rst
@@ -22,13 +22,14 @@ For a detailed explanation of workflows and their role within the process model,
 .. workflow:: Create/Maintain Process Management Strategy
    :id: wf__cr_mt_process_mgt_strategy
    :status: valid
-   :responsible: rl__contributor
-   :approved_by: rl__process_community
-   :supported_by: rl__safety_external_auditor, rl__security_external_auditor, rl__project_lead
-   :input: wp__policies, wp__issue_track_system
-   :output: wp__process_strategy, wp__policies
-   :contains: gd_guidl__process_management, gd_temp__process_workflow
-   :has: doc_concept__process_management, doc_getstrt__process_management
+   :version: 1
+   :responsible: rl__contributor[version==1]
+   :approved_by: rl__process_community[version==1]
+   :supported_by: rl__safety_external_auditor[version==1], rl__security_external_auditor[version==1], rl__project_lead[version==1]
+   :input: wp__policies[version==1], wp__issue_track_system[version==1]
+   :output: wp__process_strategy[version==1], wp__policies[version==1]
+   :contains: gd_guidl__process_management[version==1], gd_temp__process_workflow[version==1]
+   :has: doc_concept__process_management[version==1], doc_getstrt__process_management[version==1]
 
    The process management strategy is created and maintained. Policies are
    reviewed and updated, if required.
@@ -36,26 +37,28 @@ For a detailed explanation of workflows and their role within the process model,
 .. workflow:: Define/Approve Process Description
    :id: wf__def_app_process_description
    :status: valid
-   :responsible: rl__contributor
-   :approved_by: rl__process_community
-   :supported_by: rl__safety_external_auditor, rl__security_external_auditor, rl__project_lead
-   :input: wp__process_strategy, wp__issue_track_system
-   :output: wp__process_description, wp__tailoring_work_products
-   :contains: gd_guidl__process_management, gd_temp__process_workflow
-   :has: doc_concept__process_management, doc_getstrt__process_management
+   :version: 1
+   :responsible: rl__contributor[version==1]
+   :approved_by: rl__process_community[version==1]
+   :supported_by: rl__safety_external_auditor[version==1], rl__security_external_auditor[version==1], rl__project_lead[version==1]
+   :input: wp__process_strategy[version==1], wp__issue_track_system[version==1]
+   :output: wp__process_description[version==1], wp__tailoring_work_products[version==1]
+   :contains: gd_guidl__process_management[version==1], gd_temp__process_workflow[version==1]
+   :has: doc_concept__process_management[version==1], doc_getstrt__process_management[version==1]
 
    The process description is defined and approved.
 
 .. workflow:: Monitor/Improve Process Implementation
    :id: wf__mon_imp_process_description
    :status: valid
-   :responsible: rl__contributor
-   :approved_by: rl__process_community
-   :supported_by: rl__safety_external_auditor, rl__security_external_auditor, rl__project_lead
-   :input: wp__process_description
-   :output: wp__process_impr_report, wp__issue_track_system
-   :contains: gd_guidl__process_management, gd_temp__process_workflow
-   :has: doc_concept__process_management, doc_getstrt__process_management
+   :version: 1
+   :responsible: rl__contributor[version==1]
+   :approved_by: rl__process_community[version==1]
+   :supported_by: rl__safety_external_auditor[version==1], rl__security_external_auditor[version==1], rl__project_lead[version==1]
+   :input: wp__process_description[version==1]
+   :output: wp__process_impr_report[version==1], wp__issue_track_system[version==1]
+   :contains: gd_guidl__process_management[version==1], gd_temp__process_workflow[version==1]
+   :has: doc_concept__process_management[version==1], doc_getstrt__process_management[version==1]
 
    The process strategy and description implementation is monitored and improvements are
    triggered, if required.

--- a/process/process_areas/process_management/process_management_workproducts.rst
+++ b/process/process_areas/process_management/process_management_workproducts.rst
@@ -20,8 +20,9 @@ Here only project specific work products are listed, which are generic for the p
 .. workproduct:: Policies
    :id: wp__policies
    :status: valid
+   :version: 1
    :tags: doc_lifecycle_model_2
-   :complies: std_wp__iso26262__management_551
+   :complies: std_wp__iso26262__management_551[version==1]
 
    In general the project follows the Eclipse Foundation Development Process (EDP,
    `Eclipse Foundation Development Process <https://www.eclipse.org/projects/dev_process/>`_).
@@ -47,8 +48,14 @@ Here only project specific work products are listed, which are generic for the p
 .. workproduct:: Process Management Strategy
    :id: wp__process_strategy
    :status: valid
+   :version: 1
    :tags: doc_lifecycle_model_2
-   :complies: std_wp__iso26262__management_551, std_wp__isosae21434__org_management_551, std_wp__isosae21434__org_management_552, std_wp__isosae21434__org_management_553, std_wp__isosae21434__org_management_554, std_wp__isosae21434__org_management_555
+   :complies: std_wp__iso26262__management_551[version==1],
+              std_wp__isosae21434__org_management_551[version==1],
+              std_wp__isosae21434__org_management_552[version==1],
+              std_wp__isosae21434__org_management_553[version==1],
+              std_wp__isosae21434__org_management_554[version==1],
+              std_wp__isosae21434__org_management_555[version==1]
 
    Strategy to manage and guide execution of the process management activities.
 
@@ -62,8 +69,19 @@ Here only project specific work products are listed, which are generic for the p
 .. workproduct:: Process Description
    :id: wp__process_description
    :status: valid
+   :version: 1
    :tags: doc_lifecycle_model_2
-   :complies: std_wp__iso26262__management_551, std_wp__isosae21434__org_management_551, std_wp__isosae21434__org_management_552, std_wp__isosae21434__org_management_553, std_wp__isosae21434__org_management_554, std_wp__isosae21434__org_management_555, std_req__aspice_40__iic-10-00, std_req__aspice_40__iic-10-50, std_req__aspice_40__iic-06-51, std_req__aspice_40__iic-15-54, std_req__aspice_40__iic-14-53
+   :complies: std_wp__iso26262__management_551[version==1],
+              std_wp__isosae21434__org_management_551[version==1],
+              std_wp__isosae21434__org_management_552[version==1],
+              std_wp__isosae21434__org_management_553[version==1],
+              std_wp__isosae21434__org_management_554[version==1],
+              std_wp__isosae21434__org_management_555[version==1],
+              std_req__aspice_40__iic-10-00[version==1],
+              std_req__aspice_40__iic-10-50[version==1],
+              std_req__aspice_40__iic-06-51[version==1],
+              std_req__aspice_40__iic-15-54[version==1],
+              std_req__aspice_40__iic-14-53[version==1]
 
    The process description is defined here: :ref:`process_description`.
 
@@ -72,8 +90,44 @@ Here only project specific work products are listed, which are generic for the p
 .. workproduct:: Tailoring Document Work Products
    :id: wp__tailoring_work_products
    :status: valid
+   :version: 1
    :tags: doc_lifecycle_model_2
-   :complies: std_wp__iso26262__management_651, std_wp__iso26262__management_751, std_wp__iso26262__system_652, std_wp__iso26262__system_653, std_wp__iso26262__system_654, std_wp__iso26262__system_655, std_wp__iso26262__system_656, std_wp__iso26262__system_657, std_wp__iso26262__system_751, std_wp__iso26262__system_752, std_wp__iso26262__system_851, std_wp__iso26262__system_852, std_wp__iso26262__software_652, std_wp__iso26262__software_1052, std_wp__iso26262__software_1151, std_wp__iso26262__software_1152, std_wp__iso26262__software_app_c_52, std_wp__iso26262__software_app_c_54, std_wp__iso26262__software_app_c_57, std_wp__iso26262__support_551, std_wp__iso26262__support_552, std_wp__iso26262__support_553, std_wp__iso26262__support_554, std_wp__iso26262__support_555, std_wp__iso26262__support_1351, std_wp__iso26262__support_1352, std_wp__iso26262__support_1353, std_wp__iso26262__support_1451, std_wp__iso26262__support_1452, std_wp__iso26262__support_1551, std_wp__iso26262__support_1651, std_wp__iso26262__analysis_551, std_wp__iso26262__analysis_552, std_wp__isopas8926__4522, std_wp__isosae21434__assessment_15331, std_wp__isosae21434__assessment_15531
+   :complies: std_wp__iso26262__management_651[version==1],
+              std_wp__iso26262__management_751[version==1],
+              std_wp__iso26262__system_652[version==1],
+              std_wp__iso26262__system_653[version==1],
+              std_wp__iso26262__system_654[version==1],
+              std_wp__iso26262__system_655[version==1],
+              std_wp__iso26262__system_656[version==1],
+              std_wp__iso26262__system_657[version==1],
+              std_wp__iso26262__system_751[version==1],
+              std_wp__iso26262__system_752[version==1],
+              std_wp__iso26262__system_851[version==1],
+              std_wp__iso26262__system_852[version==1],
+              std_wp__iso26262__software_652[version==1],
+              std_wp__iso26262__software_1052[version==1],
+              std_wp__iso26262__software_1151[version==1],
+              std_wp__iso26262__software_1152[version==1],
+              std_wp__iso26262__software_app_c_52[version==1],
+              std_wp__iso26262__software_app_c_54[version==1],
+              std_wp__iso26262__software_app_c_57[version==1],
+              std_wp__iso26262__support_551[version==1],
+              std_wp__iso26262__support_552[version==1],
+              std_wp__iso26262__support_553[version==1],
+              std_wp__iso26262__support_554[version==1],
+              std_wp__iso26262__support_555[version==1],
+              std_wp__iso26262__support_1351[version==1],
+              std_wp__iso26262__support_1352[version==1],
+              std_wp__iso26262__support_1353[version==1],
+              std_wp__iso26262__support_1451[version==1],
+              std_wp__iso26262__support_1452[version==1],
+              std_wp__iso26262__support_1551[version==1],
+              std_wp__iso26262__support_1651[version==1],
+              std_wp__iso26262__analysis_551[version==1],
+              std_wp__iso26262__analysis_552[version==1],
+              std_wp__isopas8926__4522[version==1],
+              std_wp__isosae21434__assessment_15331[version==1],
+              std_wp__isosae21434__assessment_15531[version==1]
 
    This work product "definition" links to all the work products which are not covered by the
    processes work products documented. Make sure these are tailored out in the safety, security and quality plans

--- a/process/process_areas/quality_management/guidance/quality_plan_guideline.rst
+++ b/process/process_areas/quality_management/guidance/quality_plan_guideline.rst
@@ -20,7 +20,30 @@ Guideline Quality Management Plan
 .. gd_guidl:: Quality Management Plan Definitions Guideline
    :id: gd_guidl__qlm_plan_definitions
    :status: valid
-   :complies: std_req__iso26262__management_5423, std_req__aspice_40__SUP-1-BP1, std_req__aspice_40__SUP-1-BP2, std_req__aspice_40__SUP-1-BP3, std_req__aspice_40__SUP-1-BP4, std_req__aspice_40__SUP-1-BP7, std_req__aspice_40__PIM-3-BP1, std_req__aspice_40__PIM-3-BP2, std_req__aspice_40__PIM-3-BP3, std_req__aspice_40__PIM-3-BP4, std_req__aspice_40__PIM-3-BP5, std_req__aspice_40__PIM-3-BP6, std_req__aspice_40__PIM-3-BP7, std_req__aspice_40__SUP-1-BP5, std_req__aspice_40__SUP-1-BP6, std_req__aspice_40__PIM-3-BP8, std_req__iso26262__management_5451, std_req__aspice_40__iic-06-04, std_req__aspice_40__iic-10-51, std_req__aspice_40__iic-15-13, std_req__aspice_40__iic-15-16, std_req__aspice_40__iic-18-07, std_req__aspice_40__iic-18-52
+   :version: 1
+   :complies: std_req__iso26262__management_5423[version==1],
+              std_req__aspice_40__SUP-1-BP1[version==1],
+              std_req__aspice_40__SUP-1-BP2[version==1],
+              std_req__aspice_40__SUP-1-BP3[version==1],
+              std_req__aspice_40__SUP-1-BP4[version==1],
+              std_req__aspice_40__SUP-1-BP7[version==1],
+              std_req__aspice_40__PIM-3-BP1[version==1],
+              std_req__aspice_40__PIM-3-BP2[version==1],
+              std_req__aspice_40__PIM-3-BP3[version==1],
+              std_req__aspice_40__PIM-3-BP4[version==1],
+              std_req__aspice_40__PIM-3-BP5[version==1],
+              std_req__aspice_40__PIM-3-BP6[version==1],
+              std_req__aspice_40__PIM-3-BP7[version==1],
+              std_req__aspice_40__SUP-1-BP5[version==1],
+              std_req__aspice_40__SUP-1-BP6[version==1],
+              std_req__aspice_40__PIM-3-BP8[version==1],
+              std_req__iso26262__management_5451[version==1],
+              std_req__aspice_40__iic-06-04[version==1],
+              std_req__aspice_40__iic-10-51[version==1],
+              std_req__aspice_40__iic-15-13[version==1],
+              std_req__aspice_40__iic-15-16[version==1],
+              std_req__aspice_40__iic-18-07[version==1],
+              std_req__aspice_40__iic-18-52[version==1]
 
    | **Overall quality management:**
    |

--- a/process/process_areas/quality_management/guidance/quality_plan_template.rst
+++ b/process/process_areas/quality_management/guidance/quality_plan_template.rst
@@ -20,7 +20,21 @@ Template Quality Plan
 .. gd_temp:: Quality Management Plan Template
    :id: gd_temp__qlm_plan
    :status: valid
-   :complies: std_req__iso26262__management_5423, std_req__aspice_40__SUP-1-BP1, std_req__aspice_40__SUP-1-BP2, std_req__aspice_40__SUP-1-BP3, std_req__aspice_40__SUP-1-BP4, std_req__aspice_40__SUP-1-BP7, std_req__aspice_40__PIM-3-BP1, std_req__aspice_40__PIM-3-BP2, std_req__aspice_40__PIM-3-BP3, std_req__aspice_40__PIM-3-BP4, std_req__aspice_40__PIM-3-BP5, std_req__aspice_40__PIM-3-BP6, std_req__aspice_40__PIM-3-BP7, std_req__iso26262__management_5451
+   :version: 1
+   :complies: std_req__iso26262__management_5423[version==1],
+              std_req__aspice_40__SUP-1-BP1[version==1],
+              std_req__aspice_40__SUP-1-BP2[version==1],
+              std_req__aspice_40__SUP-1-BP3[version==1],
+              std_req__aspice_40__SUP-1-BP4[version==1],
+              std_req__aspice_40__SUP-1-BP7[version==1],
+              std_req__aspice_40__PIM-3-BP1[version==1],
+              std_req__aspice_40__PIM-3-BP2[version==1],
+              std_req__aspice_40__PIM-3-BP3[version==1],
+              std_req__aspice_40__PIM-3-BP4[version==1],
+              std_req__aspice_40__PIM-3-BP5[version==1],
+              std_req__aspice_40__PIM-3-BP6[version==1],
+              std_req__aspice_40__PIM-3-BP7[version==1],
+              std_req__iso26262__management_5451[version==1]
 
 :note: The quality management plan shall be continuously maintained during the project.
        Deviations to the platform plan should be documented here.

--- a/process/process_areas/quality_management/guidance/quality_process_reqs.rst
+++ b/process/process_areas/quality_management/guidance/quality_process_reqs.rst
@@ -18,9 +18,10 @@ Process Requirements
 .. gd_req:: Quality report automated generation
    :id: gd_req__quality_report
    :status: valid
+   :version: 1
    :tags: prio_3_automation, quality_management
-   :satisfies: wf__mr_imp_qlm_plan_processes
-   :complies: std_req__iso26262__management_5423, std_req__aspice_40__SUP-1-BP5, std_req__aspice_40__SUP-1-BP6
+   :satisfies: wf__mr_imp_qlm_plan_processes[version==1]
+   :complies: std_req__iso26262__management_5423[version==1], std_req__aspice_40__SUP-1-BP5[version==1], std_req__aspice_40__SUP-1-BP6[version==1]
 
    | The quality report shall be generated progressively and automatically compiling the work products.
    | A template exists to guide the reporting and the right collection of the required work products.

--- a/process/process_areas/quality_management/guidance/quality_report_template.rst
+++ b/process/process_areas/quality_management/guidance/quality_report_template.rst
@@ -20,7 +20,20 @@ Template Quality Report
 .. gd_temp:: Quality Report Template
    :id: gd_temp__qlm_report
    :status: valid
-   :complies: std_req__iso26262__management_5423, std_req__aspice_40__SUP-1-BP1, std_req__aspice_40__SUP-1-BP2, std_req__aspice_40__SUP-1-BP3, std_req__aspice_40__SUP-1-BP4, std_req__aspice_40__SUP-1-BP7, std_req__aspice_40__PIM-3-BP1, std_req__aspice_40__PIM-3-BP2, std_req__aspice_40__PIM-3-BP3, std_req__aspice_40__PIM-3-BP4, std_req__aspice_40__PIM-3-BP5, std_req__aspice_40__PIM-3-BP6, std_req__aspice_40__PIM-3-BP7
+   :version: 1
+   :complies: std_req__iso26262__management_5423[version==1],
+              std_req__aspice_40__SUP-1-BP1[version==1],
+              std_req__aspice_40__SUP-1-BP2[version==1],
+              std_req__aspice_40__SUP-1-BP3[version==1],
+              std_req__aspice_40__SUP-1-BP4[version==1],
+              std_req__aspice_40__SUP-1-BP7[version==1],
+              std_req__aspice_40__PIM-3-BP1[version==1],
+              std_req__aspice_40__PIM-3-BP2[version==1],
+              std_req__aspice_40__PIM-3-BP3[version==1],
+              std_req__aspice_40__PIM-3-BP4[version==1],
+              std_req__aspice_40__PIM-3-BP5[version==1],
+              std_req__aspice_40__PIM-3-BP6[version==1],
+              std_req__aspice_40__PIM-3-BP7[version==1]
 
    This document implements :need:`wp__qms_report` and based on the :need:`wp__qms_plan`. It summarizes
    the results of the quality related activities. It shall be referred in the :need:`wp__platform_sw_release_note`

--- a/process/process_areas/quality_management/guidance/quality_review_checklist.rst
+++ b/process/process_areas/quality_management/guidance/quality_review_checklist.rst
@@ -20,7 +20,8 @@ Checklist Quality Work Product Review
 .. gd_chklst:: Quality Work Product Review Checklist
    :id: gd_chklst__review_checklist
    :status: valid
-   :complies: std_req__aspice_40__iic-13-19
+   :version: 1
+   :complies: std_req__aspice_40__iic-13-19[version==1]
    :tags: quality_management
 
 

--- a/process/process_areas/quality_management/guidance/quality_work_product_review_guideline.rst
+++ b/process/process_areas/quality_management/guidance/quality_work_product_review_guideline.rst
@@ -19,6 +19,7 @@ Quality Work Product Review Guideline
 .. gd_guidl:: Quality work product review
    :id: gd_guidl__wp_review
    :status: valid
+   :version: 1
 
 Purpose
 -------

--- a/process/process_areas/quality_management/quality_concept.rst
+++ b/process/process_areas/quality_management/quality_concept.rst
@@ -18,6 +18,7 @@ Concept
 .. doc_concept:: Quality Management Concept
    :id: doc_concept__quality_process
    :status: valid
+   :version: 1
    :tags: quality_management
 
 In this section a concept for the Quality Management will be discussed. Inputs for this concepts is ASPICE SUP.1

--- a/process/process_areas/quality_management/quality_getstrt.rst
+++ b/process/process_areas/quality_management/quality_getstrt.rst
@@ -18,6 +18,7 @@ Getting started
 .. doc_getstrt:: Getting Started on Quality Management
    :id: doc_getstrt__quality_process
    :status: valid
+   :version: 1
    :tags: quality_management
 
 This document describes the steps which need to be done to ensure Quality according to ASPICE 4.0 as used

--- a/process/process_areas/quality_management/quality_roles.rst
+++ b/process/process_areas/quality_management/quality_roles.rst
@@ -18,6 +18,7 @@ Roles
 .. role:: Quality Manager
    :id: rl__quality_manager
    :status: valid
+   :version: 1
 
    The quality managers shall be responsible for the planning and coordination of the quality activities, i.e. the quality management. They shall lead and monitor the quality relevant activities of the project.
 

--- a/process/process_areas/quality_management/quality_workflow.rst
+++ b/process/process_areas/quality_management/quality_workflow.rst
@@ -23,39 +23,42 @@ For a detailed explanation of workflows and their role within the process model,
 .. workflow:: Create/Maintain Quality Management Plan
    :id: wf__cr_mt_qlm_plan
    :status: valid
-   :responsible: rl__quality_manager
-   :approved_by: rl__project_lead
+   :version: 1
+   :responsible: rl__quality_manager[version==1]
+   :approved_by: rl__project_lead[version==1]
    :supported_by:
-   :input: wp__policies, wp__issue_track_system, wp__platform_mgmt
-   :output: wp__qms_plan
-   :contains: gd_guidl__qlm_plan_definitions, gd_temp__qlm_plan
-   :has: doc_concept__quality_process, doc_getstrt__quality_process
+   :input: wp__policies[version==1], wp__issue_track_system[version==1], wp__platform_mgmt[version==1]
+   :output: wp__qms_plan[version==1]
+   :contains: gd_guidl__qlm_plan_definitions[version==1], gd_temp__qlm_plan[version==1]
+   :has: doc_concept__quality_process[version==1], doc_getstrt__quality_process[version==1]
 
    | The Quality Management Plan is created and maintained by the :need:`rl__quality_manager`.
 
 .. workflow:: Execute Platform Process Audit
    :id: wf__exe_pltprocess_audit
    :status: valid
-   :responsible: rl__quality_manager
-   :approved_by: rl__project_lead
-   :supported_by: rl__safety_manager, rl__security_manager
-   :input: wp__qms_plan, wp__process_description
-   :output: wp__process_impr_report
-   :contains: gd_guidl__qlm_plan_definitions, gd_chklst__review_checklist
-   :has: doc_concept__quality_process, doc_getstrt__quality_process
+   :version: 1
+   :responsible: rl__quality_manager[version==1]
+   :approved_by: rl__project_lead[version==1]
+   :supported_by: rl__safety_manager[version==1], rl__security_manager[version==1]
+   :input: wp__qms_plan[version==1], wp__process_description[version==1]
+   :output: wp__process_impr_report[version==1]
+   :contains: gd_guidl__qlm_plan_definitions[version==1], gd_chklst__review_checklist[version==1]
+   :has: doc_concept__quality_process[version==1], doc_getstrt__quality_process[version==1]
 
    | The project/platform processes are audited.
 
 .. workflow:: Execute Feature Contribution Conformance Checks
    :id: wf__exe_featprocess_conformance_checks
    :status: valid
-   :responsible: rl__quality_manager
-   :approved_by: rl__project_lead
-   :supported_by: rl__safety_manager, rl__security_manager
-   :input: wp__qms_plan, wp__feat_request, wp__process_description
-   :output: wp__qms_report
-   :contains: gd_guidl__qlm_plan_definitions, gd_chklst__review_checklist
-   :has: doc_concept__quality_process, doc_getstrt__quality_process
+   :version: 1
+   :responsible: rl__quality_manager[version==1]
+   :approved_by: rl__project_lead[version==1]
+   :supported_by: rl__safety_manager[version==1], rl__security_manager[version==1]
+   :input: wp__qms_plan[version==1], wp__feat_request[version==1], wp__process_description[version==1]
+   :output: wp__qms_report[version==1]
+   :contains: gd_guidl__qlm_plan_definitions[version==1], gd_chklst__review_checklist[version==1]
+   :has: doc_concept__quality_process[version==1], doc_getstrt__quality_process[version==1]
 
    | The conformance of the feature contribution is checked. The conformance check consists of
    | * No open issues that are related to quality that are relevant for the feature contribution
@@ -66,39 +69,49 @@ For a detailed explanation of workflows and their role within the process model,
 .. workflow:: Execute Work Product Reviews
    :id: wf__exe_wp_review
    :status: valid
-   :responsible: rl__quality_manager
-   :approved_by: rl__project_lead
-   :supported_by: rl__committer
-   :input: wp__qms_plan, wp__process_description
-   :output: wp__verification_platform_ver_report
-   :contains: gd_guidl__qlm_plan_definitions, gd_chklst__review_checklist, gd_guidl__wp_review
-   :has: doc_concept__quality_process, doc_getstrt__quality_process
+   :version: 1
+   :responsible: rl__quality_manager[version==1]
+   :approved_by: rl__project_lead[version==1]
+   :supported_by: rl__committer[version==1]
+   :input: wp__qms_plan[version==1], wp__process_description[version==1]
+   :output: wp__verification_platform_ver_report[version==1]
+   :contains: gd_guidl__qlm_plan_definitions[version==1], gd_chklst__review_checklist[version==1], gd_guidl__wp_review[version==1]
+   :has: doc_concept__quality_process[version==1], doc_getstrt__quality_process[version==1]
 
    | The quality of the work products is assured.
 
 .. workflow:: Consult and Execute Quality Trainings
    :id: wf__consult_exe_qly_training
    :status: valid
-   :responsible: rl__quality_manager
-   :approved_by: rl__project_lead
-   :supported_by: rl__safety_manager, rl__security_manager
-   :input: wp__qms_plan, wp__policies, wp__process_description
-   :output: wp__training_path
-   :contains: gd_guidl__qlm_plan_definitions
-   :has: doc_concept__quality_process, doc_getstrt__quality_process
+   :version: 1
+   :responsible: rl__quality_manager[version==1]
+   :approved_by: rl__project_lead[version==1]
+   :supported_by: rl__safety_manager[version==1], rl__security_manager[version==1]
+   :input: wp__qms_plan[version==1], wp__policies[version==1], wp__process_description[version==1]
+   :output: wp__training_path[version==1]
+   :contains: gd_guidl__qlm_plan_definitions[version==1]
+   :has: doc_concept__quality_process[version==1], doc_getstrt__quality_process[version==1]
 
    | The :need:`rl__quality_manager` consults all project/platform stakeholder as defined in :need:`doc_concept__quality_process` for quality topics and executes regularly quality trainings.
 
 .. workflow:: Monitor/Improve Quality Activities
    :id: wf__mr_imp_qlm_plan_processes
    :status: valid
-   :responsible: rl__quality_manager
-   :approved_by: rl__project_lead
-   :supported_by: rl__safety_manager, rl__security_manager
-   :input: wp__qms_plan, wp__platform_sw_release_note, wp__module_sw_release_note, wp__process_impr_report, wp__qms_report, wp__verification_platform_ver_report, wp__verification_module_ver_report, wp__training_path
-   :output: wp__issue_track_system
-   :contains: gd_guidl__qlm_plan_definitions, gd_chklst__review_checklist, gd_req__quality_report
-   :has: doc_concept__quality_process, doc_getstrt__quality_process
+   :version: 1
+   :responsible: rl__quality_manager[version==1]
+   :approved_by: rl__project_lead[version==1]
+   :supported_by: rl__safety_manager[version==1], rl__security_manager[version==1]
+   :input: wp__qms_plan[version==1],
+           wp__platform_sw_release_note[version==1],
+           wp__module_sw_release_note[version==1],
+           wp__process_impr_report[version==1],
+           wp__qms_report[version==1],
+           wp__verification_platform_ver_report[version==1],
+           wp__verification_module_ver_report[version==1],
+           wp__training_path[version==1]
+   :output: wp__issue_track_system[version==1]
+   :contains: gd_guidl__qlm_plan_definitions[version==1], gd_chklst__review_checklist[version==1], gd_req__quality_report[version==1]
+   :has: doc_concept__quality_process[version==1], doc_getstrt__quality_process[version==1]
 
    | The :need:`rl__quality_manager` is responsible for the monitoring of the activities against the quality management plan.
    | The :need:`rl__quality_manager` is responsible to adjust the quality management plan, if deviations are detected.

--- a/process/process_areas/quality_management/quality_workproducts.rst
+++ b/process/process_areas/quality_management/quality_workproducts.rst
@@ -18,8 +18,9 @@ Quality Management Work Products
 .. workproduct:: Quality Management Plan
    :id: wp__qms_plan
    :status: valid
+   :version: 1
    :tags: doc_lifecycle_model_2
-   :complies: std_wp__iso26262__management_553, std_req__aspice_40__iic-18-07, std_req__aspice_40__iic-18-52
+   :complies: std_wp__iso26262__management_553[version==1], std_req__aspice_40__iic-18-07[version==1], std_req__aspice_40__iic-18-52[version==1]
 
    | Quality Management Plan to define the quality aspects like:
    | * Quality strategy
@@ -33,16 +34,18 @@ Quality Management Work Products
 .. workproduct:: Quality report
    :id: wp__qms_report
    :status: valid
+   :version: 1
    :tags: doc_lifecycle_model_2
-   :complies: std_req__aspice_40__iic-13-19
+   :complies: std_req__aspice_40__iic-13-19[version==1]
 
    | The quality report summarizes the results of the quality related activities
 
 .. workproduct:: Process Improvement Report
    :id: wp__process_impr_report
    :status: valid
+   :version: 1
    :tags: doc_lifecycle_model_2
-   :complies: std_req__aspice_40__iic-07-04, std_req__aspice_40__iic-15-13
+   :complies: std_req__aspice_40__iic-07-04[version==1], std_req__aspice_40__iic-15-13[version==1]
 
    | Process Improvement Report that describes the improvement with description of:
    | * Description of used methods, assumptions, involved persons, etc.
@@ -56,7 +59,8 @@ Quality Management Work Products
 .. workproduct:: Training path
    :id: wp__training_path
    :status: valid
+   :version: 1
    :tags: doc_lifecycle_model_2
-   :complies: std_wp__iso26262__management_552, std_req__aspice_40__iic-06-04, std_req__aspice_40__iic-10-51
+   :complies: std_wp__iso26262__management_552[version==1], std_req__aspice_40__iic-06-04[version==1], std_req__aspice_40__iic-10-51[version==1]
 
    | Trainings shall give dedicated information how to apply the processes and work products in the project.

--- a/process/process_areas/release_management/guidance/release_guideline.rst
+++ b/process/process_areas/release_management/guidance/release_guideline.rst
@@ -18,7 +18,16 @@ Guideline
 .. gd_guidl:: Release Management Guideline
    :id: gd_guidl__rel_management
    :status: valid
-   :complies: std_req__iso26262__software_1041, std_req__iso26262__management_6424, std_req__iso26262__management_64102, std_req__iso26262__management_64131, std_req__iso26262__management_64132, std_req__iso26262__management_64133, std_req__iso26262__management_64134, std_req__iso26262__management_64135, std_req__aspice_40__SPL-2-BP7
+   :version: 1
+   :complies: std_req__iso26262__software_1041[version==1],
+              std_req__iso26262__management_6424[version==1],
+              std_req__iso26262__management_64102[version==1],
+              std_req__iso26262__management_64131[version==1],
+              std_req__iso26262__management_64132[version==1],
+              std_req__iso26262__management_64133[version==1],
+              std_req__iso26262__management_64134[version==1],
+              std_req__iso26262__management_64135[version==1],
+              std_req__aspice_40__SPL-2-BP7[version==1]
 
 .. _workflow_release:
 
@@ -116,7 +125,8 @@ Release Handbook
 .. gd_guidl:: Release Handbook
    :id: gd_guidl__rel_handbook
    :status: valid
-   :complies: std_req__iso26262__software_1041
+   :version: 1
+   :complies: std_req__iso26262__software_1041[version==1]
 
    The release handbook incorporates an overview including a tutorial to explain the usage of the released software.
    It extends as a decent documentation for users and contributors beyond the pure release notes created according to the template :need:`gd_temp__rel_plat_rel_note`.

--- a/process/process_areas/release_management/guidance/release_process_reqs.rst
+++ b/process/process_areas/release_management/guidance/release_process_reqs.rst
@@ -18,9 +18,10 @@ Process Requirements
 .. gd_req:: Release note automated generation
    :id: gd_req__release_note
    :status: valid
+   :version: 1
    :tags: prio_2_automation, release_management
-   :satisfies: wf__rel_platform_rel_note, wf__rel_mod_rel_note
-   :complies: std_req__iso26262__management_64134, std_req__iso26262__management_64135, std_req__aspice_40__SUP-8-BP7
+   :satisfies: wf__rel_platform_rel_note[version==1], wf__rel_mod_rel_note[version==1]
+   :complies: std_req__iso26262__management_64134[version==1], std_req__iso26262__management_64135[version==1], std_req__aspice_40__SUP-8-BP7[version==1]
 
    | The release note shall be generated progressively and automatically compiling the content as far as possible.
    | This shall be done according to templates :need:`gd_temp__rel_plat_rel_note` and :need:`gd_temp__rel_mod_rel_note`.

--- a/process/process_areas/release_management/guidance/release_templates.rst
+++ b/process/process_areas/release_management/guidance/release_templates.rst
@@ -18,7 +18,18 @@ Templates
 .. gd_temp:: Platform Release Note Template
    :id: gd_temp__rel_plat_rel_note
    :status: valid
-   :complies: std_req__iso26262__management_64134, std_req__iso26262__management_64135, std_req__aspice_40__SUP-8-BP7, std_req__aspice_40__SPL-2-BP1, std_req__aspice_40__iic-11-03, std_req__aspice_40__iic-18-06, std_req__aspice_40__SPL-2-BP2, std_req__aspice_40__SPL-2-BP3, std_req__aspice_40__iic-11-04, std_req__aspice_40__SPL-2-BP4, std_req__aspice_40__SPL-2-BP6
+   :version: 1
+   :complies: std_req__iso26262__management_64134[version==1],
+              std_req__iso26262__management_64135[version==1],
+              std_req__aspice_40__SUP-8-BP7[version==1],
+              std_req__aspice_40__SPL-2-BP1[version==1],
+              std_req__aspice_40__iic-11-03[version==1],
+              std_req__aspice_40__iic-18-06[version==1],
+              std_req__aspice_40__SPL-2-BP2[version==1],
+              std_req__aspice_40__SPL-2-BP3[version==1],
+              std_req__aspice_40__iic-11-04[version==1],
+              std_req__aspice_40__SPL-2-BP4[version==1],
+              std_req__aspice_40__SPL-2-BP6[version==1]
 
    For the content see here: :need:`doc__platform_release_note`
 
@@ -26,7 +37,19 @@ Templates
 .. gd_temp:: Module Release Note Template
    :id: gd_temp__rel_mod_rel_note
    :status: valid
-   :complies: std_req__iso26262__management_64134, std_req__iso26262__management_64135, std_req__iso26262__support_12425, std_req__aspice_40__SPL-2-BP1, std_req__aspice_40__iic-11-03, std_req__aspice_40__iic-18-06, std_req__aspice_40__SPL-2-BP2, std_req__aspice_40__SPL-2-BP3, std_req__aspice_40__iic-11-04, std_req__aspice_40__SPL-2-BP4, std_req__aspice_40__SPL-2-BP6, std_req__aspice_40__REU-2-BP6
+   :version: 1
+   :complies: std_req__iso26262__management_64134[version==1],
+              std_req__iso26262__management_64135[version==1],
+              std_req__iso26262__support_12425[version==1],
+              std_req__aspice_40__SPL-2-BP1[version==1],
+              std_req__aspice_40__iic-11-03[version==1],
+              std_req__aspice_40__iic-18-06[version==1],
+              std_req__aspice_40__SPL-2-BP2[version==1],
+              std_req__aspice_40__SPL-2-BP3[version==1],
+              std_req__aspice_40__iic-11-04[version==1],
+              std_req__aspice_40__SPL-2-BP4[version==1],
+              std_req__aspice_40__SPL-2-BP6[version==1],
+              std_req__aspice_40__REU-2-BP6[version==1]
 
    For the content see here: `Module Release Note Template <https://eclipse-score.github.io/module_template/main/docs/release/release_note.html>`__
 
@@ -34,7 +57,12 @@ Templates
 .. gd_temp:: Release Issue Template
    :id: gd_temp__rel_issue
    :status: valid
-   :complies: std_req__iso26262__management_64131, std_req__iso26262__management_64132, std_req__iso26262__management_64133, std_req__aspice_40__SPL-2-BP5, std_req__aspice_40__SPL-2-BP8
+   :version: 1
+   :complies: std_req__iso26262__management_64131[version==1],
+              std_req__iso26262__management_64132[version==1],
+              std_req__iso26262__management_64133[version==1],
+              std_req__aspice_40__SPL-2-BP5[version==1],
+              std_req__aspice_40__SPL-2-BP8[version==1]
 
    | Copy the below steps into the release ticket:
    |

--- a/process/process_areas/release_management/release_concept.rst
+++ b/process/process_areas/release_management/release_concept.rst
@@ -18,6 +18,7 @@ Concept Description
 .. doc_concept:: Concept Description
    :id: doc_concept__rel_process
    :status: valid
+   :version: 1
 
 This section describes the general concept for the release management process.
 The release process can be separated into two parts. On the first level are the software module

--- a/process/process_areas/release_management/release_getstrt.rst
+++ b/process/process_areas/release_management/release_getstrt.rst
@@ -18,6 +18,7 @@ Getting Started
 .. doc_getstrt:: Getting Started on Release Management
    :id: doc_getstrt__release_process
    :status: valid
+   :version: 1
    :tags: release_mgt
 
 This document describes the steps to create a release of the SW and collaterals (test, documentation).

--- a/process/process_areas/release_management/release_workflow.rst
+++ b/process/process_areas/release_management/release_workflow.rst
@@ -22,12 +22,13 @@ For a detailed explanation of workflows and their role within the process model,
 .. workflow:: Create/Maintain Module Release Note
    :id: wf__rel_mod_rel_note
    :status: valid
-   :responsible: rl__committer
-   :approved_by: rl__project_lead
-   :input: wp__module_safety_package, wp__module_sw_release_plan, wp__verification_module_ver_report
-   :output: wp__module_sw_release_note
-   :contains: gd_temp__rel_mod_rel_note, gd_guidl__rel_management
-   :has: doc_concept__rel_process, doc_getstrt__release_process
+   :version: 1
+   :responsible: rl__committer[version==1]
+   :approved_by: rl__project_lead[version==1]
+   :input: wp__module_safety_package[version==1], wp__module_sw_release_plan[version==1], wp__verification_module_ver_report[version==1]
+   :output: wp__module_sw_release_note[version==1]
+   :contains: gd_temp__rel_mod_rel_note[version==1], gd_guidl__rel_management[version==1]
+   :has: doc_concept__rel_process[version==1], doc_getstrt__release_process[version==1]
 
    The module release note is created for each release by the committer acting as the module lead.
    It may be updated later in case of bugs are found after the release is published.
@@ -35,12 +36,13 @@ For a detailed explanation of workflows and their role within the process model,
 .. workflow:: Create/Maintain Platform Release Note
    :id: wf__rel_platform_rel_note
    :status: valid
-   :responsible: rl__project_lead
-   :approved_by: rl__project_lead
-   :input: wp__platform_safety_package, wp__platform_sw_release_plan, wp__verification_platform_ver_report
-   :output: wp__platform_sw_release_note
-   :contains: gd_temp__rel_plat_rel_note, gd_guidl__rel_management
-   :has: doc_concept__rel_process, doc_getstrt__release_process
+   :version: 1
+   :responsible: rl__project_lead[version==1]
+   :approved_by: rl__project_lead[version==1]
+   :input: wp__platform_safety_package[version==1], wp__platform_sw_release_plan[version==1], wp__verification_platform_ver_report[version==1]
+   :output: wp__platform_sw_release_note[version==1]
+   :contains: gd_temp__rel_plat_rel_note[version==1], gd_guidl__rel_management[version==1]
+   :has: doc_concept__rel_process[version==1], doc_getstrt__release_process[version==1]
 
    The platform release note is prepared and approved by the project lead circle.
    It may be updated later in case of bugs found after the release is published.
@@ -48,24 +50,26 @@ For a detailed explanation of workflows and their role within the process model,
 .. workflow:: Plan Module Release
    :id: wf__rel_mod_rel_plan
    :status: valid
-   :responsible: rl__committer
-   :approved_by: rl__project_lead
-   :input: wp__issue_track_system, wp__platform_mgmt
-   :output: wp__module_sw_release_plan
-   :contains: gd_temp__rel_issue, gd_guidl__rel_management
-   :has: doc_concept__rel_process, doc_getstrt__release_process
+   :version: 1
+   :responsible: rl__committer[version==1]
+   :approved_by: rl__project_lead[version==1]
+   :input: wp__issue_track_system[version==1], wp__platform_mgmt[version==1]
+   :output: wp__module_sw_release_plan[version==1]
+   :contains: gd_temp__rel_issue[version==1], gd_guidl__rel_management[version==1]
+   :has: doc_concept__rel_process[version==1], doc_getstrt__release_process[version==1]
 
    The module release plan is created as part of the modules planning and documented as part of the module's project planning.
 
 .. workflow:: Plan Platform Release
    :id: wf__rel_plat_rel_plan
    :status: valid
-   :responsible: rl__project_lead
-   :approved_by: rl__project_lead
-   :input: wp__issue_track_system, wp__platform_mgmt
-   :output: wp__platform_sw_release_plan
-   :contains: gd_temp__rel_issue, gd_guidl__rel_management
-   :has: doc_concept__rel_process, doc_getstrt__release_process
+   :version: 1
+   :responsible: rl__project_lead[version==1]
+   :approved_by: rl__project_lead[version==1]
+   :input: wp__issue_track_system[version==1], wp__platform_mgmt[version==1]
+   :output: wp__platform_sw_release_plan[version==1]
+   :contains: gd_temp__rel_issue[version==1], gd_guidl__rel_management[version==1]
+   :has: doc_concept__rel_process[version==1], doc_getstrt__release_process[version==1]
 
    The platform release plan is created as part of the project planning and documented in the platform management plan.
 
@@ -73,12 +77,13 @@ For a detailed explanation of workflows and their role within the process model,
 .. workflow:: Create/Maintain Platform Handbook
    :id: wf__rel_platform_handbook
    :status: valid
-   :responsible: rl__project_lead
-   :approved_by: rl__project_lead
-   :input: wp__platform_safety_package, wp__platform_sw_release_plan, wp__verification_platform_ver_report
-   :output: wp__platform_handbook
-   :contains: gd_guidl__rel_handbook
-   :has: doc_concept__rel_process, doc_getstrt__release_process
+   :version: 1
+   :responsible: rl__project_lead[version==1]
+   :approved_by: rl__project_lead[version==1]
+   :input: wp__platform_safety_package[version==1], wp__platform_sw_release_plan[version==1], wp__verification_platform_ver_report[version==1]
+   :output: wp__platform_handbook[version==1]
+   :contains: gd_guidl__rel_handbook[version==1]
+   :has: doc_concept__rel_process[version==1], doc_getstrt__release_process[version==1]
 
    The platform handbook is prepared and approved by the project lead circle.
    It may be updated later in case of bugs found after the release is published.
@@ -87,12 +92,13 @@ For a detailed explanation of workflows and their role within the process model,
 .. workflow:: Verify/Approve Module Release
    :id: wf__vy_ap_modrelease
    :status: valid
-   :responsible: rl__release_team
-   :approved_by: rl__project_lead, rl__quality_manager
-   :input: wp__module_sw_release_plan
-   :output: wp__module_sw_release_note
-   :contains: gd_temp__rel_mod_rel_note, gd_guidl__rel_management
-   :has: doc_concept__rel_process, doc_getstrt__release_process
+   :version: 1
+   :responsible: rl__release_team[version==1]
+   :approved_by: rl__project_lead[version==1], rl__quality_manager[version==1]
+   :input: wp__module_sw_release_plan[version==1]
+   :output: wp__module_sw_release_note[version==1]
+   :contains: gd_temp__rel_mod_rel_note[version==1], gd_guidl__rel_management[version==1]
+   :has: doc_concept__rel_process[version==1], doc_getstrt__release_process[version==1]
 
    | The module release is verified and approved.
 
@@ -100,12 +106,19 @@ For a detailed explanation of workflows and their role within the process model,
 .. workflow:: Verify/Approve Platform Release
    :id: wf__vy_ap_pltrelease
    :status: valid
-   :responsible: rl__release_team
-   :approved_by: rl__project_lead, rl__quality_manager
-   :input: wp__qms_plan, wp__platform_sw_release_plan
-   :output: wp__platform_sw_release_note
-   :contains: gd_guidl__qlm_plan_definitions, gd_chklst__review_checklist, gd_temp__rel_plat_rel_note, gd_guidl__rel_management
-   :has: doc_concept__quality_process, doc_getstrt__quality_process, doc_concept__rel_process, doc_getstrt__release_process
+   :version: 1
+   :responsible: rl__release_team[version==1]
+   :approved_by: rl__project_lead[version==1], rl__quality_manager[version==1]
+   :input: wp__qms_plan[version==1], wp__platform_sw_release_plan[version==1]
+   :output: wp__platform_sw_release_note[version==1]
+   :contains: gd_guidl__qlm_plan_definitions[version==1],
+              gd_chklst__review_checklist[version==1],
+              gd_temp__rel_plat_rel_note[version==1],
+              gd_guidl__rel_management[version==1]
+   :has: doc_concept__quality_process[version==1],
+         doc_getstrt__quality_process[version==1],
+         doc_concept__rel_process[version==1],
+         doc_getstrt__release_process[version==1]
 
    | The project/platform release is verified and approved.
 

--- a/process/process_areas/release_management/release_workproducts.rst
+++ b/process/process_areas/release_management/release_workproducts.rst
@@ -18,8 +18,9 @@ Release Management Work Products
 .. workproduct:: Platform Release Notes
    :id: wp__platform_sw_release_note
    :status: valid
+   :version: 1
    :tags: doc_lifecycle_model_2
-   :complies: std_wp__iso26262__management_656
+   :complies: std_wp__iso26262__management_656[version==1]
 
    The platform release note provides clarity what is included in the current version of the platform
    release. The platform release note mentions all individual software modules used in the platform
@@ -36,8 +37,9 @@ Release Management Work Products
 .. workproduct:: Module Release Notes
    :id: wp__module_sw_release_note
    :status: valid
+   :version: 1
    :tags: doc_lifecycle_model_2
-   :complies: std_wp__iso26262__management_656, std_req__aspice_40__iic-13-52
+   :complies: std_wp__iso26262__management_656[version==1], std_req__aspice_40__iic-13-52[version==1]
 
    The module release note provides clarity what is included in the current version of the software
    module release. It shall indicate also the distinct changes to previous versions and provide
@@ -54,6 +56,7 @@ Release Management Work Products
    :id: wp__platform_sw_release_plan
    :tags: doc_lifecycle_model_2
    :status: valid
+   :version: 1
 
    The platform release plan is a high-level document that outlines which software modules
    will be included in the overall platform and what features can be expected within the platform.
@@ -65,6 +68,7 @@ Release Management Work Products
    :id: wp__module_sw_release_plan
    :tags: doc_lifecycle_model_2
    :status: valid
+   :version: 1
 
    The module release plan is a strategic document that outlines the features planned for upcoming
    module releases along with their estimated release dates. It provides a roadmap for the
@@ -75,6 +79,7 @@ Release Management Work Products
    :id: wp__platform_handbook
    :tags: doc_lifecycle_model_2
    :status: valid
+   :version: 1
 
    The platform handbook is a tutorial to explain how the project works from a technical
    perspective. It explains the background of the project, but also what the project is

--- a/process/process_areas/requirements_engineering/guidance/requirements_guideline.rst
+++ b/process/process_areas/requirements_engineering/guidance/requirements_guideline.rst
@@ -18,8 +18,12 @@ Guideline
 .. gd_guidl:: Requirements Guideline
    :id: gd_guidl__req_engineering
    :status: valid
-   :complies: std_req__isopas8926__44421, std_req__isopas8926__44422, std_req__isopas8926__44423,
-              std_req__iso26262__software_app_c_41, std_req__iso26262__software_app_c_43
+   :version: 1
+   :complies: std_req__isopas8926__44421[version==1],
+              std_req__isopas8926__44422[version==1],
+              std_req__isopas8926__44423[version==1],
+              std_req__iso26262__software_app_c_41[version==1],
+              std_req__iso26262__software_app_c_43[version==1]
 
 This document describes the general guidances for requirements based on the concept which is defined in :need:`[[title]]<doc_concept__req_process>`.
 
@@ -285,7 +289,13 @@ Tailoring
 .. gd_guidl:: Requirements Tailored
    :id: gd_guidl__req_tailored
    :status: valid
-   :complies: std_req__iso26262__system_6423, std_req__iso26262__system_6424, std_req__iso26262__system_6425, std_req__iso26262__software_643, std_req__iso26262__software_644, std_req__iso26262__software_646
+   :version: 1
+   :complies: std_req__iso26262__system_6423[version==1],
+              std_req__iso26262__system_6424[version==1],
+              std_req__iso26262__system_6425[version==1],
+              std_req__iso26262__software_643[version==1],
+              std_req__iso26262__software_644[version==1],
+              std_req__iso26262__software_646[version==1]
 
    This part of the guideline links to all the requirements which are not fulfilled by the
    requirements engineering process. Make sure these are tailored out in the safety/security/quality plans

--- a/process/process_areas/requirements_engineering/guidance/requirements_inspection_checklist.rst
+++ b/process/process_areas/requirements_engineering/guidance/requirements_inspection_checklist.rst
@@ -22,7 +22,14 @@ Requirement Inspection Checklist
 .. gd_chklst:: Requirements Inspection Checklist Template
    :id: gd_chklst__req_inspection
    :status: valid
-   :complies: std_req__iso26262__system_6412, std_req__iso26262__system_6414, std_req__iso26262__system_6421, std_req__iso26262__system_6422, std_req__aspice_40__SWE-1-BP3, std_req__aspice_40__SWE-1-BP4, std_req__aspice_40__SWE-1-BP6
+   :version: 1
+   :complies: std_req__iso26262__system_6412[version==1],
+              std_req__iso26262__system_6414[version==1],
+              std_req__iso26262__system_6421[version==1],
+              std_req__iso26262__system_6422[version==1],
+              std_req__aspice_40__SWE-1-BP3[version==1],
+              std_req__aspice_40__SWE-1-BP4[version==1],
+              std_req__aspice_40__SWE-1-BP6[version==1]
    :tags: requirements_engineering
 
    For the content see here:

--- a/process/process_areas/requirements_engineering/guidance/requirements_process_reqs.rst
+++ b/process/process_areas/requirements_engineering/guidance/requirements_process_reqs.rst
@@ -20,9 +20,15 @@ Process Requirements
 .. gd_req:: Requirements Structure
    :id: gd_req__req_structure
    :status: valid
+   :version: 1
    :tags: done_automation, structure
-   :satisfies: wf__req_stkh_req, wf__req_feat_req, wf__req_comp_req, wf__req_tool, wf__req_feat_aou, wf__req_comp_aou
-   :complies: std_req__iso26262__support_6431, std_req__iso26262__support_6432
+   :satisfies: wf__req_stkh_req[version==1],
+               wf__req_feat_req[version==1],
+               wf__req_comp_req[version==1],
+               wf__req_tool[version==1],
+               wf__req_feat_aou[version==1],
+               wf__req_comp_aou[version==1]
+   :complies: std_req__iso26262__support_6431[version==1], std_req__iso26262__support_6432[version==1]
 
    Requirements shall be hierarchically grouped into three levels.
 
@@ -45,9 +51,15 @@ Process Requirement Attributes
 .. gd_req:: Requirement attribute: UID
    :id: gd_req__req_attr_uid
    :status: valid
+   :version: 1
    :tags: manual_prio_1, attribute, mandatory
-   :satisfies: wf__req_stkh_req, wf__req_feat_req, wf__req_comp_req, wf__req_tool, wf__req_feat_aou, wf__req_comp_aou
-   :complies: std_req__iso26262__support_6425, std_req__iso26262__support_6432
+   :satisfies: wf__req_stkh_req[version==1],
+               wf__req_feat_req[version==1],
+               wf__req_comp_req[version==1],
+               wf__req_tool[version==1],
+               wf__req_feat_aou[version==1],
+               wf__req_comp_aou[version==1]
+   :complies: std_req__iso26262__support_6425[version==1], std_req__iso26262__support_6432[version==1]
 
    Each requirement shall have a unique ID. It shall consist of three parts:
 
@@ -60,9 +72,15 @@ Process Requirement Attributes
 .. gd_req:: Requirement attribute: title
    :id: gd_req__req_attr_title
    :status: valid
+   :version: 1
    :tags: manual_prio_1 attribute, mandatory
-   :satisfies: wf__req_stkh_req, wf__req_feat_req, wf__req_comp_req, wf__req_tool, wf__req_feat_aou, wf__req_comp_aou
-   :complies: std_req__iso26262__support_6424
+   :satisfies: wf__req_stkh_req[version==1],
+               wf__req_feat_req[version==1],
+               wf__req_comp_req[version==1],
+               wf__req_tool[version==1],
+               wf__req_feat_aou[version==1],
+               wf__req_comp_aou[version==1]
+   :complies: std_req__iso26262__support_6424[version==1]
 
    The title of the requirement shall provide a short summary of the description, but is not an "additional" requirement.
 
@@ -71,9 +89,15 @@ Process Requirement Attributes
 .. gd_req:: Requirement attribute: description
    :id: gd_req__req_attr_description
    :status: valid
+   :version: 1
    :tags: manual_prio_1, attribute, mandatory
-   :satisfies: wf__req_stkh_req, wf__req_feat_req, wf__req_comp_req, wf__req_tool, wf__req_feat_aou, wf__req_comp_aou
-   :complies: std_req__iso26262__support_6424
+   :satisfies: wf__req_stkh_req[version==1],
+               wf__req_feat_req[version==1],
+               wf__req_comp_req[version==1],
+               wf__req_tool[version==1],
+               wf__req_feat_aou[version==1],
+               wf__req_comp_aou[version==1]
+   :complies: std_req__iso26262__support_6424[version==1]
 
    Each requirement shall have a description.
 
@@ -86,9 +110,14 @@ Process Requirement Attributes
 .. gd_req:: Requirement attribute: type
    :id: gd_req__req_attr_type
    :status: valid
+   :version: 1
    :tags: manual_prio_2, attribute, mandatory
-   :satisfies: wf__req_stkh_req, wf__req_feat_req, wf__req_comp_req, wf__req_feat_aou, wf__req_comp_aou
-   :complies: std_req__aspice_40__iic-17-00
+   :satisfies: wf__req_stkh_req[version==1],
+               wf__req_feat_req[version==1],
+               wf__req_comp_req[version==1],
+               wf__req_feat_aou[version==1],
+               wf__req_comp_aou[version==1]
+   :complies: std_req__aspice_40__iic-17-00[version==1]
 
    Each requirement, apart from process and tool requirements, shall have a type of one of following options:
 
@@ -100,8 +129,12 @@ Process Requirement Attributes
 .. gd_req:: Requirements attribute: security
    :id: gd_req__req_attr_security
    :status: valid
+   :version: 1
    :tags: manual_prio_2, attribute, mandatory
-   :satisfies: wf__req_feat_req, wf__req_comp_req, wf__req_feat_aou, wf__req_comp_aou
+   :satisfies: wf__req_feat_req[version==1],
+               wf__req_comp_req[version==1],
+               wf__req_feat_aou[version==1],
+               wf__req_comp_aou[version==1]
 
    Each requirement, apart from process and tool requirements, shall have a security relevance identifier:
 
@@ -111,9 +144,14 @@ Process Requirement Attributes
 .. gd_req:: Requirement attribute: safety
    :id: gd_req__req_attr_safety
    :status: valid
+   :version: 1
    :tags: manual_prio_1, attribute, mandatory
-   :complies: std_req__iso26262__support_6421, std_req__iso26262__support_6425
-   :satisfies: wf__req_stkh_req, wf__req_feat_req, wf__req_comp_req, wf__req_feat_aou, wf__req_comp_aou
+   :complies: std_req__iso26262__support_6421[version==1], std_req__iso26262__support_6425[version==1]
+   :satisfies: wf__req_stkh_req[version==1],
+               wf__req_feat_req[version==1],
+               wf__req_comp_req[version==1],
+               wf__req_feat_aou[version==1],
+               wf__req_comp_aou[version==1]
 
    Each requirement, apart from process and tool requirements, shall have a automotive safety integrity level (ASIL) identifier:
 
@@ -123,9 +161,14 @@ Process Requirement Attributes
 .. gd_req:: Requirement attribute: status
    :id: gd_req__req_attr_status
    :status: valid
+   :version: 1
    :tags: manual_prio_1, attribute, mandatory
-   :complies: std_req__iso26262__support_6425
-   :satisfies: wf__req_stkh_req, wf__req_feat_req, wf__req_comp_req, wf__req_feat_aou, wf__req_comp_aou
+   :complies: std_req__iso26262__support_6425[version==1]
+   :satisfies: wf__req_stkh_req[version==1],
+               wf__req_feat_req[version==1],
+               wf__req_comp_req[version==1],
+               wf__req_feat_aou[version==1],
+               wf__req_comp_aou[version==1]
 
    Each requirement, apart from process and tool requirements, shall have a status:
 
@@ -135,8 +178,9 @@ Process Requirement Attributes
 .. gd_req:: Requirement attribute: rationale
    :id: gd_req__req_attr_rationale
    :status: valid
+   :version: 1
    :tags: manual_prio_1, attribute, mandatory
-   :satisfies: wf__req_stkh_req
+   :satisfies: wf__req_stkh_req[version==1]
 
    Each stakeholder requirement shall provide an attribute called rationale.
    The rationale shall contain the reason why the requirement is needed.
@@ -144,9 +188,10 @@ Process Requirement Attributes
 .. gd_req:: Requirement attribute: valid_from
    :id: gd_req__req_attr_valid_from
    :status: valid
+   :version: 1
    :tags: manual_prio_2, attribute
-   :satisfies: wf__req_stkh_req, wf__req_feat_req
-   :complies: std_req__aspice_40__SWE-1-BP2, std_req__aspice_40__iic-17-54
+   :satisfies: wf__req_stkh_req[version==1], wf__req_feat_req[version==1]
+   :complies: std_req__aspice_40__SWE-1-BP2[version==1], std_req__aspice_40__iic-17-54[version==1]
 
    Stakeholder and feature requirements can have a validity attribute that tells
    from which milestone onwards the requirement is part of a feature.
@@ -160,9 +205,10 @@ Process Requirement Attributes
 .. gd_req:: Requirement attribute: valid_until
    :id: gd_req__req_attr_valid_until
    :status: valid
+   :version: 1
    :tags: manual_prio_2, attribute
-   :satisfies: wf__req_stkh_req, wf__req_feat_req
-   :complies: std_req__aspice_40__SWE-1-BP2, std_req__aspice_40__iic-17-54
+   :satisfies: wf__req_stkh_req[version==1], wf__req_feat_req[version==1]
+   :complies: std_req__aspice_40__SWE-1-BP2[version==1], std_req__aspice_40__iic-17-54[version==1]
 
    Stakeholder and feature requirements can have a validity attribute that tells
    until which milestone the requirement is part of a feature.
@@ -181,9 +227,13 @@ Process Requirement Linkage
 .. gd_req:: Requirement Linkage
    :id: gd_req__req_linkage
    :status: valid
+   :version: 1
    :tags: manual_prio_1, attribute
-   :complies: std_req__iso26262__support_6432, std_req__aspice_40__SWE-1-BP5
-   :satisfies: wf__req_stkh_req, wf__req_feat_req, wf__req_comp_req, wf__req_tool
+   :complies: std_req__iso26262__support_6432[version==1], std_req__aspice_40__SWE-1-BP5[version==1]
+   :satisfies: wf__req_stkh_req[version==1],
+               wf__req_feat_req[version==1],
+               wf__req_comp_req[version==1],
+               wf__req_tool[version==1]
 
    Requirements shall be linked to its adjacent level via the attribute derived_from.
 
@@ -194,9 +244,10 @@ Process Requirement Linkage
 .. gd_req:: Requirement Linkage to AoU
    :id: gd_req__req_linkage_aou
    :status: valid
+   :version: 1
    :tags: manual_prio_1, attribute
-   :complies: std_req__iso26262__support_6432, std_req__aspice_40__SWE-1-BP5
-   :satisfies: wf__req_feat_req, wf__req_comp_req
+   :complies: std_req__iso26262__support_6432[version==1], std_req__aspice_40__SWE-1-BP5[version==1]
+   :satisfies: wf__req_feat_req[version==1], wf__req_comp_req[version==1]
 
    Requirements shall be linked to AoU via the attribute covers, if they already cover these.
 
@@ -209,18 +260,23 @@ Process Requirement Linkage
 .. gd_req:: Requirement Traceability
    :id: gd_req__req_traceability
    :status: valid
+   :version: 1
    :tags: done_automation, attribute
-   :complies: std_req__iso26262__support_6432, std_req__aspice_40__SWE-1-BP5
-   :satisfies: wf__req_stkh_req, wf__req_feat_req, wf__req_comp_req, wf__req_tool
+   :complies: std_req__iso26262__support_6432[version==1], std_req__aspice_40__SWE-1-BP5[version==1]
+   :satisfies: wf__req_stkh_req[version==1],
+               wf__req_feat_req[version==1],
+               wf__req_comp_req[version==1],
+               wf__req_tool[version==1]
 
    Bi-directional traceability shall be provided by adding a "back-link" via attribute derives (i.e. make a <-> out of the <- in :need:`gd_req__req_linkage`).
 
 .. gd_req:: Requirement attribute: requirement covered
    :id: gd_req__req_attr_req_cov
    :status: valid
+   :version: 1
    :tags: manual_prio_1, attribute
-   :complies: std_req__iso26262__support_6423, std_req__aspice_40__iic-13-51
-   :satisfies: wf__req_stkh_req, wf__req_feat_req
+   :complies: std_req__iso26262__support_6423[version==1], std_req__aspice_40__iic-13-51[version==1]
+   :satisfies: wf__req_stkh_req[version==1], wf__req_feat_req[version==1]
 
    It shall be possible to specify the requirement coverage, meaning the requirement is covered fully by its linked children.
 
@@ -230,26 +286,29 @@ Process Requirement Linkage
 .. gd_req:: Requirement attribute: link to implementation
    :id: gd_req__req_attr_impl
    :status: valid
+   :version: 1
    :tags: done_automation, attribute
-   :satisfies: wf__req_feat_req, wf__req_comp_req
+   :satisfies: wf__req_feat_req[version==1], wf__req_comp_req[version==1]
 
    It shall be possible to link requirements to code (to the respective line of code in an attribute of the requirement).
 
 .. gd_req:: Requirement attribute: link to test
    :id: gd_req__req_attr_testlink
    :status: valid
+   :version: 1
    :tags: done_automation, attribute
-   :satisfies: wf__req_feat_req, wf__req_comp_req
-   :complies: std_req__iso26262__support_6433, std_req__iso26262__software_944
+   :satisfies: wf__req_feat_req[version==1], wf__req_comp_req[version==1]
+   :complies: std_req__iso26262__support_6433[version==1], std_req__iso26262__software_944[version==1]
 
    It shall be possible to link requirements to tests and automatically include a link to the test case in the attribute testlink.
 
 .. gd_req:: Requirement attribute: complete test coverage
    :id: gd_req__req_attr_test_covered
    :status: valid
+   :version: 1
    :tags: manual_prio_1, attribute
-   :satisfies: wf__req_feat_req, wf__req_comp_req
-   :complies: std_req__iso26262__support_6433, std_req__iso26262__software_944, std_req__aspice_40__iic-13-51
+   :satisfies: wf__req_feat_req[version==1], wf__req_comp_req[version==1]
+   :complies: std_req__iso26262__support_6433[version==1], std_req__iso26262__software_944[version==1], std_req__aspice_40__iic-13-51[version==1]
 
    It shall be possible to specify if a requirement is completely satisfied by the linked test case(s).
 
@@ -259,9 +318,10 @@ Process Requirement Linkage
 .. gd_req:: Requirement attribute: versioning
    :id: gd_req__req_attr_version
    :status: valid
+   :version: 1
    :tags: prio_1_automation, attribute
-   :satisfies: wf__req_stkh_req, wf__req_feat_req, wf__req_comp_req
-   :complies: std_req__iso26262__support_6425, std_req__iso26262__support_6434
+   :satisfies: wf__req_stkh_req[version==1], wf__req_feat_req[version==1], wf__req_comp_req[version==1]
+   :complies: std_req__iso26262__support_6425[version==1], std_req__iso26262__support_6434[version==1]
 
    A versioning for requirements shall be provided. For this all mandatory attributes shall be taken into account: see :need:`gd_req__req_check_mandatory`
 
@@ -273,9 +333,10 @@ Process Requirements Checks
 .. gd_req:: Requirement check: suspicious
    :id: gd_req__req_suspicious
    :status: valid
+   :version: 1
    :tags: prio_2_automation, check
-   :satisfies: wf__req_stkh_req, wf__req_feat_req, wf__req_comp_req
-   :complies: std_req__iso26262__support_6425, std_req__iso26262__support_6434, std_req__aspice_40__iic-13-51
+   :satisfies: wf__req_stkh_req[version==1], wf__req_feat_req[version==1], wf__req_comp_req[version==1]
+   :complies: std_req__iso26262__support_6425[version==1], std_req__iso26262__support_6434[version==1], std_req__aspice_40__iic-13-51[version==1]
 
    Based on the requirement versioning it shall be checked if a parent requirement was updated but not the linked child requirements (or tests).
    In case an update was detected, the attribute `requirement covered` (or `complete test coverage`) shall be set to "No"
@@ -285,8 +346,14 @@ Process Requirements Checks
 .. gd_req:: Requirements mandatory attributes provided
    :id: gd_req__req_check_mandatory
    :status: valid
+   :version: 1
    :tags: done_automation, check
-   :satisfies: wf__req_stkh_req, wf__req_feat_req, wf__req_comp_req, wf__req_tool, wf__req_feat_aou, wf__req_comp_aou
+   :satisfies: wf__req_stkh_req[version==1],
+               wf__req_feat_req[version==1],
+               wf__req_comp_req[version==1],
+               wf__req_tool[version==1],
+               wf__req_feat_aou[version==1],
+               wf__req_comp_aou[version==1]
 
    It shall be checked if all mandatory attributes for each requirement is provided by the user. For all requirements following attributes shall be mandatory:
 
@@ -301,8 +368,14 @@ Process Requirements Checks
 .. gd_req:: Requirements no weak words
    :id: gd_req__req_desc_weak
    :status: valid
+   :version: 1
    :tags: done_automation, check
-   :satisfies: wf__req_stkh_req, wf__req_feat_req, wf__req_comp_req, wf__req_tool, wf__req_feat_aou, wf__req_comp_aou
+   :satisfies: wf__req_stkh_req[version==1],
+               wf__req_feat_req[version==1],
+               wf__req_comp_req[version==1],
+               wf__req_tool[version==1],
+               wf__req_feat_aou[version==1],
+               wf__req_comp_aou[version==1]
 
    It shall be ensured that no *weak words* are contained in the requirement description for:
 
@@ -317,9 +390,10 @@ Process Requirements Checks
 .. gd_req:: Requirements linkage level
    :id: gd_req__req_linkage_fulfill
    :status: valid
+   :version: 1
    :tags: done_automation, check
-   :complies: std_req__iso26262__support_6432, std_req__aspice_40__iic-13-51
-   :satisfies: wf__req_stkh_req, wf__req_feat_req, wf__req_comp_req
+   :complies: std_req__iso26262__support_6432[version==1], std_req__aspice_40__iic-13-51[version==1]
+   :satisfies: wf__req_stkh_req[version==1], wf__req_feat_req[version==1], wf__req_comp_req[version==1]
 
    Every feature- and component requirement shall be linked to at least one parent requirement according to the defined traceability scheme:
 
@@ -328,9 +402,10 @@ Process Requirements Checks
 .. gd_req:: Requirements mandatory architecture linkage
    :id: gd_req__req_linkage_architecture_mandatory
    :status: valid
+   :version: 1
    :tags: done_automation, check
-   :complies: std_req__iso26262__support_6423
-   :satisfies: wf__req_feat_req, wf__req_comp_req
+   :complies: std_req__iso26262__support_6423[version==1]
+   :satisfies: wf__req_feat_req[version==1], wf__req_comp_req[version==1]
 
    Every feature- and component requirement shall be linked via satisfied_by at least to one valid architectural element on the same level.
 
@@ -340,9 +415,10 @@ Process Requirements Checks
 .. gd_req:: Requirements linkage architecture
    :id: gd_req__req_linkage_architecture
    :status: valid
+   :version: 1
    :tags: prio_3_automation, check
-   :complies: std_req__iso26262__support_6423
-   :satisfies: wf__req_feat_req, wf__req_comp_req
+   :complies: std_req__iso26262__support_6423[version==1]
+   :satisfies: wf__req_feat_req[version==1], wf__req_comp_req[version==1]
 
    It shall be checked if every feature requirement is linked via fulfilled_by at least to one valid architectural diagram/interface on the same level.
    This should also include requirement type checking:
@@ -355,18 +431,20 @@ Process Requirements Checks
 .. gd_req:: Requirements linkage architecture switch
    :id: gd_req__req_linkage_architecture_switch
    :status: valid
+   :version: 1
    :tags: prio_3_automation, check
-   :complies: std_req__iso26262__support_6423
-   :satisfies: wf__req_feat_req, wf__req_comp_req
+   :complies: std_req__iso26262__support_6423[version==1]
+   :satisfies: wf__req_feat_req[version==1], wf__req_comp_req[version==1]
 
    The check :need:`gd_req__req_linkage_architecture` shall only be enabled for a release build, otherwise it would block creating requirements first without architecture.
 
 .. gd_req:: Requirements linkage safety
    :id: gd_req__req_linkage_safety
    :status: valid
+   :version: 1
    :tags: done_automation, check
-   :satisfies: wf__req_stkh_req, wf__req_feat_req, wf__req_comp_req
-   :complies: std_req__iso26262__support_6422
+   :satisfies: wf__req_stkh_req[version==1], wf__req_feat_req[version==1], wf__req_comp_req[version==1]
+   :complies: std_req__iso26262__support_6422[version==1]
 
    It shall be checked that (child) QM requirements (Safety == QM) can not be linked against a (parent) safety requirement (Safety != QM).
 
@@ -375,8 +453,9 @@ Process Requirements Checks
 .. gd_req:: Requirements validity
    :id: gd_req__req_validity
    :status: valid
+   :version: 1
    :tags: prio_3_automation, check
-   :satisfies: wf__req_stkh_req, wf__req_feat_req
+   :satisfies: wf__req_stkh_req[version==1], wf__req_feat_req[version==1]
 
    Validity attributes (:need:`gd_req__req_attr_valid_from` and :need:`gd_req__req_attr_valid_until`) shall be checked for correctness (i.e. they denote an existing milestone) and consistent (e.g. the until is not before from)
    Several of the above checks are not to be executed on requirements not valid in the next milestone, these are TBD

--- a/process/process_areas/requirements_engineering/guidance/requirements_templates.rst
+++ b/process/process_areas/requirements_engineering/guidance/requirements_templates.rst
@@ -20,7 +20,13 @@ Templates
 .. gd_temp:: Stakeholder Requirements Template
    :id: gd_temp__req_stkh_req
    :status: valid
-   :complies: std_req__iso26262__system_6411, std_req__iso26262__system_6413, std_req__iso26262__support_641, std_req__iso26262__support_6421, std_req__iso26262__support_6425, std_req__aspice_40__SWE-1-BP1
+   :version: 1
+   :complies: std_req__iso26262__system_6411[version==1],
+              std_req__iso26262__system_6413[version==1],
+              std_req__iso26262__support_641[version==1],
+              std_req__iso26262__support_6421[version==1],
+              std_req__iso26262__support_6425[version==1],
+              std_req__aspice_40__SWE-1-BP1[version==1]
 
    See the stakeholder requirements template in the
    `module template documentation <https://eclipse-score.github.io/module_template/stakeholder_requirements_template.html>`__.
@@ -28,7 +34,11 @@ Templates
 .. gd_temp:: Feature Requirements Template
    :id: gd_temp__req_feat_req
    :status: valid
-   :complies: std_req__iso26262__support_641, std_req__iso26262__support_6421, std_req__iso26262__support_6425, std_req__aspice_40__SWE-1-BP1
+   :version: 1
+   :complies: std_req__iso26262__support_641[version==1],
+              std_req__iso26262__support_6421[version==1],
+              std_req__iso26262__support_6425[version==1],
+              std_req__aspice_40__SWE-1-BP1[version==1]
 
    See the feature requirements template in
    :doc:`../../../folder_templates/platform/features/feature_name/requirements/index`
@@ -36,7 +46,12 @@ Templates
 .. gd_temp:: Component Requirements Template
    :id: gd_temp__req_comp_req
    :status: valid
-   :complies: std_req__iso26262__support_641, std_req__iso26262__support_6421, std_req__iso26262__support_6425, std_req__iso26262__support_12425, std_req__aspice_40__SWE-1-BP1
+   :version: 1
+   :complies: std_req__iso26262__support_641[version==1],
+              std_req__iso26262__support_6421[version==1],
+              std_req__iso26262__support_6425[version==1],
+              std_req__iso26262__support_12425[version==1],
+              std_req__aspice_40__SWE-1-BP1[version==1]
 
    See the component requirements template in the
    `module template documentation <https://eclipse-score.github.io/module_template/main/score/component_example/docs/requirements/index.html>`__.
@@ -44,7 +59,11 @@ Templates
 .. gd_temp:: AoU Requirement Template
    :id: gd_temp__req_aou_req
    :status: valid
-   :complies: std_req__iso26262__support_641, std_req__iso26262__support_6421, std_req__iso26262__support_6425, std_req__aspice_40__SWE-1-BP1
+   :version: 1
+   :complies: std_req__iso26262__support_641[version==1],
+              std_req__iso26262__support_6421[version==1],
+              std_req__iso26262__support_6425[version==1],
+              std_req__aspice_40__SWE-1-BP1[version==1]
 
    See the Assumption of Use requirement snippets in the
    `module template documentation <https://eclipse-score.github.io/module_template/aou_requirements_template.html>`__.
@@ -53,7 +72,8 @@ Templates
 .. gd_temp:: Tool Requirements Template
    :id: gd_temp__req_tool_req
    :status: valid
-   :complies: std_req__iso26262__support_641, std_req__iso26262__support_6421, std_req__iso26262__support_6425
+   :version: 1
+   :complies: std_req__iso26262__support_641[version==1], std_req__iso26262__support_6421[version==1], std_req__iso26262__support_6425[version==1]
 
    .. code-block:: rst
 
@@ -63,12 +83,14 @@ Templates
          :safety: <QM|ASIL_B>
          :derived_from: <link to process req id>
          :status: <valid|invalid>
+         :version: 1
          :implemented: <YES|PARTIAL|NO>
 
 .. gd_temp:: Requirement Formulation Template
    :id: gd_temp__req_formulation
    :status: valid
-   :complies: std_req__iso26262__support_641, std_req__iso26262__support_6421, std_req__iso26262__support_6425
+   :version: 1
+   :complies: std_req__iso26262__support_641[version==1], std_req__iso26262__support_6421[version==1], std_req__iso26262__support_6425[version==1]
 
    Requirements shall be specified according to the following schema:
 

--- a/process/process_areas/requirements_engineering/requirements_concept.rst
+++ b/process/process_areas/requirements_engineering/requirements_concept.rst
@@ -18,6 +18,7 @@ Concept Description
 .. doc_concept:: Requirements Concept
    :id: doc_concept__req_process
    :status: valid
+   :version: 1
    :tags: requirements_engineering
 
 In this section a concept for the requirements management will be discussed. Inputs for this concepts are both the requirements of ISO26262 Part-8 and ASPICE Requirements from SWE.1 additionally including the requirements of the different stakeholders for the requirement process.

--- a/process/process_areas/requirements_engineering/requirements_getstrt.rst
+++ b/process/process_areas/requirements_engineering/requirements_getstrt.rst
@@ -18,6 +18,7 @@ Getting Started
 .. doc_getstrt:: Getting Started on Requirements
    :id: doc_getstrt__req_process
    :status: valid
+   :version: 1
    :tags: requirements_engineering
 
 This document describes the steps which need to be done to create requirements, derive child requirements and finally to perform the formal requirement inspection.

--- a/process/process_areas/requirements_engineering/requirements_workflow.rst
+++ b/process/process_areas/requirements_engineering/requirements_workflow.rst
@@ -23,14 +23,15 @@ For a detailed explanation of workflows and their role within the process model,
 .. workflow:: Create/Maintain Stakeholder requirements and SW-Platform AoU
    :id: wf__req_stkh_req
    :status: valid
+   :version: 1
    :tags: requirements_engineering
-   :responsible: rl__contributor
-   :approved_by: rl__project_lead
-   :supported_by: rl__safety_manager
-   :input: wp__policies, wp__issue_track_system
-   :output: wp__requirements_stkh, wp__requirements_sw_platform_aou
-   :contains: gd_temp__req_stkh_req, gd_temp__req_formulation
-   :has: doc_concept__req_process, doc_getstrt__req_process
+   :responsible: rl__contributor[version==1]
+   :approved_by: rl__project_lead[version==1]
+   :supported_by: rl__safety_manager[version==1]
+   :input: wp__policies[version==1], wp__issue_track_system[version==1]
+   :output: wp__requirements_stkh[version==1], wp__requirements_sw_platform_aou[version==1]
+   :contains: gd_temp__req_stkh_req[version==1], gd_temp__req_formulation[version==1]
+   :has: doc_concept__req_process[version==1], doc_getstrt__req_process[version==1]
 
    Stakeholder requirements and SW-Platform Assumptions of Use (AoU) can be created during a change request.
    Any contributor can create a stakeholder requirement (or AoU) and propose it for approval.
@@ -38,81 +39,93 @@ For a detailed explanation of workflows and their role within the process model,
 .. workflow:: Create/Maintain Feature requirements
    :id: wf__req_feat_req
    :status: valid
+   :version: 1
    :tags: requirements_engineering
-   :responsible: rl__contributor
-   :approved_by: rl__project_lead
-   :supported_by: rl__safety_manager, rl__security_manager
-   :input: wp__requirements_stkh, wp__issue_track_system
-   :output: wp__requirements_feat
-   :contains: gd_temp__req_feat_req, gd_temp__req_formulation
-   :has: doc_concept__req_process, doc_getstrt__req_process
+   :responsible: rl__contributor[version==1]
+   :approved_by: rl__project_lead[version==1]
+   :supported_by: rl__safety_manager[version==1], rl__security_manager[version==1]
+   :input: wp__requirements_stkh[version==1], wp__issue_track_system[version==1]
+   :output: wp__requirements_feat[version==1]
+   :contains: gd_temp__req_feat_req[version==1], gd_temp__req_formulation[version==1]
+   :has: doc_concept__req_process[version==1], doc_getstrt__req_process[version==1]
 
    Depending on the stakeholder requirements feature requirements can be derived. This can be done by any contributor and will be approved by a project lead. If needed safety and security managers can provide support.
 
 .. workflow:: Create/Maintain Feature AoUs
    :id: wf__req_feat_aou
    :status: valid
+   :version: 1
    :tags: requirements_engineering
-   :responsible: rl__contributor
-   :approved_by: rl__project_lead
-   :supported_by: rl__safety_manager, rl__security_manager
-   :input: wp__requirements_feat, wp__feature_arch, wp__issue_track_system
-   :output: wp__requirements_feat_aou, wp__platform_safety_manual
-   :contains: gd_temp__req_aou_req, gd_temp__req_formulation
-   :has: doc_concept__req_process, doc_getstrt__req_process
+   :responsible: rl__contributor[version==1]
+   :approved_by: rl__project_lead[version==1]
+   :supported_by: rl__safety_manager[version==1], rl__security_manager[version==1]
+   :input: wp__requirements_feat[version==1], wp__feature_arch[version==1], wp__issue_track_system[version==1]
+   :output: wp__requirements_feat_aou[version==1], wp__platform_safety_manual[version==1]
+   :contains: gd_temp__req_aou_req[version==1], gd_temp__req_formulation[version==1]
+   :has: doc_concept__req_process[version==1], doc_getstrt__req_process[version==1]
 
    Based on the safety concept on feature level, feature AoUs can be derived. See also :ref:`aou_workflow`
 
 .. workflow:: Create/Maintain Component requirements
    :id: wf__req_comp_req
    :status: valid
+   :version: 1
    :tags: requirements_engineering
-   :responsible: rl__contributor
-   :approved_by: rl__committer
-   :supported_by: rl__safety_manager, rl__security_manager
-   :input: wp__requirements_feat, wp__issue_track_system
-   :output: wp__requirements_comp
-   :contains: gd_temp__req_comp_req, gd_temp__req_formulation
-   :has: doc_concept__req_process, doc_getstrt__req_process
+   :responsible: rl__contributor[version==1]
+   :approved_by: rl__committer[version==1]
+   :supported_by: rl__safety_manager[version==1], rl__security_manager[version==1]
+   :input: wp__requirements_feat[version==1], wp__issue_track_system[version==1]
+   :output: wp__requirements_comp[version==1]
+   :contains: gd_temp__req_comp_req[version==1], gd_temp__req_formulation[version==1]
+   :has: doc_concept__req_process[version==1], doc_getstrt__req_process[version==1]
 
 .. workflow:: Create/Maintain Component AoUs
    :id: wf__req_comp_aou
    :status: valid
+   :version: 1
    :tags: requirements_engineering
-   :responsible: rl__contributor
-   :approved_by: rl__committer
-   :supported_by: rl__safety_manager, rl__security_manager
-   :input: wp__requirements_comp, wp__component_arch, wp__issue_track_system
-   :output: wp__requirements_comp_aou, wp__module_safety_manual
-   :contains: gd_temp__req_aou_req, gd_temp__req_formulation
-   :has: doc_concept__req_process, doc_getstrt__req_process
+   :responsible: rl__contributor[version==1]
+   :approved_by: rl__committer[version==1]
+   :supported_by: rl__safety_manager[version==1], rl__security_manager[version==1]
+   :input: wp__requirements_comp[version==1], wp__component_arch[version==1], wp__issue_track_system[version==1]
+   :output: wp__requirements_comp_aou[version==1], wp__module_safety_manual[version==1]
+   :contains: gd_temp__req_aou_req[version==1], gd_temp__req_formulation[version==1]
+   :has: doc_concept__req_process[version==1], doc_getstrt__req_process[version==1]
 
    Based on the safety concept on component level, component AoUs can be derived. See also :ref:`aou_workflow`
 
 .. workflow:: Create/Maintain Tool Requirements
    :id: wf__req_tool
    :status: valid
+   :version: 1
    :tags: requirements_engineering
-   :responsible: rl__contributor
-   :approved_by: rl__committer
-   :supported_by: rl__safety_manager, rl__security_manager
-   :input: wp__process_description
-   :output: wp__requirements_proc_tool
-   :contains: gd_temp__req_tool_req, gd_temp__req_formulation
-   :has: doc_concept__req_process, doc_getstrt__req_process
+   :responsible: rl__contributor[version==1]
+   :approved_by: rl__committer[version==1]
+   :supported_by: rl__safety_manager[version==1], rl__security_manager[version==1]
+   :input: wp__process_description[version==1]
+   :output: wp__requirements_proc_tool[version==1]
+   :contains: gd_temp__req_tool_req[version==1], gd_temp__req_formulation[version==1]
+   :has: doc_concept__req_process[version==1], doc_getstrt__req_process[version==1]
 
    Based on the process descriptions (which comply to standards) and/or stakeholder/feature/component requirements tool requirements are derived.
 
 .. workflow:: Monitor/Verify Requirements
    :id: wf__monitor_verify_requirements
    :status: valid
+   :version: 1
    :tags: requirements_engineering
-   :responsible: rl__committer
-   :approved_by: rl__committer
-   :supported_by: rl__safety_manager
-   :input: wp__requirements_stkh, wp__requirements_feat, wp__requirements_comp, wp__requirements_feat_aou, wp__requirements_comp_aou, wp__platform_safety_manual, wp__module_safety_manual
-   :output: wp__issue_track_system, wp__requirements_inspect
-   :contains: gd_chklst__req_inspection
+   :responsible: rl__committer[version==1]
+   :approved_by: rl__committer[version==1]
+   :supported_by: rl__safety_manager[version==1]
+   :input: wp__requirements_stkh[version==1],
+           wp__requirements_feat[version==1],
+           wp__requirements_comp[version==1],
+           wp__requirements_feat_aou[version==1],
+           wp__requirements_comp_aou[version==1],
+           wp__platform_safety_manual[version==1],
+           wp__module_safety_manual[version==1]
+   :output: wp__issue_track_system[version==1], wp__requirements_inspect[version==1]
+   :contains: gd_chklst__req_inspection[version==1]
 
    The requirements are monitored and verified. The inspection shall be implemented as integral part of the review in version management tool.
 

--- a/process/process_areas/requirements_engineering/requirements_workproducts.rst
+++ b/process/process_areas/requirements_engineering/requirements_workproducts.rst
@@ -18,7 +18,8 @@ Requirements Engineering Work Products
 .. workproduct:: Stakeholder Requirements
    :id: wp__requirements_stkh
    :status: valid
-   :complies: std_wp__iso26262__system_651, std_wp__isosae21434__development_1051
+   :version: 1
+   :complies: std_wp__iso26262__system_651[version==1], std_wp__isosae21434__development_1051[version==1]
    :tags: doc_lifecycle_model_3
 
    Technical requirements from a stakeholder viewpoint on SW-platform level, contain "assumed Technical Safety Requirements" in SW-Platform SEooC development.
@@ -26,7 +27,8 @@ Requirements Engineering Work Products
 .. workproduct:: Feature Requirements
    :id: wp__requirements_feat
    :status: valid
-   :complies: std_wp__iso26262__software_651, std_wp__isosae21434__development_1051
+   :version: 1
+   :complies: std_wp__iso26262__software_651[version==1], std_wp__isosae21434__development_1051[version==1]
    :tags: doc_lifecycle_model_3
 
    Feature requirements describe in a more detailed way the functionality which will fulfill a set of stakeholder requirements. A "feature" itself represents a set of requirements. It describes the interaction of the components to form a feature. It shall also be the basis for integration testing on platform level.
@@ -34,7 +36,12 @@ Requirements Engineering Work Products
 .. workproduct:: Component Requirements
    :id: wp__requirements_comp
    :status: valid
-   :complies: std_wp__iso26262__software_651, std_wp__isopas8926__4521, std_wp__iso26262__analysis_651, std_wp__iso26262__software_app_c_51, std_wp__isosae21434__development_1051
+   :version: 1
+   :complies: std_wp__iso26262__software_651[version==1],
+              std_wp__isopas8926__4521[version==1],
+              std_wp__iso26262__analysis_651[version==1],
+              std_wp__iso26262__software_app_c_51[version==1],
+              std_wp__isosae21434__development_1051[version==1]
    :tags: doc_lifecycle_model_3
 
    SW Requirements for components, broken down from feature requirements to the realizing component. These include configuration specification.
@@ -42,7 +49,8 @@ Requirements Engineering Work Products
 .. workproduct:: SW-Platform Assumptions of Use
    :id: wp__requirements_sw_platform_aou
    :status: valid
-   :complies: std_wp__iso26262__software_651, std_wp__isosae21434__development_1051, std_wp__isosae21434__development_1052
+   :version: 1
+   :complies: std_wp__iso26262__software_651[version==1], std_wp__isosae21434__development_1051[version==1], std_wp__isosae21434__development_1052[version==1]
    :tags: doc_lifecycle_model_3
 
    SW Safety Requirements for the user of the platform, exportable requirements for the user to integrate in their requirements management system.
@@ -50,7 +58,8 @@ Requirements Engineering Work Products
 .. workproduct:: Feature Assumptions of Use
    :id: wp__requirements_feat_aou
    :status: valid
-   :complies: std_wp__iso26262__software_651, std_wp__isosae21434__development_1051, std_wp__isosae21434__development_1052
+   :version: 1
+   :complies: std_wp__iso26262__software_651[version==1], std_wp__isosae21434__development_1051[version==1], std_wp__isosae21434__development_1052[version==1]
    :tags: doc_lifecycle_model_3
 
    SW Safety Requirements for the user of the feature, exportable requirements for the user to integrate in their req mgt system.
@@ -58,7 +67,11 @@ Requirements Engineering Work Products
 .. workproduct:: Component Assumptions of Use
    :id: wp__requirements_comp_aou
    :status: valid
-   :complies: std_wp__iso26262__software_651, std_wp__isopas8926__4521, std_wp__isosae21434__development_1051, std_wp__isosae21434__development_1052
+   :version: 1
+   :complies: std_wp__iso26262__software_651[version==1],
+              std_wp__isopas8926__4521[version==1],
+              std_wp__isosae21434__development_1051[version==1],
+              std_wp__isosae21434__development_1052[version==1]
    :tags: doc_lifecycle_model_3
 
    SW Safety Requirements for the user of the component, exportable requirements for the user to integrate in their req mgt system.
@@ -66,6 +79,7 @@ Requirements Engineering Work Products
 .. workproduct:: Process/Tool Requirements
    :id: wp__requirements_proc_tool
    :status: valid
+   :version: 1
    :tags: doc_lifecycle_model_2
 
    Process and Tool requirements describe activities needed to be executed in the development process either manually or automated (i.e. tool supported).
@@ -74,7 +88,8 @@ Requirements Engineering Work Products
 .. workproduct:: Requirements Inspection
    :id: wp__requirements_inspect
    :status: valid
-   :complies: std_wp__iso26262__software_653
+   :version: 1
+   :complies: std_wp__iso26262__software_653[version==1]
    :tags: doc_lifecycle_model_2
 
    Depends on requirements management tooling, expect text based requirements.

--- a/process/process_areas/safety_analysis/guidance/dfa_failure_initiators.rst
+++ b/process/process_areas/safety_analysis/guidance/dfa_failure_initiators.rst
@@ -20,7 +20,11 @@ DFA failure initiators
 .. gd_guidl:: DFA failure initiators
   :id: gd_guidl__dfa_failure_initiators
   :status: valid
-  :complies: std_req__iso26262__software_7411, std_req__iso26262__analysis_744, std_req__iso26262__software_748, std_req__iso26262__software_749
+  :version: 1
+  :complies: std_req__iso26262__software_7411[version==1],
+             std_req__iso26262__analysis_744[version==1],
+             std_req__iso26262__software_748[version==1],
+             std_req__iso26262__software_749[version==1]
 
 
 .. note:: Use all applicable failure initiators to ensure a structured analysis. If there are additional failure initiators needed, please enlarge the list of fault models.

--- a/process/process_areas/safety_analysis/guidance/dfa_templates.rst
+++ b/process/process_areas/safety_analysis/guidance/dfa_templates.rst
@@ -20,7 +20,17 @@ DFA Templates
 .. gd_temp:: Platform DFA Templates
    :id: gd_temp__plat_saf_dfa
    :status: valid
-   :complies: std_req__iso26262__software_7411, std_req__iso26262__analysis_741, std_req__iso26262__analysis_742, std_req__iso26262__analysis_743, std_req__iso26262__analysis_745, std_req__iso26262__analysis_746, std_req__iso26262__analysis_747, std_req__iso26262__analysis_748, std_req__iso26262__analysis_749, std_req__isopas8926__44432
+   :version: 1
+   :complies: std_req__iso26262__software_7411[version==1],
+              std_req__iso26262__analysis_741[version==1],
+              std_req__iso26262__analysis_742[version==1],
+              std_req__iso26262__analysis_743[version==1],
+              std_req__iso26262__analysis_745[version==1],
+              std_req__iso26262__analysis_746[version==1],
+              std_req__iso26262__analysis_747[version==1],
+              std_req__iso26262__analysis_748[version==1],
+              std_req__iso26262__analysis_749[version==1],
+              std_req__isopas8926__44432[version==1]
 
    For the content see here: :need:`doc__platform_dfa`
 
@@ -28,7 +38,17 @@ DFA Templates
 .. gd_temp:: Feature DFA Templates
    :id: gd_temp__feat_saf_dfa
    :status: valid
-   :complies: std_req__iso26262__software_7411, std_req__iso26262__analysis_741, std_req__iso26262__analysis_742, std_req__iso26262__analysis_743, std_req__iso26262__analysis_745, std_req__iso26262__analysis_746, std_req__iso26262__analysis_747, std_req__iso26262__analysis_748, std_req__iso26262__analysis_749, std_req__isopas8926__44432
+   :version: 1
+   :complies: std_req__iso26262__software_7411[version==1],
+              std_req__iso26262__analysis_741[version==1],
+              std_req__iso26262__analysis_742[version==1],
+              std_req__iso26262__analysis_743[version==1],
+              std_req__iso26262__analysis_745[version==1],
+              std_req__iso26262__analysis_746[version==1],
+              std_req__iso26262__analysis_747[version==1],
+              std_req__iso26262__analysis_748[version==1],
+              std_req__iso26262__analysis_749[version==1],
+              std_req__isopas8926__44432[version==1]
 
    For the content see here: `Feature DFA Template <https://eclipse-score.github.io/module_template/main/docs/features/feature_example/safety_analysis/dfa.html>`__
 
@@ -36,6 +56,16 @@ DFA Templates
 .. gd_temp:: Component DFA Templates
    :id: gd_temp__comp_saf_dfa
    :status: valid
-   :complies: std_req__iso26262__software_7411, std_req__iso26262__analysis_741, std_req__iso26262__analysis_742, std_req__iso26262__analysis_743, std_req__iso26262__analysis_745, std_req__iso26262__analysis_746, std_req__iso26262__analysis_747, std_req__iso26262__analysis_748, std_req__iso26262__analysis_749, std_req__isopas8926__44432
+   :version: 1
+   :complies: std_req__iso26262__software_7411[version==1],
+              std_req__iso26262__analysis_741[version==1],
+              std_req__iso26262__analysis_742[version==1],
+              std_req__iso26262__analysis_743[version==1],
+              std_req__iso26262__analysis_745[version==1],
+              std_req__iso26262__analysis_746[version==1],
+              std_req__iso26262__analysis_747[version==1],
+              std_req__iso26262__analysis_748[version==1],
+              std_req__iso26262__analysis_749[version==1],
+              std_req__isopas8926__44432[version==1]
 
    For the content see here: `Component DFA Template <https://eclipse-score.github.io/module_template/main/score/component_example/docs/safety_analysis/dfa.html>`__

--- a/process/process_areas/safety_analysis/guidance/fault_models_guideline.rst
+++ b/process/process_areas/safety_analysis/guidance/fault_models_guideline.rst
@@ -20,7 +20,8 @@ FMEA Fault Models
 .. gd_guidl:: FMEA Fault Models
   :id: gd_guidl__fault_models
   :status: valid
-  :complies: std_req__iso26262__software_7410, std_req__iso26262__analysis_846
+  :version: 1
+  :complies: std_req__iso26262__software_7410[version==1], std_req__iso26262__analysis_846[version==1]
 
   | Fault Model for sequence diagrams
 

--- a/process/process_areas/safety_analysis/guidance/fmea_templates.rst
+++ b/process/process_areas/safety_analysis/guidance/fmea_templates.rst
@@ -20,7 +20,20 @@ FMEA Templates
 .. gd_temp:: Feature FMEA Template
    :id: gd_temp__feat_saf_fmea
    :status: valid
-   :complies: std_req__iso26262__software_7410, std_req__iso26262__software_7412, std_req__iso26262__analysis_841, std_req__iso26262__analysis_842, std_req__iso26262__analysis_843, std_req__iso26262__analysis_844, std_req__iso26262__analysis_845, std_req__iso26262__analysis_846, std_req__iso26262__analysis_847, std_req__iso26262__analysis_848, std_req__iso26262__analysis_849, std_req__iso26262__analysis_8410, std_req__isopas8926__44431
+   :version: 1
+   :complies: std_req__iso26262__software_7410[version==1],
+              std_req__iso26262__software_7412[version==1],
+              std_req__iso26262__analysis_841[version==1],
+              std_req__iso26262__analysis_842[version==1],
+              std_req__iso26262__analysis_843[version==1],
+              std_req__iso26262__analysis_844[version==1],
+              std_req__iso26262__analysis_845[version==1],
+              std_req__iso26262__analysis_846[version==1],
+              std_req__iso26262__analysis_847[version==1],
+              std_req__iso26262__analysis_848[version==1],
+              std_req__iso26262__analysis_849[version==1],
+              std_req__iso26262__analysis_8410[version==1],
+              std_req__isopas8926__44431[version==1]
 
       For the content see here: `Feature FMEA Template <https://eclipse-score.github.io/module_template/main/docs/features/feature_example/safety_analysis/fmea.html>`__
 
@@ -28,6 +41,19 @@ FMEA Templates
 .. gd_temp:: Component FMEA Template
    :id: gd_temp__comp_saf_fmea
    :status: valid
-   :complies: std_req__iso26262__software_7410, std_req__iso26262__software_7412, std_req__iso26262__analysis_841, std_req__iso26262__analysis_842, std_req__iso26262__analysis_843, std_req__iso26262__analysis_844, std_req__iso26262__analysis_845, std_req__iso26262__analysis_846, std_req__iso26262__analysis_847, std_req__iso26262__analysis_848, std_req__iso26262__analysis_849, std_req__iso26262__analysis_8410, std_req__isopas8926__44431
+   :version: 1
+   :complies: std_req__iso26262__software_7410[version==1],
+              std_req__iso26262__software_7412[version==1],
+              std_req__iso26262__analysis_841[version==1],
+              std_req__iso26262__analysis_842[version==1],
+              std_req__iso26262__analysis_843[version==1],
+              std_req__iso26262__analysis_844[version==1],
+              std_req__iso26262__analysis_845[version==1],
+              std_req__iso26262__analysis_846[version==1],
+              std_req__iso26262__analysis_847[version==1],
+              std_req__iso26262__analysis_848[version==1],
+              std_req__iso26262__analysis_849[version==1],
+              std_req__iso26262__analysis_8410[version==1],
+              std_req__isopas8926__44431[version==1]
 
       For the content see here: `Component FMEA Template <https://eclipse-score.github.io/module_template/main/score/component_example/docs/safety_analysis/fmea.html>`__

--- a/process/process_areas/safety_analysis/guidance/safety_analysis_checklist.rst
+++ b/process/process_areas/safety_analysis/guidance/safety_analysis_checklist.rst
@@ -19,8 +19,13 @@ Safety Analysis Checklist
 .. gd_chklst:: Safety Analysis Checklist Template
    :id: gd_chklst__safety_analysis
    :status: valid
+   :version: 1
    :tags: safety_analysis
-   :complies: std_req__iso26262__management_64101, std_req__iso26262__management_64102, std_req__iso26262__management_64103, std_req__iso26262__management_64104, std_req__iso26262__management_64105
+   :complies: std_req__iso26262__management_64101[version==1],
+              std_req__iso26262__management_64102[version==1],
+              std_req__iso26262__management_64103[version==1],
+              std_req__iso26262__management_64104[version==1],
+              std_req__iso26262__management_64105[version==1]
 
 
     For the content see here:

--- a/process/process_areas/safety_analysis/guidance/safety_analysis_guideline.rst
+++ b/process/process_areas/safety_analysis/guidance/safety_analysis_guideline.rst
@@ -19,7 +19,27 @@ Safety Analysis Guidelines
 .. gd_guidl:: Safety Analysis (DFA and FMEA) Guideline
    :id: gd_guidl__safety_analysis
    :status: valid
-   :complies: std_req__iso26262__analysis_741, std_req__iso26262__analysis_742, std_req__iso26262__analysis_743, std_req__iso26262__analysis_745, std_req__iso26262__analysis_746, std_req__iso26262__analysis_747, std_req__iso26262__analysis_748, std_req__iso26262__analysis_749, std_req__iso26262__analysis_841, std_req__iso26262__analysis_842, std_req__iso26262__analysis_843, std_req__iso26262__analysis_844, std_req__iso26262__analysis_845, std_req__iso26262__analysis_846, std_req__iso26262__analysis_847, std_req__iso26262__analysis_848, std_req__iso26262__analysis_849, std_req__iso26262__analysis_8410, std_req__isopas8926__44431, std_req__isopas8926__44432
+   :version: 1
+   :complies: std_req__iso26262__analysis_741[version==1],
+              std_req__iso26262__analysis_742[version==1],
+              std_req__iso26262__analysis_743[version==1],
+              std_req__iso26262__analysis_745[version==1],
+              std_req__iso26262__analysis_746[version==1],
+              std_req__iso26262__analysis_747[version==1],
+              std_req__iso26262__analysis_748[version==1],
+              std_req__iso26262__analysis_749[version==1],
+              std_req__iso26262__analysis_841[version==1],
+              std_req__iso26262__analysis_842[version==1],
+              std_req__iso26262__analysis_843[version==1],
+              std_req__iso26262__analysis_844[version==1],
+              std_req__iso26262__analysis_845[version==1],
+              std_req__iso26262__analysis_846[version==1],
+              std_req__iso26262__analysis_847[version==1],
+              std_req__iso26262__analysis_848[version==1],
+              std_req__iso26262__analysis_849[version==1],
+              std_req__iso26262__analysis_8410[version==1],
+              std_req__isopas8926__44431[version==1],
+              std_req__isopas8926__44432[version==1]
 
 This document describes the general guidances for Safety Analysis (DFA and FMEA) based on the concept which is defined :need:`Safety Analysis Concept<doc_concept__safety_analysis>`.
 Use the Platform DFA as an input so that general Safety Mechanisms are only defined once and not in every single Safety Analysis.
@@ -116,6 +136,7 @@ find possible failures. Therefore we need a mitigation.
       :mitigation_issue:
       :sufficient: yes
       :status: valid
+      :version: 1
 
     If the message is not received by the feature it will be unavailable for the user. This has to be detected by the User because
     the feature can't detect if it's not called. This requirement is addressed by the AoU requirement aou_req__Mab__func_call_not_received.
@@ -142,6 +163,7 @@ In the static view of the example could be seen that component 1 uses component 
       :mitigation_issue:
       :sufficient: yes
       :status: valid
+      :version: 1
 
     The feature shall detect and report data corruption.
 
@@ -182,6 +204,7 @@ Additionally in the static view we see Component 4 is a library used by Componen
       :mitigation_issue:
       :sufficient: yes
       :status: valid
+      :version: 1
 
       The allocation of the memory of Component 4 is managed by the memory management.
 
@@ -197,7 +220,11 @@ Tailoring
 .. gd_guidl:: Analysis Tailored
    :id: gd_guidl__analysis_tailored
    :status: valid
-   :complies: std_req__iso26262__analysis_641, std_req__iso26262__analysis_642, std_req__iso26262__analysis_643, std_req__iso26262__analysis_644
+   :version: 1
+   :complies: std_req__iso26262__analysis_641[version==1],
+              std_req__iso26262__analysis_642[version==1],
+              std_req__iso26262__analysis_643[version==1],
+              std_req__iso26262__analysis_644[version==1]
 
    This part of the guideline links to all the requirements which are not fulfilled by the
    safety analysis process. Make sure these are tailored out in the safety/security/quality plans

--- a/process/process_areas/safety_analysis/guidance/safety_analysis_process_reqs.rst
+++ b/process/process_areas/safety_analysis/guidance/safety_analysis_process_reqs.rst
@@ -22,9 +22,10 @@ Safety Analysis Process Requirements
 .. gd_req:: Safety Analysis Structure
    :id: gd_req__saf_structure
    :status: valid
+   :version: 1
    :tags: done_automation, safety_analysis
-   :satisfies: wf__analyse_platform_featarch, wf__analyse_featarch, wf__analyse_comparch
-   :complies: std_req__iso26262__support_6432
+   :satisfies: wf__analyse_platform_featarch[version==1], wf__analyse_featarch[version==1], wf__analyse_comparch[version==1]
+   :complies: std_req__iso26262__support_6432[version==1]
 
    Safety Analysis (FMEA and DFA) shall be hierarchically grouped into different levels.
 
@@ -42,9 +43,10 @@ Process Safety Analysis Attributes
 .. gd_req:: Safety Analysis attribute: UID
    :id: gd_req__saf_attr_uid
    :status: valid
+   :version: 1
    :tags: done_automation, attribute, mandatory
-   :satisfies: wf__analyse_platform_featarch, wf__analyse_featarch, wf__analyse_comparch
-   :complies: std_req__iso26262__support_6425, std_req__iso26262__support_6432
+   :satisfies: wf__analyse_platform_featarch[version==1], wf__analyse_featarch[version==1], wf__analyse_comparch[version==1]
+   :complies: std_req__iso26262__support_6425[version==1], std_req__iso26262__support_6432[version==1]
 
    Each Safety Analysis shall have a unique ID. It shall be in a format which is also human readable and consists of
 
@@ -57,18 +59,20 @@ Process Safety Analysis Attributes
 .. gd_req:: Safety Analysis attribute: title
    :id: gd_req__saf_attr_title
    :status: valid
+   :version: 1
    :tags: done_automation, attribute, mandatory
-   :satisfies: wf__analyse_platform_featarch, wf__analyse_featarch, wf__analyse_comparch
-   :complies: std_req__iso26262__support_6424
+   :satisfies: wf__analyse_platform_featarch[version==1], wf__analyse_featarch[version==1], wf__analyse_comparch[version==1]
+   :complies: std_req__iso26262__support_6424[version==1]
 
    The title of the Safety Analysis shall provide a short summary of the description
 
 .. gd_req:: Safety Analysis attribute: mitigated by
    :id: gd_req__saf_attr_mitigated_by
    :status: valid
+   :version: 1
    :tags: done_automation, attribute, optional
-   :satisfies: wf__analyse_platform_featarch, wf__analyse_featarch, wf__analyse_comparch
-   :complies: std_req__iso26262__analysis_844, std_req__iso26262__analysis_746, std_req__iso26262__analysis_747
+   :satisfies: wf__analyse_platform_featarch[version==1], wf__analyse_featarch[version==1], wf__analyse_comparch[version==1]
+   :complies: std_req__iso26262__analysis_844[version==1], std_req__iso26262__analysis_746[version==1], std_req__iso26262__analysis_747[version==1]
 
    Each violation shall have an associated mitigation (e.g. prevention, detection or mitigation) or AoU.
    If mitigation has not yet been implemented, do not use this option.
@@ -77,18 +81,23 @@ Process Safety Analysis Attributes
 .. gd_req:: Safety Analysis attribute: mitigation issue
    :id: gd_req__saf_attr_mitigation_issue
    :status: valid
+   :version: 1
    :tags: done_automation, attribute, optional
-   :satisfies: wf__analyse_platform_featarch, wf__analyse_featarch, wf__analyse_comparch
-   :complies: std_req__iso26262__analysis_844, std_req__iso26262__analysis_746, std_req__iso26262__analysis_747
+   :satisfies: wf__analyse_platform_featarch[version==1], wf__analyse_featarch[version==1], wf__analyse_comparch[version==1]
+   :complies: std_req__iso26262__analysis_844[version==1], std_req__iso26262__analysis_746[version==1], std_req__iso26262__analysis_747[version==1]
 
    If a new mitigation (e.g. prevention, detection or mitigation) is needed, link to the issue and keep status sufficient == no until mitigation is sufficient.
 
 .. gd_req:: Safety Analysis attribute: sufficient
    :id: gd_req__saf_attr_sufficient
    :status: valid
+   :version: 1
    :tags: done_automation, attribute, mandatory
-   :satisfies: wf__analyse_platform_featarch, wf__analyse_featarch, wf__analyse_comparch
-   :complies: std_req__iso26262__analysis_848, std_req__iso26262__analysis_749, std_req__isopas8926__44431, std_req__isopas8926__44432
+   :satisfies: wf__analyse_platform_featarch[version==1], wf__analyse_featarch[version==1], wf__analyse_comparch[version==1]
+   :complies: std_req__iso26262__analysis_848[version==1],
+              std_req__iso26262__analysis_749[version==1],
+              std_req__isopas8926__44431[version==1],
+              std_req__isopas8926__44432[version==1]
 
    The mitigation(s) (e.g. prevention, detection or mitigation) shall be rated as sufficient with <yes> or <no>.
    A mitigation can only be sufficient if a mitigation is linked via the attribute mitigation.
@@ -96,9 +105,10 @@ Process Safety Analysis Attributes
 .. gd_req:: Safety Analysis content: argument
    :id: gd_req__saf_argument
    :status: valid
+   :version: 1
    :tags: done_automation, attribute, mandatory
-   :satisfies: wf__analyse_platform_featarch, wf__analyse_featarch, wf__analyse_comparch
-   :complies: std_req__iso26262__analysis_848, std_req__iso26262__analysis_749, std_req__isopas8926__44433
+   :satisfies: wf__analyse_platform_featarch[version==1], wf__analyse_featarch[version==1], wf__analyse_comparch[version==1]
+   :complies: std_req__iso26262__analysis_848[version==1], std_req__iso26262__analysis_749[version==1], std_req__isopas8926__44433[version==1]
 
    The argument shall describe why the mitigation (e.g. prevention, detection or mitigation) is sufficient or not. If it is not sufficient, the argument shall describe how the mitigation
    can be improved to achieve sufficiency. The argument shall be written in the content.
@@ -106,36 +116,43 @@ Process Safety Analysis Attributes
 .. gd_req:: Safety Analysis attribute: status
    :id: gd_req__saf_attr_status
    :status: valid
+   :version: 1
    :tags: done_automation, attribute, mandatory
-   :satisfies: wf__analyse_platform_featarch, wf__analyse_featarch, wf__analyse_comparch
-   :complies: std_req__iso26262__analysis_848, std_req__iso26262__analysis_749, std_req__isopas8926__44431, std_req__isopas8926__44432
+   :satisfies: wf__analyse_platform_featarch[version==1], wf__analyse_featarch[version==1], wf__analyse_comparch[version==1]
+   :complies: std_req__iso26262__analysis_848[version==1],
+              std_req__iso26262__analysis_749[version==1],
+              std_req__isopas8926__44431[version==1],
+              std_req__isopas8926__44432[version==1]
 
    Each Safety Analysis shall have a status which can be either "valid" or "invalid".
 
 .. gd_req:: Safety Analysis attribute: failure effect
    :id: gd_req__saf_attr_feffect
    :status: valid
+   :version: 1
    :tags: done_automation, attribute, mandatory
-   :satisfies: wf__analyse_platform_featarch, wf__analyse_featarch, wf__analyse_comparch
-   :complies: std_req__iso26262__analysis_742
+   :satisfies: wf__analyse_platform_featarch[version==1], wf__analyse_featarch[version==1], wf__analyse_comparch[version==1]
+   :complies: std_req__iso26262__analysis_742[version==1]
 
    Every Safety Analysis shall have a short description of the failure effect (e.g. failure lead to an unintended actuation of the analysed element)
 
 .. gd_req:: Safety Analysis attribute: safety relevant
    :id: gd_req__saf_attr_safety_relevant
    :status: valid
+   :version: 1
    :tags: done_automation, attribute, optional
-   :satisfies: wf__analyse_platform_featarch, wf__analyse_featarch, wf__analyse_comparch
-   :complies: std_req__iso26262__analysis_742
+   :satisfies: wf__analyse_platform_featarch[version==1], wf__analyse_featarch[version==1], wf__analyse_comparch[version==1]
+   :complies: std_req__iso26262__analysis_742[version==1]
 
    Each Safety Analysis may indicate whether the analysed failure is safety relevant. The value shall be either <yes> or <no>.
 
 .. gd_req:: FMEA attribute: failure root cause
    :id: gd_req__saf_attr_failure_root_cause
    :status: valid
+   :version: 1
    :tags: done_automation, attribute, optional
-   :satisfies: wf__analyse_featarch, wf__analyse_comparch
-   :complies: std_req__iso26262__analysis_742
+   :satisfies: wf__analyse_featarch[version==1], wf__analyse_comparch[version==1]
+   :complies: std_req__iso26262__analysis_742[version==1]
 
    Each FMEA may provide a short description of the root cause of the failure.
 
@@ -147,63 +164,70 @@ Safety Analysis Linkage
 .. gd_req:: Safety Analysis Linkage check
    :id: gd_req__saf_linkage_check
    :status: valid
+   :version: 1
    :tags: done_automation, attribute, automated
-   :satisfies: wf__analyse_platform_featarch, wf__analyse_featarch, wf__analyse_comparch
-   :complies: std_req__iso26262__analysis_842, std_req__iso26262__software_7410, std_req__iso26262__software_7411
+   :satisfies: wf__analyse_platform_featarch[version==1], wf__analyse_featarch[version==1], wf__analyse_comparch[version==1]
+   :complies: std_req__iso26262__analysis_842[version==1], std_req__iso26262__software_7410[version==1], std_req__iso26262__software_7411[version==1]
 
    Safety Analysis shall be linked to the architecture view on the corresponding level via the attribute violates.
 
 .. gd_req:: Safety Analysis Linkage
    :id: gd_req__saf_linkage
    :status: valid
+   :version: 1
    :tags: done_automation, attribute, automated
-   :satisfies: wf__analyse_platform_featarch, wf__analyse_featarch, wf__analyse_comparch
-   :complies: std_req__iso26262__analysis_842, std_req__iso26262__software_7410, std_req__iso26262__software_7411
+   :satisfies: wf__analyse_platform_featarch[version==1], wf__analyse_featarch[version==1], wf__analyse_comparch[version==1]
+   :complies: std_req__iso26262__analysis_842[version==1], std_req__iso26262__software_7410[version==1], std_req__iso26262__software_7411[version==1]
 
    Each Safety Analysis shall be automatically linked (inverse direction) to the corresponding architecture view via the "violates by" linkage.
 
 .. gd_req:: Safety Analysis attribute: check Requirements linkage
    :id: gd_req__saf_attr_requirements_check
    :status: valid
+   :version: 1
    :tags: done_automation, attribute, automated
-   :satisfies: wf__analyse_platform_featarch, wf__analyse_featarch, wf__analyse_comparch
-   :complies: std_req__iso26262__analysis_842, std_req__iso26262__software_7410, std_req__iso26262__software_7411
+   :satisfies: wf__analyse_platform_featarch[version==1], wf__analyse_featarch[version==1], wf__analyse_comparch[version==1]
+   :complies: std_req__iso26262__analysis_842[version==1], std_req__iso26262__software_7410[version==1], std_req__iso26262__software_7411[version==1]
 
    Safety Analysis shall be linked to a requirement on the corresponding level via the attribute "mitigated by".
 
 .. gd_req:: Safety Analysis attribute: Requirements linkage
    :id: gd_req__saf_attr_requirements
    :status: valid
+   :version: 1
    :tags: done_automation, attribute, automated
-   :satisfies: wf__analyse_platform_featarch, wf__analyse_featarch, wf__analyse_comparch
-   :complies: std_req__iso26262__analysis_842, std_req__iso26262__software_7410, std_req__iso26262__software_7411
+   :satisfies: wf__analyse_platform_featarch[version==1], wf__analyse_featarch[version==1], wf__analyse_comparch[version==1]
+   :complies: std_req__iso26262__analysis_842[version==1], std_req__iso26262__software_7410[version==1], std_req__iso26262__software_7411[version==1]
 
    Each Safety Analysis shall be automatically linked to the corresponding Safety Requirement via the mitigates linkage.
 
 .. gd_req:: Safety Analysis attribute: link to Aou
    :id: gd_req__saf_attr_aou
    :status: valid
+   :version: 1
    :tags: done_automation, attribute, automated
-   :satisfies: wf__analyse_platform_featarch, wf__analyse_featarch, wf__analyse_comparch
-   :complies: std_req__iso26262__analysis_845
+   :satisfies: wf__analyse_platform_featarch[version==1], wf__analyse_featarch[version==1], wf__analyse_comparch[version==1]
+   :complies: std_req__iso26262__analysis_845[version==1]
 
    It shall be possible to link Aou.
 
 .. gd_req:: Safety Analysis attribute: versioning
    :id: gd_req__saf_attr_ver
    :status: valid
+   :version: 1
    :tags: prio_2_automation, attribute, automated
-   :satisfies: wf__analyse_platform_featarch, wf__analyse_featarch, wf__analyse_comparch
-   :complies: std_req__iso26262__support_6425, std_req__iso26262__support_6434
+   :satisfies: wf__analyse_platform_featarch[version==1], wf__analyse_featarch[version==1], wf__analyse_comparch[version==1]
+   :complies: std_req__iso26262__support_6425[version==1], std_req__iso26262__support_6434[version==1]
 
    It shall be possible to detect any differences in mandatory attributes compared to the versioning: :need:`gd_req__saf_attr_mandatory`
 
 .. gd_req:: Safety Analysis Linkage status check
    :id: gd_req__saf_linkage_status_check
    :status: valid
+   :version: 1
    :tags: done_automation, attribute, automated
-   :satisfies: wf__analyse_platform_featarch, wf__analyse_featarch, wf__analyse_comparch
-   :complies: std_req__iso26262__analysis_842, std_req__iso26262__software_7410, std_req__iso26262__software_7411
+   :satisfies: wf__analyse_platform_featarch[version==1], wf__analyse_featarch[version==1], wf__analyse_comparch[version==1]
+   :complies: std_req__iso26262__analysis_842[version==1], std_req__iso26262__software_7410[version==1], std_req__iso26262__software_7411[version==1]
 
    It shall be checked that Safety Analysis can only be linked against valid safety elements (architecture view, requirement, AoU). A valid safety element has the attribute 'status == valid' and safety != QM.
 
@@ -215,9 +239,10 @@ Safety Analysis Checks
 .. gd_req:: Safety Analysis mandatory attributes provided
    :id: gd_req__saf_attr_mandatory
    :status: valid
+   :version: 1
    :tags: done_automation, attribute, check
-   :satisfies: wf__analyse_platform_featarch, wf__analyse_featarch, wf__analyse_comparch
-   :complies: std_req__iso26262__analysis_848, std_req__iso26262__analysis_749
+   :satisfies: wf__analyse_platform_featarch[version==1], wf__analyse_featarch[version==1], wf__analyse_comparch[version==1]
+   :complies: std_req__iso26262__analysis_848[version==1], std_req__iso26262__analysis_749[version==1]
 
    It shall be checked if all mandatory attributes for each Safety Analysis are provided by the user. For all Safety Analysis following attributes shall be mandatory:
 
@@ -231,9 +256,10 @@ Safety Analysis Checks
 .. gd_req:: Safety Analysis linkage safety
    :id: gd_req__saf_linkage_safety
    :status: valid
+   :version: 1
    :tags: done_automation, attribute, check
-   :satisfies: wf__analyse_platform_featarch, wf__analyse_featarch, wf__analyse_comparch
-   :complies: std_req__iso26262__analysis_848, std_req__iso26262__analysis_749
+   :satisfies: wf__analyse_platform_featarch[version==1], wf__analyse_featarch[version==1], wf__analyse_comparch[version==1]
+   :complies: std_req__iso26262__analysis_848[version==1], std_req__iso26262__analysis_749[version==1]
 
    It shall be checked that Safety Analysis (DFA and FMEA) can only be linked via mitigate_by against
    <Feature | Component | AoU> Requirements with at least one Requirement with the same ASIL or with a higher ASIL
@@ -243,9 +269,13 @@ Safety Analysis Checks
 .. gd_req:: Safety Analysis finalization check
    :id: gd_req__saf_finalization_check
    :status: valid
+   :version: 1
    :tags: prio_2_automation, attribute, automated
-   :satisfies: wf__analyse_platform_featarch, wf__analyse_featarch, wf__analyse_comparch
-   :complies: std_req__iso26262__analysis_848, std_req__iso26262__analysis_749, std_req__isopas8926__44431, std_req__isopas8926__44432
+   :satisfies: wf__analyse_platform_featarch[version==1], wf__analyse_featarch[version==1], wf__analyse_comparch[version==1]
+   :complies: std_req__iso26262__analysis_848[version==1],
+              std_req__iso26262__analysis_749[version==1],
+              std_req__isopas8926__44431[version==1],
+              std_req__isopas8926__44432[version==1]
 
     It shall be checked if all artifacts of the analysis are "valid" and "sufficient".
 
@@ -255,9 +285,10 @@ DFA Process Requirements
 .. gd_req:: DFA attribute: failure ID
    :id: gd_req__saf_attr_failure_id
    :status: valid
+   :version: 1
    :tags: done_automation, attribute, mandatory
-   :satisfies: wf__analyse_platform_featarch, wf__analyse_featarch, wf__analyse_comparch
-   :complies: std_req__iso26262__support_6425, std_req__iso26262__support_6432
+   :satisfies: wf__analyse_platform_featarch[version==1], wf__analyse_featarch[version==1], wf__analyse_comparch[version==1]
+   :complies: std_req__iso26262__support_6425[version==1], std_req__iso26262__support_6432[version==1]
 
    Each DFA shall have a failure ID. The failure ID is used to identify the related fault <:need:`gd_guidl__dfa_failure_initiators`>.
    The failure ID links to the corresponding failure initiator which describes how a potential violation can occur.
@@ -269,9 +300,10 @@ FMEA Process Requirements
 .. gd_req:: FMEA attribute: fault ID
    :id: gd_req__saf_attr_fault_id
    :status: valid
+   :version: 1
    :tags: done_automation, attribute, mandatory
-   :satisfies: wf__analyse_featarch, wf__analyse_comparch
-   :complies: std_req__iso26262__analysis_848
+   :satisfies: wf__analyse_featarch[version==1], wf__analyse_comparch[version==1]
+   :complies: std_req__iso26262__analysis_848[version==1]
 
    Each FMEA shall have a fault ID. The fault ID is used to identify the related fault <:need:`gd_guidl__fault_models`>.
    The fault ID links to the corresponding fault which describes how a potential violation can occur.

--- a/process/process_areas/safety_analysis/safety_analysis_concept.rst
+++ b/process/process_areas/safety_analysis/safety_analysis_concept.rst
@@ -18,6 +18,7 @@ Concept Description
 .. doc_concept:: Safety Analysis Concept
    :id: doc_concept__safety_analysis
    :status: valid
+   :version: 1
    :tags: safety_analysis
 
 This section discusses a concept for Safety Analysis. As methods for Safety Analysis are used DFA (Dependent Failure Analysis)

--- a/process/process_areas/safety_analysis/safety_analysis_getstrt.rst
+++ b/process/process_areas/safety_analysis/safety_analysis_getstrt.rst
@@ -18,6 +18,7 @@ Getting Started
 .. doc_getstrt:: Getting Started on Safety Analysis (FMEA and DFA)
    :id: doc_getstrt__safety_analysis
    :status: valid
+   :version: 1
    :tags: safety_analysis
 
 

--- a/process/process_areas/safety_analysis/safety_analysis_roles.rst
+++ b/process/process_areas/safety_analysis/safety_analysis_roles.rst
@@ -18,7 +18,8 @@ Roles
 .. role:: Safety Engineer
    :id: rl__safety_engineer
    :status: valid
-   :contains: rl__committer
+   :version: 1
+   :contains: rl__committer[version==1]
 
    The Safety Engineer is responsible for the Safety Analysis (FMEA and DFA) in the project. There might be several analysis
    on different levels (e.g., Platform DFA, Feature and Component FMEA/DFA).

--- a/process/process_areas/safety_analysis/safety_analysis_workflow.rst
+++ b/process/process_areas/safety_analysis/safety_analysis_workflow.rst
@@ -25,14 +25,15 @@ Safety Analysis is used as a umbrella term for the methods FMEA (Failure Modes a
 .. workflow:: Analyze Platform Feature Architecture
    :id: wf__analyse_platform_featarch
    :status: valid
+   :version: 1
    :tags: safety_analysis
-   :responsible: rl__safety_engineer
-   :approved_by: rl__safety_manager
-   :supported_by: rl__contributor, rl__committer, rl__security_manager
-   :input: wp__requirements_feat, wp__feature_arch, wp__issue_track_system
-   :output: wp__platform_dfa
-   :contains: gd_guidl__dfa_failure_initiators, gd_temp__plat_saf_dfa
-   :has: doc_concept__safety_analysis, doc_getstrt__safety_analysis
+   :responsible: rl__safety_engineer[version==1]
+   :approved_by: rl__safety_manager[version==1]
+   :supported_by: rl__contributor[version==1], rl__committer[version==1], rl__security_manager[version==1]
+   :input: wp__requirements_feat[version==1], wp__feature_arch[version==1], wp__issue_track_system[version==1]
+   :output: wp__platform_dfa[version==1]
+   :contains: gd_guidl__dfa_failure_initiators[version==1], gd_temp__plat_saf_dfa[version==1]
+   :has: doc_concept__safety_analysis[version==1], doc_getstrt__safety_analysis[version==1]
 
    | With a platform DFA the potential common usage of features shall be analysed. It shall be used as an input for all other DFA's.
    | There will be only one platform DFA.
@@ -40,56 +41,84 @@ Safety Analysis is used as a umbrella term for the methods FMEA (Failure Modes a
 .. workflow:: Analyse Feature Architecture
    :id: wf__analyse_featarch
    :status: valid
+   :version: 1
    :tags: safety_analysis
-   :responsible: rl__safety_engineer
-   :approved_by: rl__safety_manager
-   :supported_by: rl__contributor, rl__committer, rl__security_manager
-   :input: wp__requirements_feat, wp__feature_arch, wp__issue_track_system
-   :output: wp__feature_fmea, wp__feature_dfa
-   :contains: gd_guidl__dfa_failure_initiators, gd_temp__feat_saf_dfa, gd_guidl__fault_models, gd_temp__feat_saf_fmea
-   :has: doc_concept__safety_analysis, doc_getstrt__safety_analysis
+   :responsible: rl__safety_engineer[version==1]
+   :approved_by: rl__safety_manager[version==1]
+   :supported_by: rl__contributor[version==1], rl__committer[version==1], rl__security_manager[version==1]
+   :input: wp__requirements_feat[version==1], wp__feature_arch[version==1], wp__issue_track_system[version==1]
+   :output: wp__feature_fmea[version==1], wp__feature_dfa[version==1]
+   :contains: gd_guidl__dfa_failure_initiators[version==1],
+              gd_temp__feat_saf_dfa[version==1],
+              gd_guidl__fault_models[version==1],
+              gd_temp__feat_saf_fmea[version==1]
+   :has: doc_concept__safety_analysis[version==1], doc_getstrt__safety_analysis[version==1]
 
    | The FMEA and DFA for the feature is executed.
 
 .. workflow:: Analyse Component Architecture
    :id: wf__analyse_comparch
    :status: valid
+   :version: 1
    :tags: safety_analysis
-   :responsible: rl__safety_engineer
-   :approved_by: rl__safety_manager
-   :supported_by: rl__contributor, rl__committer, rl__security_manager
-   :input:  wp__requirements_comp, wp__component_arch, wp__issue_track_system
-   :output: wp__sw_component_fmea, wp__sw_component_dfa
-   :contains: gd_guidl__dfa_failure_initiators, gd_temp__comp_saf_dfa, gd_guidl__fault_models, gd_temp__comp_saf_fmea
-   :has: doc_concept__safety_analysis, doc_getstrt__safety_analysis
+   :responsible: rl__safety_engineer[version==1]
+   :approved_by: rl__safety_manager[version==1]
+   :supported_by: rl__contributor[version==1], rl__committer[version==1], rl__security_manager[version==1]
+   :input: wp__requirements_comp[version==1], wp__component_arch[version==1], wp__issue_track_system[version==1]
+   :output: wp__sw_component_fmea[version==1], wp__sw_component_dfa[version==1]
+   :contains: gd_guidl__dfa_failure_initiators[version==1],
+              gd_temp__comp_saf_dfa[version==1],
+              gd_guidl__fault_models[version==1],
+              gd_temp__comp_saf_fmea[version==1]
+   :has: doc_concept__safety_analysis[version==1], doc_getstrt__safety_analysis[version==1]
 
    | The FMEA and DFA for the component is executed.
 
 .. workflow:: Monitor FMEA and DFA
    :id: wf__mr_saf_analyses_dfa
    :status: valid
+   :version: 1
    :tags: safety_analysis
-   :responsible: rl__safety_engineer
-   :approved_by: rl__safety_manager
-   :supported_by: rl__contributor, rl__committer, rl__security_manager
-   :input: wp__feature_fmea, wp__feature_dfa, wp__sw_component_fmea, wp__sw_component_dfa
-   :output: wp__verification_platform_ver_report, wp__issue_track_system, wp__verification_module_ver_report
-   :contains: gd_guidl__dfa_failure_initiators, gd_temp__feat_saf_dfa, gd_temp__comp_saf_dfa, gd_guidl__fault_models, gd_temp__feat_saf_fmea, gd_temp__comp_saf_fmea
-   :has: doc_concept__safety_analysis, doc_getstrt__safety_analysis
+   :responsible: rl__safety_engineer[version==1]
+   :approved_by: rl__safety_manager[version==1]
+   :supported_by: rl__contributor[version==1], rl__committer[version==1], rl__security_manager[version==1]
+   :input: wp__feature_fmea[version==1],
+           wp__feature_dfa[version==1],
+           wp__sw_component_fmea[version==1],
+           wp__sw_component_dfa[version==1]
+   :output: wp__verification_platform_ver_report[version==1], wp__issue_track_system[version==1], wp__verification_module_ver_report[version==1]
+   :contains: gd_guidl__dfa_failure_initiators[version==1],
+              gd_temp__feat_saf_dfa[version==1],
+              gd_temp__comp_saf_dfa[version==1],
+              gd_guidl__fault_models[version==1],
+              gd_temp__feat_saf_fmea[version==1],
+              gd_temp__comp_saf_fmea[version==1]
+   :has: doc_concept__safety_analysis[version==1], doc_getstrt__safety_analysis[version==1]
 
    | The FMEA and DFA are monitored.
 
 .. workflow:: Verify FMEA and DFA
    :id: wf__vy_saf_analyses_dfa
    :status: valid
+   :version: 1
    :tags: safety_analysis
-   :responsible: rl__safety_engineer
-   :approved_by: rl__safety_manager
-   :supported_by: rl__contributor, rl__committer, rl__security_manager
-   :input: wp__platform_dfa, wp__feature_fmea, wp__feature_dfa, wp__sw_component_fmea, wp__sw_component_dfa
-   :output: wp__verification_platform_ver_report, wp__verification_module_ver_report
-   :contains: gd_guidl__dfa_failure_initiators, gd_temp__feat_saf_dfa, gd_temp__comp_saf_dfa, gd_guidl__fault_models, gd_temp__feat_saf_fmea, gd_temp__comp_saf_fmea, gd_chklst__safety_analysis
-   :has: doc_concept__safety_analysis, doc_getstrt__safety_analysis
+   :responsible: rl__safety_engineer[version==1]
+   :approved_by: rl__safety_manager[version==1]
+   :supported_by: rl__contributor[version==1], rl__committer[version==1], rl__security_manager[version==1]
+   :input: wp__platform_dfa[version==1],
+           wp__feature_fmea[version==1],
+           wp__feature_dfa[version==1],
+           wp__sw_component_fmea[version==1],
+           wp__sw_component_dfa[version==1]
+   :output: wp__verification_platform_ver_report[version==1], wp__verification_module_ver_report[version==1]
+   :contains: gd_guidl__dfa_failure_initiators[version==1],
+              gd_temp__feat_saf_dfa[version==1],
+              gd_temp__comp_saf_dfa[version==1],
+              gd_guidl__fault_models[version==1],
+              gd_temp__feat_saf_fmea[version==1],
+              gd_temp__comp_saf_fmea[version==1],
+              gd_chklst__safety_analysis[version==1]
+   :has: doc_concept__safety_analysis[version==1], doc_getstrt__safety_analysis[version==1]
 
    | The FMEA and DFA are verified. The verification criteria is that it can be proven that the safety requirements for functions and the corresponding safety monitoring are not violated.
 

--- a/process/process_areas/safety_analysis/safety_analysis_workproducts.rst
+++ b/process/process_areas/safety_analysis/safety_analysis_workproducts.rst
@@ -18,16 +18,18 @@ Safety Analysis Work Products
 .. workproduct:: Platform DFA
    :id: wp__platform_dfa
    :status: valid
+   :version: 1
    :tags: doc_lifecycle_model_2
-   :complies: std_wp__iso26262__analysis_751, std_wp__iso26262__software_753, std_wp__isopas8926__4524
+   :complies: std_wp__iso26262__analysis_751[version==1], std_wp__iso26262__software_753[version==1], std_wp__isopas8926__4524[version==1]
 
    Analyse the dependencies between features that references all platform feature static architecture diagrams, highlighting potential shared use of features.
 
 .. workproduct:: Feature FMEA
    :id: wp__feature_fmea
    :status: valid
+   :version: 1
    :tags: doc_lifecycle_model_2
-   :complies: std_wp__iso26262__analysis_851, std_wp__iso26262__software_752, std_wp__isopas8926__4524
+   :complies: std_wp__iso26262__analysis_851[version==1], std_wp__iso26262__software_752[version==1], std_wp__isopas8926__4524[version==1]
 
    FMEA verifies the feature architecture (as part of SW Safety Concept)
 
@@ -36,8 +38,9 @@ Safety Analysis Work Products
 .. workproduct:: Feature DFA
    :id: wp__feature_dfa
    :status: valid
+   :version: 1
    :tags: doc_lifecycle_model_2
-   :complies: std_wp__iso26262__analysis_751, std_wp__iso26262__software_753, std_wp__isopas8926__4524
+   :complies: std_wp__iso26262__analysis_751[version==1], std_wp__iso26262__software_753[version==1], std_wp__isopas8926__4524[version==1]
 
    Dependent Failure Analysis on feature level.
 
@@ -48,8 +51,12 @@ Safety Analysis Work Products
 .. workproduct:: Component FMEA
    :id: wp__sw_component_fmea
    :status: valid
+   :version: 1
    :tags: doc_lifecycle_model_2
-   :complies: std_wp__iso26262__analysis_851, std_wp__iso26262__software_752, std_wp__isopas8926__4524, std_wp__iso26262__software_752
+   :complies: std_wp__iso26262__analysis_851[version==1],
+              std_wp__iso26262__software_752[version==1],
+              std_wp__isopas8926__4524[version==1],
+              std_wp__iso26262__software_752[version==1]
 
    FMEA, verifies the component architecture (as part of SW Safety Concept)
 
@@ -58,8 +65,12 @@ Safety Analysis Work Products
 .. workproduct:: Component DFA
    :id: wp__sw_component_dfa
    :status: valid
+   :version: 1
    :tags: doc_lifecycle_model_2
-   :complies: std_wp__iso26262__analysis_751, std_wp__iso26262__software_753, std_wp__isopas8926__4524, std_wp__iso26262__software_752
+   :complies: std_wp__iso26262__analysis_751[version==1],
+              std_wp__iso26262__software_753[version==1],
+              std_wp__isopas8926__4524[version==1],
+              std_wp__iso26262__software_752[version==1]
 
    Dependent Failure Analysis on component level.
 

--- a/process/process_areas/safety_management/guidance/checklist_safety_package.rst
+++ b/process/process_areas/safety_management/guidance/checklist_safety_package.rst
@@ -18,6 +18,18 @@ Safety Package Formal Review Checklist
 .. gd_chklst:: Safety Package Formal Review Checklist
    :id: gd_chklst__safety_package
    :status: valid
-   :complies: std_req__iso26262__management_5425, std_req__iso26262__management_6469, std_req__iso26262__management_6481, std_req__iso26262__management_6482, std_req__iso26262__management_6491, std_req__iso26262__management_6492, std_req__iso26262__management_6493, std_req__iso26262__management_64101, std_req__iso26262__management_64102, std_req__iso26262__management_64103, std_req__iso26262__management_64104, std_req__iso26262__management_64105
+   :version: 1
+   :complies: std_req__iso26262__management_5425[version==1],
+              std_req__iso26262__management_6469[version==1],
+              std_req__iso26262__management_6481[version==1],
+              std_req__iso26262__management_6482[version==1],
+              std_req__iso26262__management_6491[version==1],
+              std_req__iso26262__management_6492[version==1],
+              std_req__iso26262__management_6493[version==1],
+              std_req__iso26262__management_64101[version==1],
+              std_req__iso26262__management_64102[version==1],
+              std_req__iso26262__management_64103[version==1],
+              std_req__iso26262__management_64104[version==1],
+              std_req__iso26262__management_64105[version==1]
 
    For the content see here: `Safety Package Formal Review Checklist <https://eclipse-score.github.io/module_template/main/docs/safety_mgt/module_safety_package_fdr.html>`__

--- a/process/process_areas/safety_management/guidance/checklist_safety_plan.rst
+++ b/process/process_areas/safety_management/guidance/checklist_safety_plan.rst
@@ -18,6 +18,24 @@ Safety Plan Formal Review Checklist
 .. gd_chklst:: Safety Plan Formal Review Checklist
    :id: gd_chklst__safety_plan
    :status: valid
-   :complies: std_req__iso26262__management_6451, std_req__iso26262__management_6452, std_req__iso26262__management_6455, std_req__iso26262__management_6457, std_req__iso26262__management_6461, std_req__iso26262__management_6462, std_req__iso26262__management_6463, std_req__iso26262__management_6464, std_req__iso26262__management_6465, std_req__iso26262__management_6467, std_req__iso26262__management_6468, std_req__iso26262__management_6491, std_req__iso26262__management_64101, std_req__iso26262__management_64102, std_req__iso26262__management_64103, std_req__iso26262__management_64104, std_req__iso26262__management_64105, std_req__iso26262__management_64111
+   :version: 1
+   :complies: std_req__iso26262__management_6451[version==1],
+              std_req__iso26262__management_6452[version==1],
+              std_req__iso26262__management_6455[version==1],
+              std_req__iso26262__management_6457[version==1],
+              std_req__iso26262__management_6461[version==1],
+              std_req__iso26262__management_6462[version==1],
+              std_req__iso26262__management_6463[version==1],
+              std_req__iso26262__management_6464[version==1],
+              std_req__iso26262__management_6465[version==1],
+              std_req__iso26262__management_6467[version==1],
+              std_req__iso26262__management_6468[version==1],
+              std_req__iso26262__management_6491[version==1],
+              std_req__iso26262__management_64101[version==1],
+              std_req__iso26262__management_64102[version==1],
+              std_req__iso26262__management_64103[version==1],
+              std_req__iso26262__management_64104[version==1],
+              std_req__iso26262__management_64105[version==1],
+              std_req__iso26262__management_64111[version==1]
 
    For the content see here: `Safety Plan Formal Review Checklist <https://eclipse-score.github.io/module_template/main/docs/safety_mgt/module_safety_plan_fdr.html>`__

--- a/process/process_areas/safety_management/guidance/guideline_component_classification.rst
+++ b/process/process_areas/safety_management/guidance/guideline_component_classification.rst
@@ -18,7 +18,23 @@ Component Classification Guideline
 .. gd_guidl:: Classification of a component
    :id: gd_guidl__component_classification
    :status: valid
-   :complies: std_req__isopas8926__441, std_req__isopas8926__4421, std_req__isopas8926__4422, std_req__isopas8926__4423, std_req__isopas8926__4424, std_req__isopas8926__4425, std_req__isopas8926__4426, std_req__isopas8926__4427, std_req__isopas8926__4428, std_req__isopas8926__4429, std_req__isopas8926__44210, std_req__isopas8926__44321, std_req__isopas8926__44322, std_req__isopas8926__4433,
-              std_req__aspice_40__REU-2-BP1, std_req__aspice_40__REU-2-BP2, std_req__aspice_40__REU-2-BP3
+   :version: 1
+   :complies: std_req__isopas8926__441[version==1],
+              std_req__isopas8926__4421[version==1],
+              std_req__isopas8926__4422[version==1],
+              std_req__isopas8926__4423[version==1],
+              std_req__isopas8926__4424[version==1],
+              std_req__isopas8926__4425[version==1],
+              std_req__isopas8926__4426[version==1],
+              std_req__isopas8926__4427[version==1],
+              std_req__isopas8926__4428[version==1],
+              std_req__isopas8926__4429[version==1],
+              std_req__isopas8926__44210[version==1],
+              std_req__isopas8926__44321[version==1],
+              std_req__isopas8926__44322[version==1],
+              std_req__isopas8926__4433[version==1],
+              std_req__aspice_40__REU-2-BP1[version==1],
+              std_req__aspice_40__REU-2-BP2[version==1],
+              std_req__aspice_40__REU-2-BP3[version==1]
 
    For the content see here: `Component Classification Template <https://eclipse-score.github.io/module_template/main/score/component_example/docs/component_classification.html>`__

--- a/process/process_areas/safety_management/guidance/guideline_safety_management.rst
+++ b/process/process_areas/safety_management/guidance/guideline_safety_management.rst
@@ -20,8 +20,42 @@ Safety Management Guideline
 .. gd_guidl:: Safety plan definitions
    :id: gd_guidl__saf_plan_definitions
    :status: valid
-   :complies: std_req__iso26262__management_5426, std_req__iso26262__management_6465, std_req__iso26262__management_6466, std_req__iso26262__management_6467, std_req__iso26262__management_6468, std_req__iso26262__management_6469, std_req__iso26262__management_6422, std_req__iso26262__management_6423, std_req__iso26262__management_6424, std_req__iso26262__management_6451, std_req__iso26262__management_6452, std_req__iso26262__management_6455, std_req__iso26262__management_6457, std_req__iso26262__management_6461, std_req__iso26262__management_6462, std_req__iso26262__management_6463, std_req__iso26262__management_6472, std_req__iso26262__management_6471, std_req__iso26262__management_64111, std_req__iso26262__management_64112, std_req__iso26262__management_64113, std_req__iso26262__management_64114, std_req__iso26262__management_6431, std_req__iso26262__management_6432, std_req__iso26262__management_6433, std_req__iso26262__software_747, std_req__iso26262__support_8441, std_req__iso26262__management_5424, std_req__iso26262__management_5427, std_req__iso26262__management_5432, std_req__iso26262__management_5441, std_req__iso26262__management_5424, std_req__iso26262__management_5427, std_req__iso26262__management_5461,
-              std_req__aspice_40__REU-2-BP1
+   :version: 1
+   :complies: std_req__iso26262__management_5426[version==1],
+              std_req__iso26262__management_6465[version==1],
+              std_req__iso26262__management_6466[version==1],
+              std_req__iso26262__management_6467[version==1],
+              std_req__iso26262__management_6468[version==1],
+              std_req__iso26262__management_6469[version==1],
+              std_req__iso26262__management_6422[version==1],
+              std_req__iso26262__management_6423[version==1],
+              std_req__iso26262__management_6424[version==1],
+              std_req__iso26262__management_6451[version==1],
+              std_req__iso26262__management_6452[version==1],
+              std_req__iso26262__management_6455[version==1],
+              std_req__iso26262__management_6457[version==1],
+              std_req__iso26262__management_6461[version==1],
+              std_req__iso26262__management_6462[version==1],
+              std_req__iso26262__management_6463[version==1],
+              std_req__iso26262__management_6472[version==1],
+              std_req__iso26262__management_6471[version==1],
+              std_req__iso26262__management_64111[version==1],
+              std_req__iso26262__management_64112[version==1],
+              std_req__iso26262__management_64113[version==1],
+              std_req__iso26262__management_64114[version==1],
+              std_req__iso26262__management_6431[version==1],
+              std_req__iso26262__management_6432[version==1],
+              std_req__iso26262__management_6433[version==1],
+              std_req__iso26262__software_747[version==1],
+              std_req__iso26262__support_8441[version==1],
+              std_req__iso26262__management_5424[version==1],
+              std_req__iso26262__management_5427[version==1],
+              std_req__iso26262__management_5432[version==1],
+              std_req__iso26262__management_5441[version==1],
+              std_req__iso26262__management_5424[version==1],
+              std_req__iso26262__management_5427[version==1],
+              std_req__iso26262__management_5461[version==1],
+              std_req__aspice_40__REU-2-BP1[version==1]
 
    **Safety culture:**
 
@@ -165,7 +199,17 @@ Safety Management Guideline
 .. gd_guidl:: Safety manual generation
    :id: gd_guidl__saf_man
    :status: valid
-   :complies: std_req__iso26262__system_6411, std_req__iso26262__system_6412, std_req__iso26262__system_6413, std_req__iso26262__system_6414, std_req__iso26262__system_6421, std_req__iso26262__system_6422, std_req__iso26262__software_641, std_req__iso26262__software_642, std_req__iso26262__software_645, std_req__iso26262__support_12421
+   :version: 1
+   :complies: std_req__iso26262__system_6411[version==1],
+              std_req__iso26262__system_6412[version==1],
+              std_req__iso26262__system_6413[version==1],
+              std_req__iso26262__system_6414[version==1],
+              std_req__iso26262__system_6421[version==1],
+              std_req__iso26262__system_6422[version==1],
+              std_req__iso26262__software_641[version==1],
+              std_req__iso26262__software_642[version==1],
+              std_req__iso26262__software_645[version==1],
+              std_req__iso26262__support_12421[version==1]
 
    | The safety manual collects several workproducts and adds some additional content mainly to instruct the user of
    | a SEooC (in this project on platform and module level) to safely use it in the context of the user's own safety
@@ -176,7 +220,8 @@ Safety Management Guideline
 .. gd_guidl:: Safety package automated generation
    :id: gd_guidl__saf_package
    :status: valid
-   :complies: std_req__iso26262__management_6481, std_req__iso26262__management_6482
+   :version: 1
+   :complies: std_req__iso26262__management_6481[version==1], std_req__iso26262__management_6482[version==1]
 
    | The safety package shall be generated progressively and automatically compiling the work products.
    | One of the checks to perform on the platform safety package is to check completeness of the
@@ -189,10 +234,25 @@ Tailoring
 .. gd_guidl:: Safety Mgt Tailored
    :id: gd_guidl__saf_tailored
    :status: valid
-   :complies: std_req__iso26262__support_12423, std_req__iso26262__management_6453, std_req__iso26262__management_6454, std_req__iso26262__management_6456, std_req__iso26262__management_64610,
-              std_req__iso26262__management_64121, std_req__iso26262__management_64122, std_req__iso26262__management_64123, std_req__iso26262__management_64124, std_req__iso26262__management_64125,
-              std_req__iso26262__management_64126, std_req__iso26262__management_64127, std_req__iso26262__management_64128, std_req__iso26262__management_64129, std_req__iso26262__management_641210,
-              std_req__iso26262__management_641211, std_req__iso26262__management_641212, std_req__iso26262__management_641213
+   :version: 1
+   :complies: std_req__iso26262__support_12423[version==1],
+              std_req__iso26262__management_6453[version==1],
+              std_req__iso26262__management_6454[version==1],
+              std_req__iso26262__management_6456[version==1],
+              std_req__iso26262__management_64610[version==1],
+              std_req__iso26262__management_64121[version==1],
+              std_req__iso26262__management_64122[version==1],
+              std_req__iso26262__management_64123[version==1],
+              std_req__iso26262__management_64124[version==1],
+              std_req__iso26262__management_64125[version==1],
+              std_req__iso26262__management_64126[version==1],
+              std_req__iso26262__management_64127[version==1],
+              std_req__iso26262__management_64128[version==1],
+              std_req__iso26262__management_64129[version==1],
+              std_req__iso26262__management_641210[version==1],
+              std_req__iso26262__management_641211[version==1],
+              std_req__iso26262__management_641212[version==1],
+              std_req__iso26262__management_641213[version==1]
 
    This part of the guideline links to all the requirements which are not fulfilled by the
    safety management process. Make sure these are tailored out in the safety/security/quality plans

--- a/process/process_areas/safety_management/guidance/process_req.rst
+++ b/process/process_areas/safety_management/guidance/process_req.rst
@@ -18,9 +18,10 @@ Safety Management Process Requirements
 .. gd_req:: Safety Management Document Status
    :id: gd_req__safety_doc_status
    :status: valid
+   :version: 1
    :tags: done_automation
-   :complies: std_req__iso26262__management_6468
-   :satisfies: wf__cr_mt_safety_plan, wf__cr_comp_class, wf__cr_mt_safety_manual
+   :complies: std_req__iso26262__management_6468[version==1]
+   :satisfies: wf__cr_mt_safety_plan[version==1], wf__cr_comp_class[version==1], wf__cr_mt_safety_manual[version==1]
 
    Safety plans shall contain documents references where the status is derived automatically.
 
@@ -29,9 +30,10 @@ Safety Management Process Requirements
 .. gd_req:: Safety Management Work Product Status
    :id: gd_req__safety_wp_status
    :status: valid
+   :version: 1
    :tags: prio_2_automation
-   :complies: std_req__iso26262__management_6468
-   :satisfies: wf__cr_mt_safety_plan, wf__cr_comp_class, wf__cr_mt_safety_manual
+   :complies: std_req__iso26262__management_6468[version==1]
+   :satisfies: wf__cr_mt_safety_plan[version==1], wf__cr_comp_class[version==1], wf__cr_mt_safety_manual[version==1]
 
    Safety plans shall contain work product references where the accumulated status is derived automatically.
 

--- a/process/process_areas/safety_management/guidance/template_component_classification.rst
+++ b/process/process_areas/safety_management/guidance/template_component_classification.rst
@@ -18,6 +18,20 @@ Component Classification Template
 .. gd_temp:: Component Classification Template
    :id: gd_temp__component_classification
    :status: valid
-   :complies: std_req__isopas8926__441, std_req__isopas8926__4421, std_req__isopas8926__4422, std_req__isopas8926__4423, std_req__isopas8926__4424, std_req__isopas8926__4425, std_req__isopas8926__4426, std_req__isopas8926__4427, std_req__isopas8926__4428, std_req__isopas8926__4429, std_req__isopas8926__44210, std_req__iso26262__software_743, std_req__aspice_40__iic-12-03, std_req__aspice_40__iic-15-07
+   :version: 1
+   :complies: std_req__isopas8926__441[version==1],
+              std_req__isopas8926__4421[version==1],
+              std_req__isopas8926__4422[version==1],
+              std_req__isopas8926__4423[version==1],
+              std_req__isopas8926__4424[version==1],
+              std_req__isopas8926__4425[version==1],
+              std_req__isopas8926__4426[version==1],
+              std_req__isopas8926__4427[version==1],
+              std_req__isopas8926__4428[version==1],
+              std_req__isopas8926__4429[version==1],
+              std_req__isopas8926__44210[version==1],
+              std_req__iso26262__software_743[version==1],
+              std_req__aspice_40__iic-12-03[version==1],
+              std_req__aspice_40__iic-15-07[version==1]
 
    For the content see here: `Component Classification Template <https://eclipse-score.github.io/module_template/main/score/component_example/docs/component_classification.html>`__

--- a/process/process_areas/safety_management/guidance/template_safety_manual.rst
+++ b/process/process_areas/safety_management/guidance/template_safety_manual.rst
@@ -18,6 +18,18 @@ Safety Manual Template
 .. gd_temp:: Safety Manual Template
    :id: gd_temp__safety_manual
    :status: valid
-   :complies: std_req__iso26262__management_5425, std_req__iso26262__system_6411, std_req__iso26262__system_6412, std_req__iso26262__system_6413, std_req__iso26262__system_6414, std_req__iso26262__system_6421, std_req__iso26262__system_6422, std_req__iso26262__software_641, std_req__iso26262__software_642, std_req__iso26262__software_645, std_req__iso26262__support_12421, std_req__aspice_40__iic-13-53
+   :version: 1
+   :complies: std_req__iso26262__management_5425[version==1],
+              std_req__iso26262__system_6411[version==1],
+              std_req__iso26262__system_6412[version==1],
+              std_req__iso26262__system_6413[version==1],
+              std_req__iso26262__system_6414[version==1],
+              std_req__iso26262__system_6421[version==1],
+              std_req__iso26262__system_6422[version==1],
+              std_req__iso26262__software_641[version==1],
+              std_req__iso26262__software_642[version==1],
+              std_req__iso26262__software_645[version==1],
+              std_req__iso26262__support_12421[version==1],
+              std_req__aspice_40__iic-13-53[version==1]
 
    For the content see here: `Safety Manual Template <https://eclipse-score.github.io/module_template/main/docs/manuals/safety_manual.html>`__

--- a/process/process_areas/safety_management/guidance/templates_safety_plan.rst
+++ b/process/process_areas/safety_management/guidance/templates_safety_plan.rst
@@ -18,7 +18,12 @@ Safety Planning Templates
 .. gd_temp:: Feature Safety Work Products Template
    :id: gd_temp__feature_safety_wp
    :status: valid
-   :complies: std_req__iso26262__management_6465, std_req__iso26262__management_6466, std_req__iso26262__management_6467, std_req__iso26262__management_6468, std_req__iso26262__management_6469
+   :version: 1
+   :complies: std_req__iso26262__management_6465[version==1],
+              std_req__iso26262__management_6466[version==1],
+              std_req__iso26262__management_6467[version==1],
+              std_req__iso26262__management_6468[version==1],
+              std_req__iso26262__management_6469[version==1]
 
    For the content see here: `Feature Safety Work Products Template <https://eclipse-score.github.io/module_template/main/docs/features/feature_example/safety_planning/index.html>`__
 
@@ -26,8 +31,25 @@ Safety Planning Templates
 .. gd_temp:: Module Safety Plan Template
    :id: gd_temp__module_safety_plan
    :status: valid
-   :complies: std_req__iso26262__management_5425, std_req__iso26262__management_5424, std_req__iso26262__management_6465, std_req__iso26262__management_6466, std_req__iso26262__management_6467, std_req__iso26262__management_6468, std_req__iso26262__management_6469, std_req__iso26262__support_12424, std_req__iso26262__support_12425, std_req__iso26262__support_1243, std_req__isopas8926__44341, std_req__isopas8926__44342, std_req__isopas8926__44611, std_req__isopas8926__4463, std_req__iso26262__management_5427, std_req__iso26262__management_6421,
-              std_req__aspice_40__REU-2-BP4, std_req__aspice_40__REU-2-BP5
+   :version: 1
+   :complies: std_req__iso26262__management_5425[version==1],
+              std_req__iso26262__management_5424[version==1],
+              std_req__iso26262__management_6465[version==1],
+              std_req__iso26262__management_6466[version==1],
+              std_req__iso26262__management_6467[version==1],
+              std_req__iso26262__management_6468[version==1],
+              std_req__iso26262__management_6469[version==1],
+              std_req__iso26262__support_12424[version==1],
+              std_req__iso26262__support_12425[version==1],
+              std_req__iso26262__support_1243[version==1],
+              std_req__isopas8926__44341[version==1],
+              std_req__isopas8926__44342[version==1],
+              std_req__isopas8926__44611[version==1],
+              std_req__isopas8926__4463[version==1],
+              std_req__iso26262__management_5427[version==1],
+              std_req__iso26262__management_6421[version==1],
+              std_req__aspice_40__REU-2-BP4[version==1],
+              std_req__aspice_40__REU-2-BP5[version==1]
 
    For the content see here: `Module Safety Plan Template <https://eclipse-score.github.io/module_template/main/docs/safety_mgt/module_safety_plan.html>`__
 
@@ -35,6 +57,19 @@ Safety Planning Templates
 .. gd_temp:: Platform Safety Plan Template
    :id: gd_temp__platform_safety_plan
    :status: valid
-   :complies: std_req__iso26262__management_5425, std_req__iso26262__management_5424, std_req__iso26262__management_6465, std_req__iso26262__management_6466, std_req__iso26262__management_6467, std_req__iso26262__management_6468, std_req__iso26262__management_6469, std_req__isopas8926__44341, std_req__isopas8926__44342, std_req__isopas8926__44611, std_req__isopas8926__4463, std_req__iso26262__management_5427, std_req__iso26262__management_6421
+   :version: 1
+   :complies: std_req__iso26262__management_5425[version==1],
+              std_req__iso26262__management_5424[version==1],
+              std_req__iso26262__management_6465[version==1],
+              std_req__iso26262__management_6466[version==1],
+              std_req__iso26262__management_6467[version==1],
+              std_req__iso26262__management_6468[version==1],
+              std_req__iso26262__management_6469[version==1],
+              std_req__isopas8926__44341[version==1],
+              std_req__isopas8926__44342[version==1],
+              std_req__isopas8926__44611[version==1],
+              std_req__isopas8926__4463[version==1],
+              std_req__iso26262__management_5427[version==1],
+              std_req__iso26262__management_6421[version==1]
 
    For the content see here: :need:`doc__platform_safety_plan`

--- a/process/process_areas/safety_management/safety_management_concept.rst
+++ b/process/process_areas/safety_management/safety_management_concept.rst
@@ -18,6 +18,7 @@ Concept Description
 .. doc_concept:: Safety Management Concept
    :id: doc_concept__safety_management_process
    :status: valid
+   :version: 1
 
 In this section a concept for the Safety Management will be discussed.
 Inputs for this concepts are mainly the requirements of ISO26262 "Part 2: Management of functional safety".

--- a/process/process_areas/safety_management/safety_management_getstrt.rst
+++ b/process/process_areas/safety_management/safety_management_getstrt.rst
@@ -18,6 +18,7 @@ Getting Started
 .. doc_getstrt:: Getting started on Safety Management
    :id: doc_getstrt__safety_management_process
    :status: valid
+   :version: 1
 
 This document describes the steps which need to be done to ensure Functional Safety according to ISO 26262 as used standard in the project.
 

--- a/process/process_areas/safety_management/safety_management_roles.rst
+++ b/process/process_areas/safety_management/safety_management_roles.rst
@@ -18,7 +18,8 @@ Roles
 .. role:: Safety Manager
    :id: rl__safety_manager
    :status: valid
-   :contains: rl__committer
+   :version: 1
+   :contains: rl__committer[version==1]
 
    The safety manager is responsible for making sure that ISO26262 is complied to in the project. He/She shall lead and monitor the safety relevant activities of the project.
 
@@ -72,6 +73,7 @@ Roles
 .. role:: Safety External Auditor
    :id: rl__safety_external_auditor 
    :status: valid
+   :version: 1
 
    Required skills, Knowledge of standards, Experience
 

--- a/process/process_areas/safety_management/safety_management_workflow.rst
+++ b/process/process_areas/safety_management/safety_management_workflow.rst
@@ -20,12 +20,16 @@ Safety Management Workflows
 .. workflow:: Create/Maintain Safety Plan
    :id: wf__cr_mt_safety_plan
    :status: valid
-   :responsible: rl__safety_manager
-   :approved_by: rl__project_lead
-   :input: wp__platform_mgmt, wp__issue_track_system, wp__sw_component_class, wp__tailoring_work_products
-   :output: wp__module_safety_plan, wp__platform_safety_plan, wp__safety_tailoring
-   :contains: gd_guidl__saf_plan_definitions, gd_temp__feature_safety_wp, gd_temp__module_safety_plan
-   :has: doc_concept__safety_management_process, doc_getstrt__safety_management_process
+   :version: 1
+   :responsible: rl__safety_manager[version==1]
+   :approved_by: rl__project_lead[version==1]
+   :input: wp__platform_mgmt[version==1],
+           wp__issue_track_system[version==1],
+           wp__sw_component_class[version==1],
+           wp__tailoring_work_products[version==1]
+   :output: wp__module_safety_plan[version==1], wp__platform_safety_plan[version==1], wp__safety_tailoring[version==1]
+   :contains: gd_guidl__saf_plan_definitions[version==1], gd_temp__feature_safety_wp[version==1], gd_temp__module_safety_plan[version==1]
+   :has: doc_concept__safety_management_process[version==1], doc_getstrt__safety_management_process[version==1]
 
    | The Safety Manager is responsible for the planning and coordination of the safety activities for the platform.
    | The Safety Manager creates and maintains the safety plan.
@@ -34,24 +38,29 @@ Safety Management Workflows
 .. workflow:: Create Component Classification
    :id: wf__cr_comp_class
    :status: valid
-   :responsible: rl__committer
-   :approved_by: rl__safety_manager
-   :input: wp__platform_mgmt, wp__issue_track_system
-   :output: wp__sw_component_class
-   :contains: gd_guidl__component_classification, gd_temp__component_classification
-   :has: doc_concept__safety_management_process, doc_getstrt__safety_management_process
+   :version: 1
+   :responsible: rl__committer[version==1]
+   :approved_by: rl__safety_manager[version==1]
+   :input: wp__platform_mgmt[version==1], wp__issue_track_system[version==1]
+   :output: wp__sw_component_class[version==1]
+   :contains: gd_guidl__component_classification[version==1], gd_temp__component_classification[version==1]
+   :has: doc_concept__safety_management_process[version==1], doc_getstrt__safety_management_process[version==1]
 
    | The Safety Manager shall approve the OSS component classification performed by an expert on this component.
 
 .. workflow:: Create/Maintain Safety Package
    :id: wf__cr_mt_safety_package
    :status: valid
-   :responsible: rl__safety_engineer
-   :approved_by: rl__safety_manager
-   :input: wp__module_safety_plan, wp__platform_safety_plan, wp__issue_track_system, wp__safety_tailoring
-   :output: wp__module_safety_package, wp__platform_safety_package
-   :contains: gd_guidl__saf_package, gd_temp__feature_safety_wp, gd_temp__module_safety_plan
-   :has: doc_concept__safety_management_process, doc_getstrt__safety_management_process
+   :version: 1
+   :responsible: rl__safety_engineer[version==1]
+   :approved_by: rl__safety_manager[version==1]
+   :input: wp__module_safety_plan[version==1],
+           wp__platform_safety_plan[version==1],
+           wp__issue_track_system[version==1],
+           wp__safety_tailoring[version==1]
+   :output: wp__module_safety_package[version==1], wp__platform_safety_package[version==1]
+   :contains: gd_guidl__saf_package[version==1], gd_temp__feature_safety_wp[version==1], gd_temp__module_safety_plan[version==1]
+   :has: doc_concept__safety_management_process[version==1], doc_getstrt__safety_management_process[version==1]
 
    | The Safety Manager in the project is NOT responsible to provide the argument for the achievement of functional safety.
    | But the Safety Manager creates and maintains the safety package in the sense of a collection of safety related work products.
@@ -62,12 +71,16 @@ Safety Management Workflows
 .. workflow:: Perform Safety Audit
    :id: wf__p_fs_audit
    :status: valid
-   :responsible: rl__safety_external_auditor
-   :approved_by: rl__safety_manager
-   :input: wp__module_safety_plan, wp__platform_safety_plan, wp__module_safety_package, wp__platform_safety_package
-   :output: wp__audit_report
-   :contains: gd_guidl__saf_plan_definitions
-   :has: doc_concept__safety_management_process, doc_getstrt__safety_management_process
+   :version: 1
+   :responsible: rl__safety_external_auditor[version==1]
+   :approved_by: rl__safety_manager[version==1]
+   :input: wp__module_safety_plan[version==1],
+           wp__platform_safety_plan[version==1],
+           wp__module_safety_package[version==1],
+           wp__platform_safety_package[version==1]
+   :output: wp__audit_report[version==1]
+   :contains: gd_guidl__saf_plan_definitions[version==1]
+   :has: doc_concept__safety_management_process[version==1], doc_getstrt__safety_management_process[version==1]
 
    | The external auditor is responsible to perform a safety audit.
    | The Safety Manager and the process community shall support the external auditor during this.
@@ -76,12 +89,16 @@ Safety Management Workflows
 .. workflow:: Perform Formal Reviews
    :id: wf__p_formal_rv
    :status: valid
-   :responsible: rl__safety_manager
-   :approved_by: rl__safety_manager
-   :input: wp__module_safety_plan, wp__platform_safety_plan, wp__module_safety_package, wp__platform_safety_package
-   :output: wp__fdr_reports
-   :contains: gd_guidl__saf_plan_definitions, gd_chklst__safety_plan, gd_chklst__safety_package
-   :has: doc_concept__safety_management_process, doc_getstrt__safety_management_process
+   :version: 1
+   :responsible: rl__safety_manager[version==1]
+   :approved_by: rl__safety_manager[version==1]
+   :input: wp__module_safety_plan[version==1],
+           wp__platform_safety_plan[version==1],
+           wp__module_safety_package[version==1],
+           wp__platform_safety_package[version==1]
+   :output: wp__fdr_reports[version==1]
+   :contains: gd_guidl__saf_plan_definitions[version==1], gd_chklst__safety_plan[version==1], gd_chklst__safety_package[version==1]
+   :has: doc_concept__safety_management_process[version==1], doc_getstrt__safety_management_process[version==1]
 
    | An "external" safety manager is responsible the formal reviews on safety plan, safety package and safety analysis.
    | In this context "external" means that the person is not the Safety Manager of the platform/module (i.e. created or approved the respective work product).
@@ -92,12 +109,22 @@ Safety Management Workflows
 .. workflow:: Create/Maintain Safety Manual
    :id: wf__cr_mt_safety_manual
    :status: valid
-   :responsible: rl__safety_engineer
-   :approved_by: rl__safety_manager
-   :input: wp__requirements_feat_aou, wp__requirements_feat, wp__feature_arch, wp__feature_fmea, wp__feature_dfa, wp__requirements_comp_aou, wp__requirements_comp, wp__component_arch, wp__sw_component_fmea, wp__sw_component_dfa
-   :output: wp__platform_safety_manual, wp__module_safety_manual
-   :contains: gd_guidl__saf_man, gd_temp__safety_manual
-   :has: doc_concept__safety_management_process, doc_getstrt__safety_management_process
+   :version: 1
+   :responsible: rl__safety_engineer[version==1]
+   :approved_by: rl__safety_manager[version==1]
+   :input: wp__requirements_feat_aou[version==1],
+           wp__requirements_feat[version==1],
+           wp__feature_arch[version==1],
+           wp__feature_fmea[version==1],
+           wp__feature_dfa[version==1],
+           wp__requirements_comp_aou[version==1],
+           wp__requirements_comp[version==1],
+           wp__component_arch[version==1],
+           wp__sw_component_fmea[version==1],
+           wp__sw_component_dfa[version==1]
+   :output: wp__platform_safety_manual[version==1], wp__module_safety_manual[version==1]
+   :contains: gd_guidl__saf_man[version==1], gd_temp__safety_manual[version==1]
+   :has: doc_concept__safety_management_process[version==1], doc_getstrt__safety_management_process[version==1]
 
    | The Safety Engineer collects the necessary input for the safety manuals on platform and module level and documents it.
    | The safety manager makes sure all items are in valid state for a release of the safety manual.
@@ -106,12 +133,18 @@ Safety Management Workflows
 .. workflow:: Monitor/Verify Safety
    :id: wf__mr_vy_safety
    :status: valid
-   :responsible: rl__safety_manager
-   :approved_by: rl__project_lead
-   :input: wp__module_safety_plan, wp__platform_safety_plan, wp__module_safety_package, wp__platform_safety_package, wp__audit_report, wp__fdr_reports
-   :output: wp__issue_track_system, wp__module_sw_release_note, wp__platform_sw_release_note
-   :contains: gd_guidl__saf_plan_definitions
-   :has: doc_concept__safety_management_process, doc_getstrt__safety_management_process
+   :version: 1
+   :responsible: rl__safety_manager[version==1]
+   :approved_by: rl__project_lead[version==1]
+   :input: wp__module_safety_plan[version==1],
+           wp__platform_safety_plan[version==1],
+           wp__module_safety_package[version==1],
+           wp__platform_safety_package[version==1],
+           wp__audit_report[version==1],
+           wp__fdr_reports[version==1]
+   :output: wp__issue_track_system[version==1], wp__module_sw_release_note[version==1], wp__platform_sw_release_note[version==1]
+   :contains: gd_guidl__saf_plan_definitions[version==1]
+   :has: doc_concept__safety_management_process[version==1], doc_getstrt__safety_management_process[version==1]
 
    | The Safety Manager is responsible for the monitoring of the safety activities against the safety plan.
    | The Safety Manager is responsible to verify, that the preconditions for the release, which are  part of the release notes, are fulfilled.
@@ -120,12 +153,16 @@ Safety Management Workflows
 .. workflow:: Impact Analysis of Change Request
    :id: wf__impact_analysis_change_request
    :status: valid
-   :responsible: rl__safety_manager
-   :approved_by: rl__project_lead
-   :input: wp__platform_mgmt, wp__issue_track_system, wp__sw_component_class, wp__safety_tailoring
-   :output: wp__issue_track_system
-   :contains: gd_temp__change_component_request, gd_temp__change_decision_record, gd_temp__change_impact_analysis
-   :has: doc_concept__safety_management_process, doc_getstrt__safety_management_process
+   :version: 1
+   :responsible: rl__safety_manager[version==1]
+   :approved_by: rl__project_lead[version==1]
+   :input: wp__platform_mgmt[version==1],
+           wp__issue_track_system[version==1],
+           wp__sw_component_class[version==1],
+           wp__safety_tailoring[version==1]
+   :output: wp__issue_track_system[version==1]
+   :contains: gd_temp__change_component_request[version==1], gd_temp__change_decision_record[version==1], gd_temp__change_impact_analysis[version==1]
+   :has: doc_concept__safety_management_process[version==1], doc_getstrt__safety_management_process[version==1]
 
    | In accordance with ISO 26262-2:2018 section 5.2.2.3 d/e (Impact Analysis), the project implements a dedicated workflow for analyzing change requests.
    | The Safety Manager is responsible for ensuring that each change request is analyzed for its impact on safety, as required by ISO 26262-2:2018.

--- a/process/process_areas/safety_management/safety_management_workproducts.rst
+++ b/process/process_areas/safety_management/safety_management_workproducts.rst
@@ -18,8 +18,12 @@ Safety Management Work Products
 .. workproduct:: Platform Safety Plan
    :id: wp__platform_safety_plan
    :status: valid
+   :version: 1
    :tags: doc_lifecycle_model_2
-   :complies: std_wp__iso26262__management_551, std_wp__iso26262__management_552, std_wp__iso26262__management_653, std_wp__iso26262__support_853
+   :complies: std_wp__iso26262__management_551[version==1],
+              std_wp__iso26262__management_552[version==1],
+              std_wp__iso26262__management_653[version==1],
+              std_wp__iso26262__support_853[version==1]
 
    Plan to manage and guide the execution of the safety activities of a project including dates, milestones, tasks, deliverables, responsibilities (including the Safety Manager appointment)  and resources.
 
@@ -34,8 +38,14 @@ Safety Management Work Products
 .. workproduct:: Module Safety Plan
    :id: wp__module_safety_plan
    :status: valid
+   :version: 1
    :tags: doc_lifecycle_model_2
-   :complies: std_wp__iso26262__management_552, std_wp__iso26262__management_653, std_wp__iso26262__support_853, std_wp__iso26262__support_1251, std_wp__iso26262__support_1252, std_wp__isopas8926__4512
+   :complies: std_wp__iso26262__management_552[version==1],
+              std_wp__iso26262__management_653[version==1],
+              std_wp__iso26262__support_853[version==1],
+              std_wp__iso26262__support_1251[version==1],
+              std_wp__iso26262__support_1252[version==1],
+              std_wp__isopas8926__4512[version==1]
 
    Plan to manage and guide the execution of the safety activities of a project including dates, milestones, tasks, deliverables, responsibilities (including the Safety Manager appointment) and resources.
 
@@ -48,8 +58,9 @@ Safety Management Work Products
 .. workproduct:: Platform Safety Package
    :id: wp__platform_safety_package
    :status: valid
+   :version: 1
    :tags: doc_lifecycle_model_2
-   :complies: std_wp__iso26262__management_654
+   :complies: std_wp__iso26262__management_654[version==1]
 
    Compiled Safety Relevant Work Products. For Platform SEooC.
 
@@ -58,8 +69,9 @@ Safety Management Work Products
 .. workproduct:: Module Safety Package
    :id: wp__module_safety_package
    :status: valid
+   :version: 1
    :tags: doc_lifecycle_model_2
-   :complies: std_wp__iso26262__management_654
+   :complies: std_wp__iso26262__management_654[version==1]
 
    Compiled Safety Relevant Work Products. For Module SEooC.
 
@@ -68,8 +80,9 @@ Safety Management Work Products
 .. workproduct:: Formal Document Review Reports
    :id: wp__fdr_reports
    :status: valid
+   :version: 1
    :tags: doc_lifecycle_model_2
-   :complies: std_wp__iso26262__management_655
+   :complies: std_wp__iso26262__management_655[version==1]
 
    Review that a work product provides sufficient and convincing evidence of their contribution to the achievement of functional safety considering the corresponding objectives and requirements of ISO 26262.
 
@@ -78,16 +91,18 @@ Safety Management Work Products
 .. workproduct:: Process Safety Audit Report
    :id: wp__audit_report
    :status: valid
+   :version: 1
    :tags: doc_lifecycle_model_2
-   :complies: std_wp__iso26262__management_655
+   :complies: std_wp__iso26262__management_655[version==1]
 
    Examination of an implemented process with regard to the process objectives and that those match the ISO 26262.
 
 .. workproduct:: Platform Safety Manual
    :id: wp__platform_safety_manual
    :status: valid
+   :version: 1
    :tags: doc_lifecycle_model_2
-   :complies: std_wp__iso26262__software_651, std_wp__iso26262__system_651
+   :complies: std_wp__iso26262__software_651[version==1], std_wp__iso26262__system_651[version==1]
 
    The safety manual describes:
 
@@ -104,8 +119,12 @@ Safety Management Work Products
 .. workproduct:: Module Safety Manual
    :id: wp__module_safety_manual
    :status: valid
+   :version: 1
    :tags: doc_lifecycle_model_2
-   :complies: std_wp__iso26262__software_651, std_wp__iso26262__system_651, std_wp__iso26262__support_1251, std_req__aspice_40__iic-13-53
+   :complies: std_wp__iso26262__software_651[version==1],
+              std_wp__iso26262__system_651[version==1],
+              std_wp__iso26262__support_1251[version==1],
+              std_req__aspice_40__iic-13-53[version==1]
 
    The safety manual describes:
 
@@ -122,8 +141,12 @@ Safety Management Work Products
 .. workproduct:: Software component classification
    :id: wp__sw_component_class
    :status: valid
+   :version: 1
    :tags: doc_lifecycle_model_2
-   :complies: std_wp__iso26262__support_1251, std_wp__isopas8926__4511, std_req__aspice_40__iic-12-03, std_req__aspice_40__iic-15-07
+   :complies: std_wp__iso26262__support_1251[version==1],
+              std_wp__isopas8926__4511[version==1],
+              std_req__aspice_40__iic-12-03[version==1],
+              std_req__aspice_40__iic-15-07[version==1]
 
    The classification shall include:
 
@@ -136,8 +159,9 @@ Safety Management Work Products
 .. workproduct:: Tailoring Documents
    :id: wp__safety_tailoring
    :status: valid
+   :version: 1
    :tags: doc_lifecycle_model_2
-   :complies: std_wp__iso26262__management_653
+   :complies: std_wp__iso26262__management_653[version==1]
 
    This work product argues why some safety work products are not needed in the project.
 

--- a/process/process_areas/security_analysis/guidance/security_analysis_checklist.rst
+++ b/process/process_areas/security_analysis/guidance/security_analysis_checklist.rst
@@ -20,6 +20,7 @@ Security Analysis Checklist
 .. gd_chklst:: Security Analysis Checklist Template
    :id: gd_chklst__security_analysis
    :status: valid
+   :version: 1
    :tags: security_analysis
 
    For the content see here:

--- a/process/process_areas/security_analysis/guidance/security_analysis_guideline.rst
+++ b/process/process_areas/security_analysis/guidance/security_analysis_guideline.rst
@@ -20,6 +20,7 @@ Security Analysis Guidelines
 .. gd_guidl:: Security Analysis Guideline
    :id: gd_guidl__security_analysis
    :status: valid
+   :version: 1
    :complies:
 
 This document describes the general guidance for Security Analysis based on the concept

--- a/process/process_areas/security_analysis/guidance/security_analysis_process_reqs.rst
+++ b/process/process_areas/security_analysis/guidance/security_analysis_process_reqs.rst
@@ -24,9 +24,20 @@ Security Analysis Process Requirements
 .. gd_req:: Security Analysis Structure
    :id: gd_req__sec_structure
    :status: valid
+   :version: 1
    :tags: done_automation, security_analysis
-   :satisfies: wf__analyse_sec_platform_featarch, wf__analyse_sec_featarch, wf__analyse_sec_comparch
-   :complies: std_req__isosae21434__continual_8321, std_req__isosae21434__continual_8621, std_req__isosae21434__assessment_15621, std_req__isosae21434__assessment_15622, std_req__isosae21434__assessment_15722, std_req__isosae21434__assessment_15723, std_req__isosae21434__assessment_15724, std_req__isosae21434__assessment_15725, std_req__isosae21434__assessment_15821, std_req__isosae21434__assessment_15822, std_req__isosae21434__assessment_15921
+   :satisfies: wf__analyse_sec_platform_featarch[version==1], wf__analyse_sec_featarch[version==1], wf__analyse_sec_comparch[version==1]
+   :complies: std_req__isosae21434__continual_8321[version==1],
+              std_req__isosae21434__continual_8621[version==1],
+              std_req__isosae21434__assessment_15621[version==1],
+              std_req__isosae21434__assessment_15622[version==1],
+              std_req__isosae21434__assessment_15722[version==1],
+              std_req__isosae21434__assessment_15723[version==1],
+              std_req__isosae21434__assessment_15724[version==1],
+              std_req__isosae21434__assessment_15725[version==1],
+              std_req__isosae21434__assessment_15821[version==1],
+              std_req__isosae21434__assessment_15822[version==1],
+              std_req__isosae21434__assessment_15921[version==1]
 
    Security Analysis shall be hierarchically grouped into different levels.
 
@@ -44,9 +55,10 @@ Process Security Analysis Attributes
 .. gd_req:: Security Analysis attribute: UID
    :id: gd_req__sec_attr_uid
    :status: valid
+   :version: 1
    :tags: done_automation, attribute, mandatory
-   :satisfies: wf__analyse_sec_platform_featarch, wf__analyse_sec_featarch, wf__analyse_sec_comparch
-   :complies: std_req__isosae21434__continual_8321
+   :satisfies: wf__analyse_sec_platform_featarch[version==1], wf__analyse_sec_featarch[version==1], wf__analyse_sec_comparch[version==1]
+   :complies: std_req__isosae21434__continual_8321[version==1]
 
    Each Security Analysis shall have a unique ID. It shall be in a format which is also human readable and consists of
 
@@ -59,18 +71,31 @@ Process Security Analysis Attributes
 .. gd_req:: Security Analysis attribute: title
    :id: gd_req__sec_attr_title
    :status: valid
+   :version: 1
    :tags: manual_prio_1, attribute, mandatory
-   :satisfies: wf__analyse_sec_platform_featarch, wf__analyse_sec_featarch, wf__analyse_sec_comparch
-   :complies: std_req__isosae21434__continual_8321
+   :satisfies: wf__analyse_sec_platform_featarch[version==1], wf__analyse_sec_featarch[version==1], wf__analyse_sec_comparch[version==1]
+   :complies: std_req__isosae21434__continual_8321[version==1]
 
    The title of the Security Analysis shall provide a short summary of the description
 
 .. gd_req:: Security Analysis attribute: mitigated by
    :id: gd_req__sec_attr_mitigated_by
    :status: valid
+   :version: 1
    :tags: prio_1_automation, attribute, optional
-   :satisfies: wf__analyse_sec_platform_featarch, wf__analyse_sec_featarch, wf__analyse_sec_comparch
-   :complies: std_req__isosae21434__continual_8621, std_req__isosae21434__continual_8622, std_req__isosae21434__assessment_15621, std_req__isosae21434__assessment_15622, std_req__isosae21434__assessment_15721, std_req__isosae21434__assessment_15722, std_req__isosae21434__assessment_15723, std_req__isosae21434__assessment_15724, std_req__isosae21434__assessment_15725, std_req__isosae21434__assessment_15821, std_req__isosae21434__assessment_15822, std_req__isosae21434__assessment_15921
+   :satisfies: wf__analyse_sec_platform_featarch[version==1], wf__analyse_sec_featarch[version==1], wf__analyse_sec_comparch[version==1]
+   :complies: std_req__isosae21434__continual_8621[version==1],
+              std_req__isosae21434__continual_8622[version==1],
+              std_req__isosae21434__assessment_15621[version==1],
+              std_req__isosae21434__assessment_15622[version==1],
+              std_req__isosae21434__assessment_15721[version==1],
+              std_req__isosae21434__assessment_15722[version==1],
+              std_req__isosae21434__assessment_15723[version==1],
+              std_req__isosae21434__assessment_15724[version==1],
+              std_req__isosae21434__assessment_15725[version==1],
+              std_req__isosae21434__assessment_15821[version==1],
+              std_req__isosae21434__assessment_15822[version==1],
+              std_req__isosae21434__assessment_15921[version==1]
 
    Each threat shall have an associated treatment (accept, avoid, reduce, share) or AoU.
    If mitigation has not yet been implemented, do not use this option.
@@ -79,18 +104,33 @@ Process Security Analysis Attributes
 .. gd_req:: Security Analysis attribute: mitigation issue
    :id: gd_req__sec_attr_mitigation_issue
    :status: valid
+   :version: 1
    :tags: prio_1_automation, attribute, optional
-   :satisfies: wf__analyse_sec_platform_featarch, wf__analyse_sec_featarch, wf__analyse_sec_comparch
-   :complies: std_req__isosae21434__continual_8322, std_req__isosae21434__continual_8323, std_req__isosae21434__continual_8621, std_req__isosae21434__continual_8622, std_req__isosae21434__assessment_15921
+   :satisfies: wf__analyse_sec_platform_featarch[version==1], wf__analyse_sec_featarch[version==1], wf__analyse_sec_comparch[version==1]
+   :complies: std_req__isosae21434__continual_8322[version==1],
+              std_req__isosae21434__continual_8323[version==1],
+              std_req__isosae21434__continual_8621[version==1],
+              std_req__isosae21434__continual_8622[version==1],
+              std_req__isosae21434__assessment_15921[version==1]
 
    If a new security mitigation (avoid, reduce, or share) is needed, link to the issue and keep status invalid until the mitigation is sufficient.
 
 .. gd_req:: Security Analysis attribute: sufficient
    :id: gd_req__sec_attr_sufficient
    :status: valid
+   :version: 1
    :tags: prio_1_automation, attribute, mandatory
-   :satisfies: wf__analyse_sec_platform_featarch, wf__analyse_sec_featarch, wf__analyse_sec_comparch
-   :complies: std_req__isosae21434__continual_8621, std_req__isosae21434__continual_8622, std_req__isosae21434__assessment_15721, std_req__isosae21434__assessment_15722, std_req__isosae21434__assessment_15723, std_req__isosae21434__assessment_15724, std_req__isosae21434__assessment_15725, std_req__isosae21434__assessment_15821, std_req__isosae21434__assessment_15822, std_req__isosae21434__assessment_15921
+   :satisfies: wf__analyse_sec_platform_featarch[version==1], wf__analyse_sec_featarch[version==1], wf__analyse_sec_comparch[version==1]
+   :complies: std_req__isosae21434__continual_8621[version==1],
+              std_req__isosae21434__continual_8622[version==1],
+              std_req__isosae21434__assessment_15721[version==1],
+              std_req__isosae21434__assessment_15722[version==1],
+              std_req__isosae21434__assessment_15723[version==1],
+              std_req__isosae21434__assessment_15724[version==1],
+              std_req__isosae21434__assessment_15725[version==1],
+              std_req__isosae21434__assessment_15821[version==1],
+              std_req__isosae21434__assessment_15822[version==1],
+              std_req__isosae21434__assessment_15921[version==1]
 
    The mitigation(s) shall be rated as sufficient with <yes> or <no>.
    A mitigation can only be sufficient if a mitigation is linked via the attribute mitigation.
@@ -98,9 +138,24 @@ Process Security Analysis Attributes
 .. gd_req:: Security Analysis content: argument
    :id: gd_req__sec_argument
    :status: valid
+   :version: 1
    :tags: prio_1_automation, attribute, mandatory
-   :satisfies: wf__analyse_sec_platform_featarch, wf__analyse_sec_featarch, wf__analyse_sec_comparch
-   :complies: std_req__isosae21434__continual_8421, std_req__isosae21434__continual_8521, std_req__isosae21434__continual_8522, std_req__isosae21434__continual_8621, std_req__isosae21434__continual_8622, std_req__isosae21434__assessment_15621, std_req__isosae21434__assessment_15622, std_req__isosae21434__assessment_15721, std_req__isosae21434__assessment_15722, std_req__isosae21434__assessment_15723, std_req__isosae21434__assessment_15724, std_req__isosae21434__assessment_15725, std_req__isosae21434__assessment_15821, std_req__isosae21434__assessment_15822, std_req__isosae21434__assessment_15921
+   :satisfies: wf__analyse_sec_platform_featarch[version==1], wf__analyse_sec_featarch[version==1], wf__analyse_sec_comparch[version==1]
+   :complies: std_req__isosae21434__continual_8421[version==1],
+              std_req__isosae21434__continual_8521[version==1],
+              std_req__isosae21434__continual_8522[version==1],
+              std_req__isosae21434__continual_8621[version==1],
+              std_req__isosae21434__continual_8622[version==1],
+              std_req__isosae21434__assessment_15621[version==1],
+              std_req__isosae21434__assessment_15622[version==1],
+              std_req__isosae21434__assessment_15721[version==1],
+              std_req__isosae21434__assessment_15722[version==1],
+              std_req__isosae21434__assessment_15723[version==1],
+              std_req__isosae21434__assessment_15724[version==1],
+              std_req__isosae21434__assessment_15725[version==1],
+              std_req__isosae21434__assessment_15821[version==1],
+              std_req__isosae21434__assessment_15822[version==1],
+              std_req__isosae21434__assessment_15921[version==1]
 
    The argument shall describe why the mitigation is sufficient or not. If it is not sufficient, the argument shall describe how the mitigation
    can be improved to achieve sufficiency. The argument shall be written in the content.
@@ -108,9 +163,13 @@ Process Security Analysis Attributes
 .. gd_req:: Security Analysis attribute: status
    :id: gd_req__sec_attr_status
    :status: valid
+   :version: 1
    :tags: prio_1_automation, attribute, mandatory
-   :satisfies: wf__analyse_sec_platform_featarch, wf__analyse_sec_featarch, wf__analyse_sec_comparch
-   :complies: std_req__isosae21434__continual_8322, std_req__isosae21434__continual_8621, std_req__isosae21434__continual_8622, std_req__isosae21434__assessment_15921
+   :satisfies: wf__analyse_sec_platform_featarch[version==1], wf__analyse_sec_featarch[version==1], wf__analyse_sec_comparch[version==1]
+   :complies: std_req__isosae21434__continual_8322[version==1],
+              std_req__isosae21434__continual_8621[version==1],
+              std_req__isosae21434__continual_8622[version==1],
+              std_req__isosae21434__assessment_15921[version==1]
 
    Each Security Analysis shall have the status invalid until the analysis is finished.
    The status shall be set to valid if the analysis is finished and all issues are closed.
@@ -118,9 +177,19 @@ Process Security Analysis Attributes
 .. gd_req:: Security Analysis attribute: threat impact
    :id: gd_req__sec_attr_teffect
    :status: valid
+   :version: 1
    :tags: prio_1_automation, attribute, mandatory
-   :satisfies: wf__analyse_sec_platform_featarch, wf__analyse_sec_featarch, wf__analyse_sec_comparch
-   :complies: std_req__isosae21434__continual_8321, std_req__isosae21434__assessment_15621, std_req__isosae21434__assessment_15622, std_req__isosae21434__assessment_15721, std_req__isosae21434__assessment_15722, std_req__isosae21434__assessment_15723, std_req__isosae21434__assessment_15724, std_req__isosae21434__assessment_15725, std_req__isosae21434__assessment_15822, std_req__isosae21434__assessment_15921
+   :satisfies: wf__analyse_sec_platform_featarch[version==1], wf__analyse_sec_featarch[version==1], wf__analyse_sec_comparch[version==1]
+   :complies: std_req__isosae21434__continual_8321[version==1],
+              std_req__isosae21434__assessment_15621[version==1],
+              std_req__isosae21434__assessment_15622[version==1],
+              std_req__isosae21434__assessment_15721[version==1],
+              std_req__isosae21434__assessment_15722[version==1],
+              std_req__isosae21434__assessment_15723[version==1],
+              std_req__isosae21434__assessment_15724[version==1],
+              std_req__isosae21434__assessment_15725[version==1],
+              std_req__isosae21434__assessment_15822[version==1],
+              std_req__isosae21434__assessment_15921[version==1]
 
    Every Security Analysis shall have a short description of the threat impact
    (e.g. threat leads to unauthorized access of the analyzed element)
@@ -133,8 +202,9 @@ Security Analysis Linkage
 .. gd_req:: Security Analysis Linkage check
    :id: gd_req__sec_linkage_check
    :status: valid
+   :version: 1
    :tags: prio_1_automation, attribute, automated
-   :satisfies: wf__analyse_sec_platform_featarch, wf__analyse_sec_featarch, wf__analyse_sec_comparch
+   :satisfies: wf__analyse_sec_platform_featarch[version==1], wf__analyse_sec_featarch[version==1], wf__analyse_sec_comparch[version==1]
    :complies:
 
    Security Analysis shall be linked to the architecture view on the corresponding level
@@ -143,8 +213,9 @@ Security Analysis Linkage
 .. gd_req:: Security Analysis Linkage
    :id: gd_req__sec_linkage
    :status: valid
+   :version: 1
    :tags: prio_2_automation, attribute, automated
-   :satisfies: wf__analyse_sec_platform_featarch, wf__analyse_sec_featarch, wf__analyse_sec_comparch
+   :satisfies: wf__analyse_sec_platform_featarch[version==1], wf__analyse_sec_featarch[version==1], wf__analyse_sec_comparch[version==1]
    :complies:
 
    Each Security Analysis shall be automatically linked (inverse direction) to the
@@ -153,8 +224,9 @@ Security Analysis Linkage
 .. gd_req:: Security Analysis attribute: check Requirements linkage
    :id: gd_req__sec_attr_requirements_check
    :status: valid
+   :version: 1
    :tags: prio_1_automation, attribute, automated
-   :satisfies: wf__analyse_sec_platform_featarch, wf__analyse_sec_featarch, wf__analyse_sec_comparch
+   :satisfies: wf__analyse_sec_platform_featarch[version==1], wf__analyse_sec_featarch[version==1], wf__analyse_sec_comparch[version==1]
    :complies:
 
    Security Analysis shall be linked to a requirement on the corresponding level via
@@ -163,8 +235,9 @@ Security Analysis Linkage
 .. gd_req:: Security Analysis attribute: Requirements linkage
    :id: gd_req__sec_attr_requirements
    :status: valid
+   :version: 1
    :tags: prio_2_automation, attribute, automated
-   :satisfies: wf__analyse_sec_platform_featarch, wf__analyse_sec_featarch, wf__analyse_sec_comparch
+   :satisfies: wf__analyse_sec_platform_featarch[version==1], wf__analyse_sec_featarch[version==1], wf__analyse_sec_comparch[version==1]
    :complies:
 
    Each Security Analysis shall be automatically linked to the corresponding Security
@@ -173,8 +246,9 @@ Security Analysis Linkage
 .. gd_req:: Security Analysis attribute: link to Aou
    :id: gd_req__sec_attr_aou
    :status: valid
+   :version: 1
    :tags: prio_1_automation, attribute, automated
-   :satisfies: wf__analyse_sec_platform_featarch, wf__analyse_sec_featarch, wf__analyse_sec_comparch
+   :satisfies: wf__analyse_sec_platform_featarch[version==1], wf__analyse_sec_featarch[version==1], wf__analyse_sec_comparch[version==1]
    :complies:
 
    It shall be possible to link AoU.
@@ -182,8 +256,9 @@ Security Analysis Linkage
 .. gd_req:: Security Analysis attribute: versioning
    :id: gd_req__sec_attr_ver
    :status: valid
+   :version: 1
    :tags: prio_2_automation, attribute, automated
-   :satisfies: wf__analyse_sec_platform_featarch, wf__analyse_sec_featarch, wf__analyse_sec_comparch
+   :satisfies: wf__analyse_sec_platform_featarch[version==1], wf__analyse_sec_featarch[version==1], wf__analyse_sec_comparch[version==1]
    :complies:
 
    It shall be possible to detect any differences in mandatory attributes compared to
@@ -192,8 +267,9 @@ Security Analysis Linkage
 .. gd_req:: Security Analysis Linkage status check
    :id: gd_req__sec_linkage_status_check
    :status: valid
+   :version: 1
    :tags: prio_3_automation, attribute, automated
-   :satisfies: wf__analyse_sec_platform_featarch, wf__analyse_sec_featarch, wf__analyse_sec_comparch
+   :satisfies: wf__analyse_sec_platform_featarch[version==1], wf__analyse_sec_featarch[version==1], wf__analyse_sec_comparch[version==1]
    :complies:
 
    It shall be checked that the Security Analysis can only be linked against valid
@@ -208,9 +284,10 @@ Security Analysis Checks
 .. gd_req:: Security Analysis mandatory attributes provided
    :id: gd_req__sec_attr_mandatory
    :status: valid
+   :version: 1
    :tags: prio_1_automation, attribute, check
-   :satisfies: wf__analyse_sec_platform_featarch, wf__analyse_sec_featarch, wf__analyse_sec_comparch
-   :complies: std_req__isosae21434__continual_8621,
+   :satisfies: wf__analyse_sec_platform_featarch[version==1], wf__analyse_sec_featarch[version==1], wf__analyse_sec_comparch[version==1]
+   :complies: std_req__isosae21434__continual_8621[version==1]
 
    It shall be checked if all mandatory attributes for each Security Analysis are
    provided by the user. For all Security Analysis following attributes shall be mandatory:
@@ -225,8 +302,9 @@ Security Analysis Checks
 .. gd_req:: Security Analysis linkage security
    :id: gd_req__sec_linkage_security
    :status: valid
+   :version: 1
    :tags: prio_2_automation, attribute, check
-   :satisfies: wf__analyse_sec_platform_featarch, wf__analyse_sec_featarch, wf__analyse_sec_comparch
+   :satisfies: wf__analyse_sec_platform_featarch[version==1], wf__analyse_sec_featarch[version==1], wf__analyse_sec_comparch[version==1]
    :complies:
 
    It shall be checked that Security Analysis can only be linked via mitigate_by against
@@ -237,8 +315,9 @@ Security Analysis Checks
 .. gd_req:: Security Analysis finalization check
    :id: gd_req__sec_finalization_check
    :status: valid
+   :version: 1
    :tags: prio_2_automation, attribute, automated
-   :satisfies: wf__analyse_sec_platform_featarch, wf__analyse_sec_featarch, wf__analyse_sec_comparch
+   :satisfies: wf__analyse_sec_platform_featarch[version==1], wf__analyse_sec_featarch[version==1], wf__analyse_sec_comparch[version==1]
    :complies:
 
     It shall be checked if all artifacts of the analysis are "valid" and "sufficient".
@@ -249,9 +328,17 @@ Threat Scenario Security Process Requirements
 .. gd_req:: Security Analysis attribute: threat scenario ID
    :id: gd_req__sec_attr_threat_scenario_id
    :status: valid
+   :version: 1
    :tags: prio_1_automation, attribute, mandatory
-   :satisfies: wf__analyse_sec_platform_featarch, wf__analyse_sec_featarch, wf__analyse_sec_comparch
-   :complies: std_req__isosae21434__assessment_15621, std_req__isosae21434__assessment_15622, std_req__isosae21434__assessment_15723, std_req__isosae21434__assessment_15724, std_req__isosae21434__assessment_15725, std_req__isosae21434__assessment_15821, std_req__isosae21434__assessment_15822, std_req__isosae21434__assessment_15921
+   :satisfies: wf__analyse_sec_platform_featarch[version==1], wf__analyse_sec_featarch[version==1], wf__analyse_sec_comparch[version==1]
+   :complies: std_req__isosae21434__assessment_15621[version==1],
+              std_req__isosae21434__assessment_15622[version==1],
+              std_req__isosae21434__assessment_15723[version==1],
+              std_req__isosae21434__assessment_15724[version==1],
+              std_req__isosae21434__assessment_15725[version==1],
+              std_req__isosae21434__assessment_15821[version==1],
+              std_req__isosae21434__assessment_15822[version==1],
+              std_req__isosae21434__assessment_15921[version==1]
 
    Each threat scenario used for the Security Analysis shall have a threat scenario ID.
    The threat scenario ID is used to identify the related threat <:need:`gd_guidl__sec_ana_threat_scenarios`>.
@@ -265,9 +352,17 @@ Threat Models Process Requirements
 .. gd_req:: Threat Model attribute: threat ID
    :id: gd_req__sec_attr_stride_threat_id
    :status: valid
+   :version: 1
    :tags: prio_1_automation, attribute, mandatory
-   :satisfies: wf__analyse_sec_featarch, wf__analyse_sec_comparch
-   :complies: std_req__isosae21434__assessment_15621, std_req__isosae21434__assessment_15622, std_req__isosae21434__assessment_15723, std_req__isosae21434__assessment_15724, std_req__isosae21434__assessment_15725, std_req__isosae21434__assessment_15821, std_req__isosae21434__assessment_15822, std_req__isosae21434__assessment_15921
+   :satisfies: wf__analyse_sec_featarch[version==1], wf__analyse_sec_comparch[version==1]
+   :complies: std_req__isosae21434__assessment_15621[version==1],
+              std_req__isosae21434__assessment_15622[version==1],
+              std_req__isosae21434__assessment_15723[version==1],
+              std_req__isosae21434__assessment_15724[version==1],
+              std_req__isosae21434__assessment_15725[version==1],
+              std_req__isosae21434__assessment_15821[version==1],
+              std_req__isosae21434__assessment_15822[version==1],
+              std_req__isosae21434__assessment_15921[version==1]
 
    Each threat used for Security Analysis shall have a threat ID. The threat ID is used
    to identify the related threat <:need:`gd_guidl__threat_models_stride`>.

--- a/process/process_areas/security_analysis/guidance/security_analysis_threat_models_guideline.rst
+++ b/process/process_areas/security_analysis/guidance/security_analysis_threat_models_guideline.rst
@@ -20,6 +20,7 @@ Security Analysis Threat Models
 .. gd_guidl:: STRIDE Threat Model
   :id: gd_guidl__threat_models_stride
   :status: valid
+  :version: 1
   :complies:
 
   | Threat Model for sequence diagrams using STRIDE methodology

--- a/process/process_areas/security_analysis/guidance/security_analysis_threat_scenario_templates.rst
+++ b/process/process_areas/security_analysis/guidance/security_analysis_threat_scenario_templates.rst
@@ -22,6 +22,7 @@ Security Analysis Threat Scenario Templates
 .. gd_temp:: Platform Security Analysis Templates
    :id: gd_temp__plat_threat_scenario
    :status: valid
+   :version: 1
    :complies:
 
    For the content see here: (tbd)need:`doc__platform_security_analysis`
@@ -32,6 +33,7 @@ Security Analysis Threat Scenario Templates
 .. gd_temp:: Feature Security Analysis Templates
    :id: gd_temp__feat_threat_scenario
    :status: valid
+   :version: 1
    :complies:
 
    For the content see here: (tbd)need:`doc__feature_name_security_analysis`
@@ -41,6 +43,7 @@ Security Analysis Threat Scenario Templates
 .. gd_temp:: Component Security Analysis Templates
    :id: gd_temp__comp_threat_scenario
    :status: valid
+   :version: 1
    :complies:
 
    For the content see here: (tbd) `Component Security Analysis Template <https://eclipse-score.github.io/module_template/main/score/component_example/docs/index.html>`__

--- a/process/process_areas/security_analysis/guidance/security_analysis_threat_scenarios_guideline.rst
+++ b/process/process_areas/security_analysis/guidance/security_analysis_threat_scenarios_guideline.rst
@@ -22,6 +22,7 @@ Security Analysis threat scenarios
 .. gd_guidl:: Security Analysis threat scenarios
   :id: gd_guidl__sec_ana_threat_scenarios
   :status: valid
+  :version: 1
   :complies:
 
 .. note::

--- a/process/process_areas/security_analysis/guidance/security_analysis_threat_templates.rst
+++ b/process/process_areas/security_analysis/guidance/security_analysis_threat_templates.rst
@@ -22,6 +22,7 @@ Security Analysis Threat Templates
 .. gd_temp:: Feature Threat Template
    :id: gd_temp__feat_sec_ana_threat
    :status: valid
+   :version: 1
    :complies:
 
       For the content see here: (tbd)need:`doc__feature_name_threat`
@@ -31,6 +32,7 @@ Security Analysis Threat Templates
 .. gd_temp:: Component Threat Template
    :id: gd_temp__comp_sec_ana_threat
    :status: valid
+   :version: 1
    :complies:
 
       For the content see here: (tbd) `Component Threat Template <https://eclipse-score.github.io/module_template/main/score/component_example/docs/index.html>`__

--- a/process/process_areas/security_analysis/security_analysis_concept.rst
+++ b/process/process_areas/security_analysis/security_analysis_concept.rst
@@ -20,6 +20,7 @@ Concept Description
 .. doc_concept:: Security Analysis Concept
    :id: doc_concept__security_analysis
    :status: valid
+   :version: 1
    :tags: security_analysis
 
 This section discusses a concept for Security Analysis. Various methods can be used for Security Analysis (e.g. STRIDE).

--- a/process/process_areas/security_analysis/security_analysis_getstrt.rst
+++ b/process/process_areas/security_analysis/security_analysis_getstrt.rst
@@ -20,6 +20,7 @@ Getting Started
 .. doc_getstrt:: Getting Started on Security Analysis
    :id: doc_getstrt__security_analysis
    :status: valid
+   :version: 1
    :tags: security_analysis
 
 

--- a/process/process_areas/security_analysis/security_analysis_roles.rst
+++ b/process/process_areas/security_analysis/security_analysis_roles.rst
@@ -20,7 +20,8 @@ Roles
 .. role:: Security Engineer
    :id: rl__security_engineer
    :status: valid
-   :contains: rl__committer
+   :version: 1
+   :contains: rl__committer[version==1]
 
    The Security Engineer is responsible for the Security Analysis in the project.
    There might be several analyses on different levels (Platform, Feature and Component).

--- a/process/process_areas/security_analysis/security_analysis_workflow.rst
+++ b/process/process_areas/security_analysis/security_analysis_workflow.rst
@@ -26,14 +26,15 @@ Security analysis is used as an umbrella term.
 .. workflow:: Analyze Platform
    :id: wf__analyse_sec_platform_featarch
    :status: valid
+   :version: 1
    :tags: security_analysis
-   :responsible: rl__security_engineer
-   :approved_by: rl__security_manager
-   :supported_by: rl__contributor, rl__committer, rl__safety_manager
-   :input: wp__requirements_feat, wp__feature_arch, wp__issue_track_system
-   :output: wp__platform_security_analysis
-   :contains: gd_guidl__sec_ana_threat_scenarios, gd_temp__plat_threat_scenario
-   :has: doc_concept__security_analysis, doc_getstrt__security_analysis
+   :responsible: rl__security_engineer[version==1]
+   :approved_by: rl__security_manager[version==1]
+   :supported_by: rl__contributor[version==1], rl__committer[version==1], rl__safety_manager[version==1]
+   :input: wp__requirements_feat[version==1], wp__feature_arch[version==1], wp__issue_track_system[version==1]
+   :output: wp__platform_security_analysis[version==1]
+   :contains: gd_guidl__sec_ana_threat_scenarios[version==1], gd_temp__plat_threat_scenario[version==1]
+   :has: doc_concept__security_analysis[version==1], doc_getstrt__security_analysis[version==1]
 
    | With a platform Security Analysis the potential attack surfaces of features shall
    | be analyzed. It shall be used as an input for all other analysis.
@@ -42,56 +43,77 @@ Security analysis is used as an umbrella term.
 .. workflow:: Analyse Feature Architecture
    :id: wf__analyse_sec_featarch
    :status: valid
+   :version: 1
    :tags: security_analysis
-   :responsible: rl__security_engineer
-   :approved_by: rl__security_manager
-   :supported_by: rl__contributor, rl__committer, rl__safety_manager
-   :input: wp__requirements_feat, wp__feature_arch, wp__issue_track_system
-   :output: wp__feature_security_analysis
-   :contains: gd_guidl__sec_ana_threat_scenarios, gd_temp__feat_threat_scenario, gd_guidl__threat_models_stride, gd_temp__feat_sec_ana_threat
-   :has: doc_concept__security_analysis, doc_getstrt__security_analysis
+   :responsible: rl__security_engineer[version==1]
+   :approved_by: rl__security_manager[version==1]
+   :supported_by: rl__contributor[version==1], rl__committer[version==1], rl__safety_manager[version==1]
+   :input: wp__requirements_feat[version==1], wp__feature_arch[version==1], wp__issue_track_system[version==1]
+   :output: wp__feature_security_analysis[version==1]
+   :contains: gd_guidl__sec_ana_threat_scenarios[version==1],
+              gd_temp__feat_threat_scenario[version==1],
+              gd_guidl__threat_models_stride[version==1],
+              gd_temp__feat_sec_ana_threat[version==1]
+   :has: doc_concept__security_analysis[version==1], doc_getstrt__security_analysis[version==1]
 
    | The Security Analysis for the feature is executed.
 
 .. workflow:: Analyse Component Architecture
    :id: wf__analyse_sec_comparch
    :status: valid
+   :version: 1
    :tags: security_analysis
-   :responsible: rl__security_engineer
-   :approved_by: rl__security_manager
-   :supported_by: rl__contributor, rl__committer, rl__safety_manager
-   :input:  wp__requirements_comp, wp__component_arch, wp__issue_track_system
-   :output: wp__sw_component_security_analysis
-   :contains: gd_guidl__sec_ana_threat_scenarios, gd_temp__comp_threat_scenario, gd_guidl__threat_models_stride, gd_temp__comp_sec_ana_threat
-   :has: doc_concept__security_analysis, doc_getstrt__security_analysis
+   :responsible: rl__security_engineer[version==1]
+   :approved_by: rl__security_manager[version==1]
+   :supported_by: rl__contributor[version==1], rl__committer[version==1], rl__safety_manager[version==1]
+   :input: wp__requirements_comp[version==1], wp__component_arch[version==1], wp__issue_track_system[version==1]
+   :output: wp__sw_component_security_analysis[version==1]
+   :contains: gd_guidl__sec_ana_threat_scenarios[version==1],
+              gd_temp__comp_threat_scenario[version==1],
+              gd_guidl__threat_models_stride[version==1],
+              gd_temp__comp_sec_ana_threat[version==1]
+   :has: doc_concept__security_analysis[version==1], doc_getstrt__security_analysis[version==1]
 
    | The Security Analysis for the component is executed.
 
 .. workflow:: Monitor Security Analysis
    :id: wf__mr_sec_analyses
    :status: valid
+   :version: 1
    :tags: security_analysis
-   :responsible: rl__security_engineer
-   :approved_by: rl__security_manager
-   :supported_by: rl__contributor, rl__committer, rl__safety_manager
-   :input: wp__platform_security_analysis, wp__feature_security_analysis, wp__sw_component_security_analysis
-   :output: wp__verification_platform_ver_report, wp__issue_track_system, wp__verification_module_ver_report
-   :contains: gd_guidl__sec_ana_threat_scenarios, gd_temp__feat_threat_scenario, gd_temp__comp_threat_scenario, gd_guidl__threat_models_stride, gd_temp__feat_sec_ana_threat, gd_temp__comp_sec_ana_threat
-   :has: doc_concept__security_analysis, doc_getstrt__security_analysis
+   :responsible: rl__security_engineer[version==1]
+   :approved_by: rl__security_manager[version==1]
+   :supported_by: rl__contributor[version==1], rl__committer[version==1], rl__safety_manager[version==1]
+   :input: wp__platform_security_analysis[version==1], wp__feature_security_analysis[version==1], wp__sw_component_security_analysis[version==1]
+   :output: wp__verification_platform_ver_report[version==1], wp__issue_track_system[version==1], wp__verification_module_ver_report[version==1]
+   :contains: gd_guidl__sec_ana_threat_scenarios[version==1],
+              gd_temp__feat_threat_scenario[version==1],
+              gd_temp__comp_threat_scenario[version==1],
+              gd_guidl__threat_models_stride[version==1],
+              gd_temp__feat_sec_ana_threat[version==1],
+              gd_temp__comp_sec_ana_threat[version==1]
+   :has: doc_concept__security_analysis[version==1], doc_getstrt__security_analysis[version==1]
 
    | The Security Analyses are monitored.
 
 .. workflow:: Verify Security Analysis
    :id: wf__vy_sec_analyses
    :status: valid
+   :version: 1
    :tags: security_analysis
-   :responsible: rl__security_engineer
-   :approved_by: rl__security_manager
-   :supported_by: rl__contributor, rl__committer, rl__safety_manager
-   :input: wp__platform_security_analysis, wp__feature_security_analysis, wp__sw_component_security_analysis
-   :output: wp__verification_platform_ver_report, wp__verification_module_ver_report
-   :contains: gd_guidl__sec_ana_threat_scenarios, gd_temp__feat_threat_scenario, gd_temp__comp_threat_scenario, gd_guidl__threat_models_stride, gd_temp__feat_sec_ana_threat, gd_temp__comp_sec_ana_threat, gd_chklst__security_analysis
-   :has: doc_concept__security_analysis, doc_getstrt__security_analysis
+   :responsible: rl__security_engineer[version==1]
+   :approved_by: rl__security_manager[version==1]
+   :supported_by: rl__contributor[version==1], rl__committer[version==1], rl__safety_manager[version==1]
+   :input: wp__platform_security_analysis[version==1], wp__feature_security_analysis[version==1], wp__sw_component_security_analysis[version==1]
+   :output: wp__verification_platform_ver_report[version==1], wp__verification_module_ver_report[version==1]
+   :contains: gd_guidl__sec_ana_threat_scenarios[version==1],
+              gd_temp__feat_threat_scenario[version==1],
+              gd_temp__comp_threat_scenario[version==1],
+              gd_guidl__threat_models_stride[version==1],
+              gd_temp__feat_sec_ana_threat[version==1],
+              gd_temp__comp_sec_ana_threat[version==1],
+              gd_chklst__security_analysis[version==1]
+   :has: doc_concept__security_analysis[version==1], doc_getstrt__security_analysis[version==1]
 
    | The Security Analyses are verified. The verification criteria is that it can be
    | proven that the security requirements for functions and the corresponding security

--- a/process/process_areas/security_analysis/security_analysis_workproducts.rst
+++ b/process/process_areas/security_analysis/security_analysis_workproducts.rst
@@ -20,8 +20,9 @@ Security Analysis Work Products
 .. workproduct:: Platform Security Analysis
    :id: wp__platform_security_analysis
    :status: valid
+   :version: 1
    :tags: doc_lifecycle_model_2
-   :complies: std_wp__isosae21434__development_1055, std_wp__isosae21434__assessment_15332, std_wp__isosae21434__assessment_15431
+   :complies: std_wp__isosae21434__development_1055[version==1], std_wp__isosae21434__assessment_15332[version==1], std_wp__isosae21434__assessment_15431[version==1]
 
    Analyze the attack surfaces between features that references all platform feature
    static architecture diagrams, highlighting potential shared attack vectors.
@@ -29,8 +30,15 @@ Security Analysis Work Products
 .. workproduct:: Feature Security Analysis
    :id: wp__feature_security_analysis
    :status: valid
+   :version: 1
    :tags: doc_lifecycle_model_2
-   :complies: std_wp__isosae21434__development_1055, std_wp__isosae21434__assessment_15332, std_wp__isosae21434__assessment_15431, std_wp__isosae21434__assessment_15631, std_wp__isosae21434__assessment_15731, std_wp__isosae21434__assessment_15831, std_wp__isosae21434__assessment_15931
+   :complies: std_wp__isosae21434__development_1055[version==1],
+              std_wp__isosae21434__assessment_15332[version==1],
+              std_wp__isosae21434__assessment_15431[version==1],
+              std_wp__isosae21434__assessment_15631[version==1],
+              std_wp__isosae21434__assessment_15731[version==1],
+              std_wp__isosae21434__assessment_15831[version==1],
+              std_wp__isosae21434__assessment_15931[version==1]
 
    Bottom-Up Security Analysis with defined methods, verifies the feature architecture (as part of SW Security Concept)
    - Mitigations linked to Software Feature Requirements or Assumptions of Use
@@ -46,8 +54,15 @@ Security Analysis Work Products
 .. workproduct:: Component Security Analysis
    :id: wp__sw_component_security_analysis
    :status: valid
+   :version: 1
    :tags: doc_lifecycle_model_2
-   :complies: std_wp__isosae21434__development_1055, std_wp__isosae21434__assessment_15332, std_wp__isosae21434__assessment_15431, std_wp__isosae21434__assessment_15631, std_wp__isosae21434__assessment_15731, std_wp__isosae21434__assessment_15831, std_wp__isosae21434__assessment_15931
+   :complies: std_wp__isosae21434__development_1055[version==1],
+              std_wp__isosae21434__assessment_15332[version==1],
+              std_wp__isosae21434__assessment_15431[version==1],
+              std_wp__isosae21434__assessment_15631[version==1],
+              std_wp__isosae21434__assessment_15731[version==1],
+              std_wp__isosae21434__assessment_15831[version==1],
+              std_wp__isosae21434__assessment_15931[version==1]
 
    Bottom-Up Security Analysis with defined methods, verifies the component architecture (as part of SW Security Concept)
    - Mitigations linked to Software Component Requirements or Assumptions of Use

--- a/process/process_areas/security_management/guidance/checklist_security_package.rst
+++ b/process/process_areas/security_management/guidance/checklist_security_package.rst
@@ -18,6 +18,7 @@ Security Package Formal Review Checklist
 .. gd_chklst:: Security Package Formal Review Checklist
    :id: gd_chklst__security_package
    :status: valid
-   :complies: std_req__isosae21434__prj_management_6471, std_req__isosae21434__prj_management_6491, std_req__isosae21434__prj_management_6492
+   :version: 1
+   :complies: std_req__isosae21434__prj_management_6471[version==1], std_req__isosae21434__prj_management_6491[version==1], std_req__isosae21434__prj_management_6492[version==1]
 
    For the content see here: `Security Package Formal Review Checklist <https://eclipse-score.github.io/module_template/main/docs/security_mgt/module_security_package_fdr.html>`__

--- a/process/process_areas/security_management/guidance/checklist_security_plan.rst
+++ b/process/process_areas/security_management/guidance/checklist_security_plan.rst
@@ -18,13 +18,57 @@ Security Plan Formal Review Checklist
 .. gd_chklst:: Platform Security Plan Formal Review Checklist
    :id: gd_chklst__platform_security_plan
    :status: valid
-   :complies: std_req__isosae21434__prj_management_6411, std_req__isosae21434__prj_management_6421, std_req__isosae21434__prj_management_6422, std_req__isosae21434__prj_management_6423, std_req__isosae21434__prj_management_6424, std_req__isosae21434__prj_management_6425, std_req__isosae21434__prj_management_6426, std_req__isosae21434__prj_management_6427, std_req__isosae21434__prj_management_6428, std_req__isosae21434__prj_management_6429, std_req__isosae21434__prj_management_64210, std_req__isosae21434__prj_management_64211, std_req__isosae21434__prj_management_6431, std_req__isosae21434__prj_management_6432, std_req__isosae21434__prj_management_6441, std_req__isosae21434__prj_management_6442, std_req__isosae21434__prj_management_6443, std_req__isosae21434__prj_management_6451, std_req__isosae21434__prj_management_6452, std_req__isosae21434__prj_management_6453, std_req__isosae21434__prj_management_6461, std_req__isosae21434__prj_management_6462
+   :version: 1
+   :complies: std_req__isosae21434__prj_management_6411[version==1],
+              std_req__isosae21434__prj_management_6421[version==1],
+              std_req__isosae21434__prj_management_6422[version==1],
+              std_req__isosae21434__prj_management_6423[version==1],
+              std_req__isosae21434__prj_management_6424[version==1],
+              std_req__isosae21434__prj_management_6425[version==1],
+              std_req__isosae21434__prj_management_6426[version==1],
+              std_req__isosae21434__prj_management_6427[version==1],
+              std_req__isosae21434__prj_management_6428[version==1],
+              std_req__isosae21434__prj_management_6429[version==1],
+              std_req__isosae21434__prj_management_64210[version==1],
+              std_req__isosae21434__prj_management_64211[version==1],
+              std_req__isosae21434__prj_management_6431[version==1],
+              std_req__isosae21434__prj_management_6432[version==1],
+              std_req__isosae21434__prj_management_6441[version==1],
+              std_req__isosae21434__prj_management_6442[version==1],
+              std_req__isosae21434__prj_management_6443[version==1],
+              std_req__isosae21434__prj_management_6451[version==1],
+              std_req__isosae21434__prj_management_6452[version==1],
+              std_req__isosae21434__prj_management_6453[version==1],
+              std_req__isosae21434__prj_management_6461[version==1],
+              std_req__isosae21434__prj_management_6462[version==1]
 
    For the content see here: :need:`doc__platform_name_security_plan_fdr`
 
 .. gd_chklst:: Module Security Plan Formal Review Checklist
    :id: gd_chklst__security_plan
    :status: valid
-   :complies: std_req__isosae21434__prj_management_6411, std_req__isosae21434__prj_management_6421, std_req__isosae21434__prj_management_6422, std_req__isosae21434__prj_management_6423, std_req__isosae21434__prj_management_6424, std_req__isosae21434__prj_management_6425, std_req__isosae21434__prj_management_6426, std_req__isosae21434__prj_management_6427, std_req__isosae21434__prj_management_6428, std_req__isosae21434__prj_management_6429, std_req__isosae21434__prj_management_64210, std_req__isosae21434__prj_management_64211, std_req__isosae21434__prj_management_6431, std_req__isosae21434__prj_management_6432, std_req__isosae21434__prj_management_6441, std_req__isosae21434__prj_management_6442, std_req__isosae21434__prj_management_6443, std_req__isosae21434__prj_management_6451, std_req__isosae21434__prj_management_6452, std_req__isosae21434__prj_management_6453, std_req__isosae21434__prj_management_6461, std_req__isosae21434__prj_management_6462
+   :version: 1
+   :complies: std_req__isosae21434__prj_management_6411[version==1],
+              std_req__isosae21434__prj_management_6421[version==1],
+              std_req__isosae21434__prj_management_6422[version==1],
+              std_req__isosae21434__prj_management_6423[version==1],
+              std_req__isosae21434__prj_management_6424[version==1],
+              std_req__isosae21434__prj_management_6425[version==1],
+              std_req__isosae21434__prj_management_6426[version==1],
+              std_req__isosae21434__prj_management_6427[version==1],
+              std_req__isosae21434__prj_management_6428[version==1],
+              std_req__isosae21434__prj_management_6429[version==1],
+              std_req__isosae21434__prj_management_64210[version==1],
+              std_req__isosae21434__prj_management_64211[version==1],
+              std_req__isosae21434__prj_management_6431[version==1],
+              std_req__isosae21434__prj_management_6432[version==1],
+              std_req__isosae21434__prj_management_6441[version==1],
+              std_req__isosae21434__prj_management_6442[version==1],
+              std_req__isosae21434__prj_management_6443[version==1],
+              std_req__isosae21434__prj_management_6451[version==1],
+              std_req__isosae21434__prj_management_6452[version==1],
+              std_req__isosae21434__prj_management_6453[version==1],
+              std_req__isosae21434__prj_management_6461[version==1],
+              std_req__isosae21434__prj_management_6462[version==1]
 
    For the content see here: `Security Plan Formal Review Checklist <https://eclipse-score.github.io/module_template/main/docs/security_mgt/module_security_plan_fdr.html>`__

--- a/process/process_areas/security_management/guidance/security_management_guideline.rst
+++ b/process/process_areas/security_management/guidance/security_management_guideline.rst
@@ -20,8 +20,16 @@ Security Management Guideline
 .. gd_guidl:: Security plan definitions
    :id: gd_guidl__security_plan_definitions
    :status: valid
-   :complies: std_req__isosae21434__org_management_5421, std_req__isosae21434__org_management_5422, std_req__isosae21434__org_management_5423, std_req__isosae21434__org_management_5443, std_req__isosae21434__org_management_5451, std_req__isosae21434__org_management_5461, std_req__isosae21434__continual_8321, std_req__isosae21434__continual_8322,
-              std_req__aspice_40__iic-14-55
+   :version: 1
+   :complies: std_req__isosae21434__org_management_5421[version==1],
+              std_req__isosae21434__org_management_5422[version==1],
+              std_req__isosae21434__org_management_5423[version==1],
+              std_req__isosae21434__org_management_5443[version==1],
+              std_req__isosae21434__org_management_5451[version==1],
+              std_req__isosae21434__org_management_5461[version==1],
+              std_req__isosae21434__continual_8321[version==1],
+              std_req__isosae21434__continual_8322[version==1],
+              std_req__aspice_40__iic-14-55[version==1]
 
    **Security Culture:**
 
@@ -172,7 +180,8 @@ Security Management Guideline
 .. gd_guidl:: Security Manual Generation
    :id: gd_guidl__security_manual
    :status: valid
-   :complies: std_req__isosae21434__prj_management_6491, std_req__isosae21434__prj_management_6492
+   :version: 1
+   :complies: std_req__isosae21434__prj_management_6491[version==1], std_req__isosae21434__prj_management_6492[version==1]
 
    The Security Manual collects several work products and adds some additional content mainly to
    instruct the user of a OoC (in this project on platform and module level) to securely use it
@@ -183,7 +192,8 @@ Security Management Guideline
 .. gd_guidl:: Security Package Automated Generation
    :id: gd_guidl__security_package
    :status: valid
-   :complies: std_req__isosae21434__prj_management_6471
+   :version: 1
+   :complies: std_req__isosae21434__prj_management_6471[version==1]
 
    The Security Package shall be generated progressively and automatically compiling the work products.
    One of the checks to perform on the platform safety package is to check completeness of the

--- a/process/process_areas/security_management/guidance/security_management_process_reqs.rst
+++ b/process/process_areas/security_management/guidance/security_management_process_reqs.rst
@@ -19,9 +19,10 @@ Security Management Process Requirements
 .. gd_req:: Security Management attribute: status derivation
    :id: gd_req__security_doc_status
    :status: valid
+   :version: 1
    :tags: done_automation, attribute, mandatory
-   :satisfies: wf__cr_mt_security_plan
-   :complies: std_req__isosae21434__prj_management_6429
+   :satisfies: wf__cr_mt_security_plan[version==1]
+   :complies: std_req__isosae21434__prj_management_6429[version==1]
 
    Security Plans shall contain documents references where the status is derived automatically.
 
@@ -30,9 +31,10 @@ Security Management Process Requirements
 .. gd_req:: Security Management attribute: status accumulation
    :id: gd_req__security_wp_status
    :status: valid
+   :version: 1
    :tags: prio_2_automation, attribute, mandatory
-   :satisfies: wf__cr_mt_security_plan
-   :complies: std_req__isosae21434__prj_management_6429
+   :satisfies: wf__cr_mt_security_plan[version==1]
+   :complies: std_req__isosae21434__prj_management_6429[version==1]
 
    Security Plans shall contain work product references where the accumulated status is derived automatically.
 

--- a/process/process_areas/security_management/guidance/security_manual_templates.rst
+++ b/process/process_areas/security_management/guidance/security_manual_templates.rst
@@ -17,13 +17,15 @@ Security Manual Templates
 .. gd_temp:: Platform Security Manual Template
    :id: gd_temp__platform_security_manual
    :status: valid
-   :complies: std_req__isosae21434__development_10421, std_req__isosae21434__development_10422
+   :version: 1
+   :complies: std_req__isosae21434__development_10421[version==1], std_req__isosae21434__development_10422[version==1]
 
    For the content see here: :need:`doc__platform_security_manual`
 
 .. gd_temp:: Module Security Manual Template
    :id: gd_temp__module_security_manual
    :status: valid
-   :complies: std_req__isosae21434__development_10421, std_req__isosae21434__development_10422
+   :version: 1
+   :complies: std_req__isosae21434__development_10421[version==1], std_req__isosae21434__development_10422[version==1]
 
    For the content see here: `Module Security Manual Template <https://eclipse-score.github.io/module_template/main/docs/manuals/security_manual.html>`__

--- a/process/process_areas/security_management/guidance/security_plan_templates.rst
+++ b/process/process_areas/security_management/guidance/security_plan_templates.rst
@@ -18,20 +18,86 @@ Security Planning Templates
 .. gd_temp:: Platform Security Plan Template
    :id: gd_temp__platform_security_plan
    :status: valid
-   :complies: std_req__isosae21434__prj_management_6411, std_req__isosae21434__prj_management_6421, std_req__isosae21434__prj_management_6422, std_req__isosae21434__prj_management_6423, std_req__isosae21434__prj_management_6424, std_req__isosae21434__prj_management_6425, std_req__isosae21434__prj_management_6426, std_req__isosae21434__prj_management_6427, std_req__isosae21434__prj_management_6428, std_req__isosae21434__prj_management_6429, std_req__isosae21434__prj_management_64210, std_req__isosae21434__prj_management_64211, std_req__isosae21434__prj_management_6431, std_req__isosae21434__prj_management_6432, std_req__isosae21434__prj_management_6441, std_req__isosae21434__prj_management_6442, std_req__isosae21434__prj_management_6443, std_req__isosae21434__prj_management_6451, std_req__isosae21434__prj_management_6452, std_req__isosae21434__prj_management_6453, std_req__isosae21434__prj_management_6461, std_req__isosae21434__prj_management_6462
+   :version: 1
+   :complies: std_req__isosae21434__prj_management_6411[version==1],
+              std_req__isosae21434__prj_management_6421[version==1],
+              std_req__isosae21434__prj_management_6422[version==1],
+              std_req__isosae21434__prj_management_6423[version==1],
+              std_req__isosae21434__prj_management_6424[version==1],
+              std_req__isosae21434__prj_management_6425[version==1],
+              std_req__isosae21434__prj_management_6426[version==1],
+              std_req__isosae21434__prj_management_6427[version==1],
+              std_req__isosae21434__prj_management_6428[version==1],
+              std_req__isosae21434__prj_management_6429[version==1],
+              std_req__isosae21434__prj_management_64210[version==1],
+              std_req__isosae21434__prj_management_64211[version==1],
+              std_req__isosae21434__prj_management_6431[version==1],
+              std_req__isosae21434__prj_management_6432[version==1],
+              std_req__isosae21434__prj_management_6441[version==1],
+              std_req__isosae21434__prj_management_6442[version==1],
+              std_req__isosae21434__prj_management_6443[version==1],
+              std_req__isosae21434__prj_management_6451[version==1],
+              std_req__isosae21434__prj_management_6452[version==1],
+              std_req__isosae21434__prj_management_6453[version==1],
+              std_req__isosae21434__prj_management_6461[version==1],
+              std_req__isosae21434__prj_management_6462[version==1]
 
    For the content see here: :need:`doc__platform_security_plan`
 
 .. gd_temp:: Feature Security Work Products Template
    :id: gd_temp__feature_security_plan
    :status: valid
-   :complies: std_req__isosae21434__prj_management_6411, std_req__isosae21434__prj_management_6421, std_req__isosae21434__prj_management_6422, std_req__isosae21434__prj_management_6423, std_req__isosae21434__prj_management_6424, std_req__isosae21434__prj_management_6425, std_req__isosae21434__prj_management_6426, std_req__isosae21434__prj_management_6427, std_req__isosae21434__prj_management_6428, std_req__isosae21434__prj_management_6429, std_req__isosae21434__prj_management_64210, std_req__isosae21434__prj_management_64211, std_req__isosae21434__prj_management_6431, std_req__isosae21434__prj_management_6432, std_req__isosae21434__prj_management_6441, std_req__isosae21434__prj_management_6442, std_req__isosae21434__prj_management_6443, std_req__isosae21434__prj_management_6451, std_req__isosae21434__prj_management_6452, std_req__isosae21434__prj_management_6453, std_req__isosae21434__prj_management_6461, std_req__isosae21434__prj_management_6462
+   :version: 1
+   :complies: std_req__isosae21434__prj_management_6411[version==1],
+              std_req__isosae21434__prj_management_6421[version==1],
+              std_req__isosae21434__prj_management_6422[version==1],
+              std_req__isosae21434__prj_management_6423[version==1],
+              std_req__isosae21434__prj_management_6424[version==1],
+              std_req__isosae21434__prj_management_6425[version==1],
+              std_req__isosae21434__prj_management_6426[version==1],
+              std_req__isosae21434__prj_management_6427[version==1],
+              std_req__isosae21434__prj_management_6428[version==1],
+              std_req__isosae21434__prj_management_6429[version==1],
+              std_req__isosae21434__prj_management_64210[version==1],
+              std_req__isosae21434__prj_management_64211[version==1],
+              std_req__isosae21434__prj_management_6431[version==1],
+              std_req__isosae21434__prj_management_6432[version==1],
+              std_req__isosae21434__prj_management_6441[version==1],
+              std_req__isosae21434__prj_management_6442[version==1],
+              std_req__isosae21434__prj_management_6443[version==1],
+              std_req__isosae21434__prj_management_6451[version==1],
+              std_req__isosae21434__prj_management_6452[version==1],
+              std_req__isosae21434__prj_management_6453[version==1],
+              std_req__isosae21434__prj_management_6461[version==1],
+              std_req__isosae21434__prj_management_6462[version==1]
 
    For the content see here: `Feature Security Work Products Template <https://eclipse-score.github.io/module_template/main/docs/features/feature_example/security_planning/index.html>`__
 
 .. gd_temp:: Module Security Plan Template
    :id: gd_temp__module_security_plan
    :status: valid
-   :complies: std_req__isosae21434__prj_management_6411, std_req__isosae21434__prj_management_6421, std_req__isosae21434__prj_management_6422, std_req__isosae21434__prj_management_6423, std_req__isosae21434__prj_management_6424, std_req__isosae21434__prj_management_6425, std_req__isosae21434__prj_management_6426, std_req__isosae21434__prj_management_6427, std_req__isosae21434__prj_management_6428, std_req__isosae21434__prj_management_6429, std_req__isosae21434__prj_management_64210, std_req__isosae21434__prj_management_64211, std_req__isosae21434__prj_management_6431, std_req__isosae21434__prj_management_6432, std_req__isosae21434__prj_management_6441, std_req__isosae21434__prj_management_6442, std_req__isosae21434__prj_management_6443, std_req__isosae21434__prj_management_6451, std_req__isosae21434__prj_management_6452, std_req__isosae21434__prj_management_6453, std_req__isosae21434__prj_management_6461, std_req__isosae21434__prj_management_6462
+   :version: 1
+   :complies: std_req__isosae21434__prj_management_6411[version==1],
+              std_req__isosae21434__prj_management_6421[version==1],
+              std_req__isosae21434__prj_management_6422[version==1],
+              std_req__isosae21434__prj_management_6423[version==1],
+              std_req__isosae21434__prj_management_6424[version==1],
+              std_req__isosae21434__prj_management_6425[version==1],
+              std_req__isosae21434__prj_management_6426[version==1],
+              std_req__isosae21434__prj_management_6427[version==1],
+              std_req__isosae21434__prj_management_6428[version==1],
+              std_req__isosae21434__prj_management_6429[version==1],
+              std_req__isosae21434__prj_management_64210[version==1],
+              std_req__isosae21434__prj_management_64211[version==1],
+              std_req__isosae21434__prj_management_6431[version==1],
+              std_req__isosae21434__prj_management_6432[version==1],
+              std_req__isosae21434__prj_management_6441[version==1],
+              std_req__isosae21434__prj_management_6442[version==1],
+              std_req__isosae21434__prj_management_6443[version==1],
+              std_req__isosae21434__prj_management_6451[version==1],
+              std_req__isosae21434__prj_management_6452[version==1],
+              std_req__isosae21434__prj_management_6453[version==1],
+              std_req__isosae21434__prj_management_6461[version==1],
+              std_req__isosae21434__prj_management_6462[version==1]
 
    For the content see here: `Module Security Plan Template <https://eclipse-score.github.io/module_template/main/docs/security_mgt/module_security_plan.html>`__

--- a/process/process_areas/security_management/security_management_concept.rst
+++ b/process/process_areas/security_management/security_management_concept.rst
@@ -20,6 +20,7 @@ Concept Description
 .. doc_concept:: Concept Description
    :id: doc_concept__security_management_process
    :status: valid
+   :version: 1
    :tags: security_management
 
 In this section a concept for the security management will be discussed. Inputs for this concepts

--- a/process/process_areas/security_management/security_management_getstrt.rst
+++ b/process/process_areas/security_management/security_management_getstrt.rst
@@ -18,6 +18,7 @@ Getting Started
 .. doc_getstrt:: Getting Started on Change Management
    :id: doc_getstrt__security_management_process
    :status: valid
+   :version: 1
    :tags: security_management
 
 This document and sub chapters outlines the required steps to ensure that project complies with ISO SAE 21434 security standard.

--- a/process/process_areas/security_management/security_management_roles.rst
+++ b/process/process_areas/security_management/security_management_roles.rst
@@ -19,8 +19,9 @@ Roles
 .. role:: Security Manager
    :id: rl__security_manager
    :status: valid
+   :version: 1
    :tags: security_management
-   :contains: rl__committer
+   :contains: rl__committer[version==1]
 
    The Security Manager is responsible for making sure that ISO SAE 21434 is complied
    to in the project. The Security Manager shall lead and monitor the security relevant
@@ -69,6 +70,7 @@ Roles
 .. role:: Security External Auditor
    :id: rl__security_external_auditor
    :status: valid
+   :version: 1
 
    Required skills, Knowledge of security standards (ISO 21434), Experience
 

--- a/process/process_areas/security_management/security_management_workflow.rst
+++ b/process/process_areas/security_management/security_management_workflow.rst
@@ -22,13 +22,14 @@ For a detailed explanation of workflows and their role within the process model,
 .. workflow:: Create/Maintain Security Plan
    :id: wf__cr_mt_security_plan
    :status: valid
-   :responsible: rl__security_manager
-   :approved_by: rl__project_lead
-   :supported_by: rl__safety_manager
-   :input: wp__platform_mgmt, wp__issue_track_system, wp__tailoring_work_products
-   :output: wp__module_security_plan, wp__platform_security_plan
-   :contains: gd_guidl__security_plan_definitions, gd_temp__module_security_plan
-   :has: doc_concept__security_management_process, doc_getstrt__security_management_process
+   :version: 1
+   :responsible: rl__security_manager[version==1]
+   :approved_by: rl__project_lead[version==1]
+   :supported_by: rl__safety_manager[version==1]
+   :input: wp__platform_mgmt[version==1], wp__issue_track_system[version==1], wp__tailoring_work_products[version==1]
+   :output: wp__module_security_plan[version==1], wp__platform_security_plan[version==1]
+   :contains: gd_guidl__security_plan_definitions[version==1], gd_temp__module_security_plan[version==1]
+   :has: doc_concept__security_management_process[version==1], doc_getstrt__security_management_process[version==1]
 
    | The Security Manager is responsible for the planning and coordination of the security activities for the platform/module.
    | The Security Manager creates and maintains the Security Plan.
@@ -37,13 +38,14 @@ For a detailed explanation of workflows and their role within the process model,
 .. workflow:: Create/Maintain Security Package
    :id: wf__cr_mt_security_package
    :status: valid
-   :responsible: rl__security_engineer
-   :approved_by: rl__security_manager
-   :supported_by: rl__committer
-   :input: wp__module_security_plan, wp__platform_security_plan, wp__issue_track_system
-   :output: wp__module_security_package, wp__platform_security_package
-   :contains: gd_guidl__security_package, gd_temp__module_security_plan, gd_guidl__security_plan_definitions
-   :has: doc_concept__security_management_process, doc_getstrt__security_management_process
+   :version: 1
+   :responsible: rl__security_engineer[version==1]
+   :approved_by: rl__security_manager[version==1]
+   :supported_by: rl__committer[version==1]
+   :input: wp__module_security_plan[version==1], wp__platform_security_plan[version==1], wp__issue_track_system[version==1]
+   :output: wp__module_security_package[version==1], wp__platform_security_package[version==1]
+   :contains: gd_guidl__security_package[version==1], gd_temp__module_security_plan[version==1], gd_guidl__security_plan_definitions[version==1]
+   :has: doc_concept__security_management_process[version==1], doc_getstrt__security_management_process[version==1]
 
    | The Security Manager is NOT responsible to provide the argument for the achievement of security.
    | But the Security Manager creates and maintains the Security Package in the sense of a collection of security related work products.
@@ -54,13 +56,17 @@ For a detailed explanation of workflows and their role within the process model,
 .. workflow:: Perform Security Audit
    :id: wf__p_fs_audit_security
    :status: valid
-   :responsible: rl__security_external_auditor
-   :approved_by: rl__project_lead
-   :supported_by: rl__security_manager, rl__security_engineer
-   :input: wp__module_security_plan, wp__platform_security_plan, wp__module_security_package, wp__platform_security_package
-   :output: wp__audit_report_security
-   :contains: gd_guidl__security_plan_definitions
-   :has: doc_concept__security_management_process, doc_getstrt__security_management_process
+   :version: 1
+   :responsible: rl__security_external_auditor[version==1]
+   :approved_by: rl__project_lead[version==1]
+   :supported_by: rl__security_manager[version==1], rl__security_engineer[version==1]
+   :input: wp__module_security_plan[version==1],
+           wp__platform_security_plan[version==1],
+           wp__module_security_package[version==1],
+           wp__platform_security_package[version==1]
+   :output: wp__audit_report_security[version==1]
+   :contains: gd_guidl__security_plan_definitions[version==1]
+   :has: doc_concept__security_management_process[version==1], doc_getstrt__security_management_process[version==1]
 
    | The external auditor is responsible to perform a security audit.
    | The Security Manager and the process community shall support the external auditor during this.
@@ -71,13 +77,17 @@ For a detailed explanation of workflows and their role within the process model,
 .. workflow:: Perform Formal Security Reviews
    :id: wf__p_formal_security_rv
    :status: valid
-   :responsible: rl__security_external_auditor
-   :approved_by: rl__project_lead
-   :supported_by: rl__security_manager, rl__security_engineer
-   :input: wp__module_security_plan, wp__platform_security_plan, wp__module_security_package, wp__platform_security_package
-   :output: wp__fdr_reports_security
-   :contains: gd_guidl__security_plan_definitions, gd_chklst__security_plan, gd_chklst__security_package
-   :has: doc_concept__security_management_process, doc_getstrt__security_management_process
+   :version: 1
+   :responsible: rl__security_external_auditor[version==1]
+   :approved_by: rl__project_lead[version==1]
+   :supported_by: rl__security_manager[version==1], rl__security_engineer[version==1]
+   :input: wp__module_security_plan[version==1],
+           wp__platform_security_plan[version==1],
+           wp__module_security_package[version==1],
+           wp__platform_security_package[version==1]
+   :output: wp__fdr_reports_security[version==1]
+   :contains: gd_guidl__security_plan_definitions[version==1], gd_chklst__security_plan[version==1], gd_chklst__security_package[version==1]
+   :has: doc_concept__security_management_process[version==1], doc_getstrt__security_management_process[version==1]
 
    | The external auditor is responsible to perform the formal reviews on Security plan and Security Analysis.
    | The Security Manager shall support the external auditor during the reviews.
@@ -89,13 +99,26 @@ For a detailed explanation of workflows and their role within the process model,
 .. workflow:: Create/Maintain Security Manual
    :id: wf__cr_mt_security_manual
    :status: valid
-   :responsible: rl__security_engineer
-   :approved_by: rl__security_manager
-   :supported_by: rl__committer
-   :input: wp__requirements_feat_aou, wp__requirements_feat, wp__feature_arch, wp__feature_fmea, wp__feature_dfa, wp__requirements_comp_aou, wp__requirements_comp, wp__component_arch, wp__sw_component_fmea, wp__sw_component_dfa
-   :output: wp__platform_security_manual, wp__module_security_manual
-   :contains: gd_guidl__security_manual, gd_temp__platform_security_manual, gd_temp__module_security_manual, gd_guidl__security_plan_definitions
-   :has: doc_concept__security_management_process, doc_getstrt__security_management_process
+   :version: 1
+   :responsible: rl__security_engineer[version==1]
+   :approved_by: rl__security_manager[version==1]
+   :supported_by: rl__committer[version==1]
+   :input: wp__requirements_feat_aou[version==1],
+           wp__requirements_feat[version==1],
+           wp__feature_arch[version==1],
+           wp__feature_fmea[version==1],
+           wp__feature_dfa[version==1],
+           wp__requirements_comp_aou[version==1],
+           wp__requirements_comp[version==1],
+           wp__component_arch[version==1],
+           wp__sw_component_fmea[version==1],
+           wp__sw_component_dfa[version==1]
+   :output: wp__platform_security_manual[version==1], wp__module_security_manual[version==1]
+   :contains: gd_guidl__security_manual[version==1],
+              gd_temp__platform_security_manual[version==1],
+              gd_temp__module_security_manual[version==1],
+              gd_guidl__security_plan_definitions[version==1]
+   :has: doc_concept__security_management_process[version==1], doc_getstrt__security_management_process[version==1]
 
    | The Security Engineer collects the necessary input for the Security Manuals on
    | platform and module level and documents it.
@@ -105,13 +128,21 @@ For a detailed explanation of workflows and their role within the process model,
 .. workflow:: Create/Maintain SBOM
    :id: wf__cr_mt_security_sbom
    :status: valid
-   :responsible: rl__committer
-   :approved_by: rl__security_manager, rl__security_engineer, rl__project_lead
-   :supported_by: rl__infrastructure_tooling_community, rl__process_community, rl__security_team, rl__contributor
-   :input: wp__issue_track_system, wp__module_security_plan, wp__platform_security_plan, wp__module_security_package, wp__platform_security_package
-   :output: wp__sw_platform_sbom, wp__sw_module_sbom
-   :contains: gd_guidl__security_plan_definitions
-   :has: doc_concept__security_management_process, doc_getstrt__security_management_process
+   :version: 1
+   :responsible: rl__committer[version==1]
+   :approved_by: rl__security_manager[version==1], rl__security_engineer[version==1], rl__project_lead[version==1]
+   :supported_by: rl__infrastructure_tooling_community[version==1],
+                  rl__process_community[version==1],
+                  rl__security_team[version==1],
+                  rl__contributor[version==1]
+   :input: wp__issue_track_system[version==1],
+           wp__module_security_plan[version==1],
+           wp__platform_security_plan[version==1],
+           wp__module_security_package[version==1],
+           wp__platform_security_package[version==1]
+   :output: wp__sw_platform_sbom[version==1], wp__sw_module_sbom[version==1]
+   :contains: gd_guidl__security_plan_definitions[version==1]
+   :has: doc_concept__security_management_process[version==1], doc_getstrt__security_management_process[version==1]
 
    | The Committer is responsible to create and the maintain the SBOM for the platform/module.
    | The Committer makes sure all components and dependencies are identified and made available.
@@ -119,13 +150,22 @@ For a detailed explanation of workflows and their role within the process model,
 .. workflow:: Monitor/Verify Security
    :id: wf__mr_vy_security
    :status: valid
-   :responsible: rl__security_manager
-   :approved_by: rl__project_lead
-   :supported_by: rl__security_team
-   :input: wp__issue_track_system, wp__module_security_plan, wp__platform_security_plan, wp__module_security_package, wp__platform_security_package, wp__audit_report, wp__fdr_reports, wp__sw_platform_sbom, wp__sw_module_sbom
-   :output: wp__issue_track_system, wp__module_sw_release_note, wp__platform_sw_release_note
-   :contains: gd_guidl__security_plan_definitions
-   :has: doc_concept__security_management_process, doc_getstrt__security_management_process
+   :version: 1
+   :responsible: rl__security_manager[version==1]
+   :approved_by: rl__project_lead[version==1]
+   :supported_by: rl__security_team[version==1]
+   :input: wp__issue_track_system[version==1],
+           wp__module_security_plan[version==1],
+           wp__platform_security_plan[version==1],
+           wp__module_security_package[version==1],
+           wp__platform_security_package[version==1],
+           wp__audit_report[version==1],
+           wp__fdr_reports[version==1],
+           wp__sw_platform_sbom[version==1],
+           wp__sw_module_sbom[version==1]
+   :output: wp__issue_track_system[version==1], wp__module_sw_release_note[version==1], wp__platform_sw_release_note[version==1]
+   :contains: gd_guidl__security_plan_definitions[version==1]
+   :has: doc_concept__security_management_process[version==1], doc_getstrt__security_management_process[version==1]
 
    | The Security Manager is responsible for the monitoring of the security activities against the Security Plan.
    | The Security Manager is responsible to verify, that the preconditions for the "release for production", which are  part of the release notes, are fulfilled.
@@ -137,13 +177,17 @@ For a detailed explanation of workflows and their role within the process model,
 .. workflow:: Consult and Execute Security Trainings
    :id: wf__consult_exe_sec_training
    :status: valid
-   :responsible: rl__security_manager
-   :approved_by: rl__project_lead
-   :supported_by: rl__security_engineer, rl__safety_manager, rl__quality_manager
-   :input: wp__module_security_plan, wp__platform_security_plan, wp__policies, wp__process_description
-   :output: wp__training_path
-   :contains: gd_temp__module_security_plan
-   :has: doc_concept__security_management_process, doc_getstrt__security_management_process
+   :version: 1
+   :responsible: rl__security_manager[version==1]
+   :approved_by: rl__project_lead[version==1]
+   :supported_by: rl__security_engineer[version==1], rl__safety_manager[version==1], rl__quality_manager[version==1]
+   :input: wp__module_security_plan[version==1],
+           wp__platform_security_plan[version==1],
+           wp__policies[version==1],
+           wp__process_description[version==1]
+   :output: wp__training_path[version==1]
+   :contains: gd_temp__module_security_plan[version==1]
+   :has: doc_concept__security_management_process[version==1], doc_getstrt__security_management_process[version==1]
 
    | The Security Manager :need:`rl__security_manager` consults all project/platform stakeholder as defined in :need:`doc_concept__security_management_process` for security topics and executes regularly security trainings.
 

--- a/process/process_areas/security_management/security_management_workproducts.rst
+++ b/process/process_areas/security_management/security_management_workproducts.rst
@@ -17,8 +17,13 @@ Security Management Work Products
 .. workproduct:: Platform Security Plan
    :id: wp__platform_security_plan
    :status: valid
+   :version: 1
    :tags: doc_lifecycle_model_2
-   :complies: std_wp__isosae21434__prj_management_651, std_wp__isosae21434__maintenance_13331, std_wp__isosae21434__continual_8331, std_wp__isosae21434__continual_8332, std_wp__isosae21434__prj_management_653
+   :complies: std_wp__isosae21434__prj_management_651[version==1],
+              std_wp__isosae21434__maintenance_13331[version==1],
+              std_wp__isosae21434__continual_8331[version==1],
+              std_wp__isosae21434__continual_8332[version==1],
+              std_wp__isosae21434__prj_management_653[version==1]
 
    Plan to manage and guide the execution of the security activities of a project including dates, milestones, tasks, deliverables, responsibilities (including the Security Manager appointment)  and resources.
 
@@ -35,8 +40,9 @@ Security Management Work Products
 .. workproduct:: Module Security Plan
    :id: wp__module_security_plan
    :status: valid
+   :version: 1
    :tags: doc_lifecycle_model_2
-   :complies: std_wp__isosae21434__prj_management_651
+   :complies: std_wp__isosae21434__prj_management_651[version==1]
 
    Plan to manage and guide the execution of the security activities of a project including dates, milestones, tasks, deliverables, responsibilities (including the Security Manager appointment) and resources.
 
@@ -51,8 +57,9 @@ Security Management Work Products
 .. workproduct:: Platform Security Package
    :id: wp__platform_security_package
    :status: valid
+   :version: 1
    :tags: doc_lifecycle_model_2
-   :complies: std_wp__isosae21434__prj_management_652
+   :complies: std_wp__isosae21434__prj_management_652[version==1]
 
    Compiled security relevant work products. For platform OoC.
 
@@ -61,8 +68,9 @@ Security Management Work Products
 .. workproduct:: Module Security Package
    :id: wp__module_security_package
    :status: valid
+   :version: 1
    :tags: doc_lifecycle_model_2
-   :complies: std_wp__isosae21434__prj_management_652
+   :complies: std_wp__isosae21434__prj_management_652[version==1]
 
    Compiled security relevant work products. For Module OoC.
 
@@ -71,8 +79,9 @@ Security Management Work Products
 .. workproduct:: Formal Document Review Reports
    :id: wp__fdr_reports_security
    :status: valid
+   :version: 1
    :tags: doc_lifecycle_model_2
-   :complies: std_wp__isosae21434__prj_management_654
+   :complies: std_wp__isosae21434__prj_management_654[version==1]
 
    Review that a work product provides sufficient and convincing evidence of their contribution to the achievement of security considering the corresponding objectives and requirements of ISO SAE 21434.
 
@@ -85,8 +94,9 @@ Security Management Work Products
 .. workproduct:: Process Security Audit Report
    :id: wp__audit_report_security
    :status: valid
+   :version: 1
    :tags: doc_lifecycle_model_2
-   :complies: std_wp__isosae21434__org_management_555
+   :complies: std_wp__isosae21434__org_management_555[version==1]
 
    Examination of an implemented process with regard to the process objectives and that those match the ISO SAE 21434.
    (Currently tailored out, needs discussion)
@@ -94,8 +104,9 @@ Security Management Work Products
 .. workproduct:: Platform Security Manual
    :id: wp__platform_security_manual
    :status: valid
+   :version: 1
    :tags: doc_lifecycle_model_2
-   :complies: std_wp__isosae21434__prj_management_654
+   :complies: std_wp__isosae21434__prj_management_654[version==1]
 
    The Security Manual describes:
 
@@ -113,8 +124,9 @@ Security Management Work Products
 .. workproduct:: Module Security Manual
    :id: wp__module_security_manual
    :status: valid
+   :version: 1
    :tags: doc_lifecycle_model_2
-   :complies: std_wp__isosae21434__prj_management_654
+   :complies: std_wp__isosae21434__prj_management_654[version==1]
 
    The Security Manual describes:
 
@@ -132,8 +144,9 @@ Security Management Work Products
 .. workproduct:: Platform Software Bill of Material (SBOM)
    :id: wp__sw_platform_sbom
    :status: valid
+   :version: 1
    :tags: doc_lifecycle_model_2
-   :complies: std_wp__isosae21434__continual_8631
+   :complies: std_wp__isosae21434__continual_8631[version==1]
 
    Platform Software Bill of Material
    - comprehensive inventory of software components to ensure security, integrity, and compliance.
@@ -141,8 +154,9 @@ Security Management Work Products
 .. workproduct:: Module Software Bill of Material (SBOM)
    :id: wp__sw_module_sbom
    :status: valid
+   :version: 1
    :tags: doc_lifecycle_model_2
-   :complies: std_wp__isosae21434__continual_8631
+   :complies: std_wp__isosae21434__continual_8631[version==1]
 
    Module Software Bill of Material
    - comprehensive inventory of software components to ensure security, integrity, and compliance.

--- a/process/process_areas/tool_management/guidance/tool_management_checklist.rst
+++ b/process/process_areas/tool_management/guidance/tool_management_checklist.rst
@@ -20,8 +20,19 @@ Tool Verification Report Review Checklist
 .. gd_chklst:: Tool Verification Report Review Checklist
    :id: gd_chklst__tool_cr_review
    :status: valid
+   :version: 1
    :tags: tool_management
-   :complies: std_req__iso26262__support_1141, std_req__iso26262__support_1142, std_req__iso26262__support_1143, std_req__iso26262__support_11441, std_req__iso26262__support_11442, std_req__iso26262__support_11451, std_req__iso26262__support_11452, std_req__iso26262__support_11453, std_req__iso26262__support_11454, std_req__iso26262__support_11461, std_req__iso26262__support_11462
+   :complies: std_req__iso26262__support_1141[version==1],
+              std_req__iso26262__support_1142[version==1],
+              std_req__iso26262__support_1143[version==1],
+              std_req__iso26262__support_11441[version==1],
+              std_req__iso26262__support_11442[version==1],
+              std_req__iso26262__support_11451[version==1],
+              std_req__iso26262__support_11452[version==1],
+              std_req__iso26262__support_11453[version==1],
+              std_req__iso26262__support_11454[version==1],
+              std_req__iso26262__support_11461[version==1],
+              std_req__iso26262__support_11462[version==1]
 
    | **1. Purpose**
    | The purpose of this checklist is to collect the topics to be checked during a tool verification.

--- a/process/process_areas/tool_management/guidance/tool_management_guideline.rst
+++ b/process/process_areas/tool_management/guidance/tool_management_guideline.rst
@@ -21,7 +21,8 @@ Tool Qualification
 .. gd_guidl:: Tool Qualification
    :id: gd_guidl__tool_qualification
    :status: valid
-   :complies: std_req__iso26262__support_11491, std_req__iso26262__support_11492
+   :version: 1
+   :complies: std_req__iso26262__support_11491[version==1], std_req__iso26262__support_11492[version==1]
 
    | The tool qualification shall be based on the method validation of the software tool.
 
@@ -31,8 +32,14 @@ Tailoring
 .. gd_guidl:: Tool Requirements Tailored
    :id: gd_guidl__tool_req_tailored
    :status: valid
-   :complies: std_req__iso26262__support_11471, std_req__iso26262__support_11472, std_req__iso26262__support_11473, std_req__iso26262__support_11474,
-              std_req__iso26262__support_11481, std_req__iso26262__support_11482, std_req__iso26262__support_11483
+   :version: 1
+   :complies: std_req__iso26262__support_11471[version==1],
+              std_req__iso26262__support_11472[version==1],
+              std_req__iso26262__support_11473[version==1],
+              std_req__iso26262__support_11474[version==1],
+              std_req__iso26262__support_11481[version==1],
+              std_req__iso26262__support_11482[version==1],
+              std_req__iso26262__support_11483[version==1]
 
 
    This part of the guideline links to all the requirements which are not fulfilled by the

--- a/process/process_areas/tool_management/guidance/tool_management_reqs.rst
+++ b/process/process_areas/tool_management/guidance/tool_management_reqs.rst
@@ -25,18 +25,20 @@ Tool Verification Report Attributes
 .. gd_req:: Tool attribute: UID
    :id: gd_req__tool_attr_uid
    :status: valid
+   :version: 1
    :tags: done_automation, tool_management, attribute, mandatory
-   :satisfies: wf__tool_create_tool_verification_report
-   :complies: std_req__iso26262__support_1141, std_req__aspice_40__SUP-8-BP1
+   :satisfies: wf__tool_create_tool_verification_report[version==1]
+   :complies: std_req__iso26262__support_1141[version==1], std_req__aspice_40__SUP-8-BP1[version==1]
 
    Each Tool Verification Report shall have a unique ID.
 
 .. gd_req:: Tool attribute: status
    :id: gd_req__tool_attr_status
    :status: valid
+   :version: 1
    :tags: prio_1_automation, tool_management, attribute, mandatory
-   :satisfies: wf__tool_create_tool_verification_report
-   :complies: std_req__iso26262__support_1141, std_req__aspice_40__SUP-8-BP1
+   :satisfies: wf__tool_create_tool_verification_report[version==1]
+   :complies: std_req__iso26262__support_1141[version==1], std_req__aspice_40__SUP-8-BP1[version==1]
 
    Each Tool Verification Report shall have a status.
 
@@ -49,9 +51,10 @@ Tool Verification Report Attributes
 .. gd_req:: Tool attribute:: version
    :id: gd_req__tool_attr_version
    :status: valid
+   :version: 1
    :tags: manual_prio_1, tool_management, attribute, mandatory
-   :satisfies: wf__tool_create_tool_verification_report
-   :complies: std_req__iso26262__support_1141, std_req__aspice_40__SUP-8-BP1
+   :satisfies: wf__tool_create_tool_verification_report[version==1]
+   :complies: std_req__iso26262__support_1141[version==1], std_req__aspice_40__SUP-8-BP1[version==1]
 
    Each Tool Verification Report shall document the tool version it applies to:
 
@@ -60,9 +63,10 @@ Tool Verification Report Attributes
 .. gd_req:: Tool attribute:: tcl
    :id: gd_req__tool_attr_tcl
    :status: valid
+   :version: 1
    :tags: manual_prio_1, tool_management, attribute, mandatory
-   :satisfies: wf__tool_create_tool_verification_report
-   :complies: std_req__iso26262__support_1141, std_req__aspice_40__SUP-8-BP1
+   :satisfies: wf__tool_create_tool_verification_report[version==1]
+   :complies: std_req__iso26262__support_1141[version==1], std_req__aspice_40__SUP-8-BP1[version==1]
 
    Each Tool Verification Report shall have a tool confidence level:
 
@@ -72,9 +76,10 @@ Tool Verification Report Attributes
 .. gd_req:: Tool attribute:: safety affected
    :id: gd_req__tool_attr_safety_affected
    :status: valid
+   :version: 1
    :tags: manual_prio_1, tool_management, attribute, mandatory
-   :satisfies: wf__tool_create_tool_verification_report
-   :complies: std_req__iso26262__support_1141, std_req__aspice_40__SUP-8-BP1
+   :satisfies: wf__tool_create_tool_verification_report[version==1]
+   :complies: std_req__iso26262__support_1141[version==1], std_req__aspice_40__SUP-8-BP1[version==1]
 
    Each Tool Verification Report shall have a safety relevance identifier:
 
@@ -84,9 +89,10 @@ Tool Verification Report Attributes
 .. gd_req:: Tool attribute:: security affected
    :id: gd_req__tool_attr_security_affected
    :status: valid
+   :version: 1
    :tags: manual_prio_2, tool_management, attribute, mandatory
-   :satisfies: wf__tool_create_tool_verification_report
-   :complies: std_req__isosae21434__org_management_5451, std_req__aspice_40__SUP-8-BP1
+   :satisfies: wf__tool_create_tool_verification_report[version==1]
+   :complies: std_req__isosae21434__org_management_5451[version==1], std_req__aspice_40__SUP-8-BP1[version==1]
 
    Each Tool Verification Report shall have a security relevance identifier:
 
@@ -100,9 +106,10 @@ Tool Verification Report Checks
 .. gd_req:: Tool Management mandatory attributes provided
    :id: gd_req__tool_check_mandatory
    :status: valid
+   :version: 1
    :tags: prio_1_automation, tool_management, attribute, check
-   :satisfies: wf__tool_create_tool_verification_report
-   :complies: std_req__aspice_40__SUP-8-BP1
+   :satisfies: wf__tool_create_tool_verification_report[version==1]
+   :complies: std_req__aspice_40__SUP-8-BP1[version==1]
 
    It shall be checked if all mandatory attributes for each Tool Verification Report
    is provided by the user. For all requirements following attributes shall be mandatory:

--- a/process/process_areas/tool_management/guidance/tool_management_template.rst
+++ b/process/process_areas/tool_management/guidance/tool_management_template.rst
@@ -20,6 +20,20 @@ Tool Verification Report Template
 .. gd_temp:: Tool Verification Report Template
    :id: gd_temp__tool_management_verif_rpt_template
    :status: valid
-   :complies: std_req__iso26262__support_1141, std_req__iso26262__support_1142, std_req__iso26262__support_1143, std_req__iso26262__support_11441, std_req__iso26262__support_11442, std_req__iso26262__support_11451, std_req__iso26262__support_11452, std_req__iso26262__support_11453, std_req__iso26262__support_11454, std_req__iso26262__support_11461, std_req__iso26262__support_11462, std_req__isosae21434__org_management_5451, std_req__aspice_40__SUP-8-BP1, std_req__aspice_40__SUP-8-BP2
+   :version: 1
+   :complies: std_req__iso26262__support_1141[version==1],
+              std_req__iso26262__support_1142[version==1],
+              std_req__iso26262__support_1143[version==1],
+              std_req__iso26262__support_11441[version==1],
+              std_req__iso26262__support_11442[version==1],
+              std_req__iso26262__support_11451[version==1],
+              std_req__iso26262__support_11452[version==1],
+              std_req__iso26262__support_11453[version==1],
+              std_req__iso26262__support_11454[version==1],
+              std_req__iso26262__support_11461[version==1],
+              std_req__iso26262__support_11462[version==1],
+              std_req__isosae21434__org_management_5451[version==1],
+              std_req__aspice_40__SUP-8-BP1[version==1],
+              std_req__aspice_40__SUP-8-BP2[version==1]
 
    For the content see here: :need:`doc_tool__tool_name_version`

--- a/process/process_areas/tool_management/tool_management_concept.rst
+++ b/process/process_areas/tool_management/tool_management_concept.rst
@@ -18,6 +18,7 @@ Concept Description
 .. doc_concept:: Concept Description
    :id: doc_concept__tool_process
    :status: valid
+   :version: 1
    :tags: tool_management
 
 In this section a concept for the Tool Management will be discussed. Inputs for this concepts

--- a/process/process_areas/tool_management/tool_management_getstrt.rst
+++ b/process/process_areas/tool_management/tool_management_getstrt.rst
@@ -18,6 +18,7 @@ Getting Started
 .. doc_getstrt:: Getting Started on Tool Management
    :id: doc_getstrt__tool_process
    :status: valid
+   :version: 1
    :tags: tool_management
 
 This document describes the steps to evaluate tools and qualify them according to

--- a/process/process_areas/tool_management/tool_management_workflow.rst
+++ b/process/process_areas/tool_management/tool_management_workflow.rst
@@ -22,13 +22,14 @@ For a detailed explanation of workflows and their role within the process model,
 .. workflow:: Create Tool Verification Report
    :id: wf__tool_create_tool_verification_report
    :status: valid
-   :responsible: rl__contributor
-   :approved_by: rl__committer
-   :supported_by: rl__safety_manager, rl__security_manager, rl__infrastructure_tooling_community
-   :input: wp__issue_track_system, wp__tlm_plan
-   :output: wp__tool_verification_report
-   :contains: gd_temp__tool_management_verif_rpt_template, gd_chklst__tool_cr_review
-   :has: doc_concept__tool_process, doc_getstrt__tool_process
+   :version: 1
+   :responsible: rl__contributor[version==1]
+   :approved_by: rl__committer[version==1]
+   :supported_by: rl__safety_manager[version==1], rl__security_manager[version==1], rl__infrastructure_tooling_community[version==1]
+   :input: wp__issue_track_system[version==1], wp__tlm_plan[version==1]
+   :output: wp__tool_verification_report[version==1]
+   :contains: gd_temp__tool_management_verif_rpt_template[version==1], gd_chklst__tool_cr_review[version==1]
+   :has: doc_concept__tool_process[version==1], doc_getstrt__tool_process[version==1]
 
    The Tool Verification Report is created during identification of a tool in status
    draft.
@@ -39,13 +40,18 @@ For a detailed explanation of workflows and their role within the process model,
 .. workflow:: Evaluate Tool and Update Tool Verification Report
    :id: wf__tool_evaluate_tool
    :status: valid
-   :responsible: rl__contributor
-   :approved_by: rl__committer, rl__safety_manager, rl__security_manager
-   :supported_by: rl__infrastructure_tooling_community
-   :input: wp__tool_verification_report, wp__requirements_stkh, wp__requirements_feat, wp__requirements_comp, wp__requirements_proc_tool
-   :output: wp__tool_verification_report
-   :contains: gd_temp__tool_management_verif_rpt_template, gd_chklst__tool_cr_review
-   :has: doc_concept__tool_process, doc_getstrt__tool_process
+   :version: 1
+   :responsible: rl__contributor[version==1]
+   :approved_by: rl__committer[version==1], rl__safety_manager[version==1], rl__security_manager[version==1]
+   :supported_by: rl__infrastructure_tooling_community[version==1]
+   :input: wp__tool_verification_report[version==1],
+           wp__requirements_stkh[version==1],
+           wp__requirements_feat[version==1],
+           wp__requirements_comp[version==1],
+           wp__requirements_proc_tool[version==1]
+   :output: wp__tool_verification_report[version==1]
+   :contains: gd_temp__tool_management_verif_rpt_template[version==1], gd_chklst__tool_cr_review[version==1]
+   :has: doc_concept__tool_process[version==1], doc_getstrt__tool_process[version==1]
 
    Each identified tool is evaluated. During evaluation the Tool Verification Report
    is updated accordingly. Stakeholder, feature, component, and process/tool
@@ -62,13 +68,14 @@ For a detailed explanation of workflows and their role within the process model,
 .. workflow:: Qualify Tool and Update Tool Verification Report
    :id: wf__tool_qualify_tool
    :status: valid
-   :responsible: rl__contributor
-   :approved_by: rl__committer, rl__safety_manager, rl__security_manager
-   :supported_by: rl__infrastructure_tooling_community
-   :input: wp__tool_verification_report
-   :output: wp__tool_verification_report
-   :contains: gd_temp__tool_management_verif_rpt_template, gd_chklst__tool_cr_review
-   :has: doc_concept__tool_process, doc_getstrt__tool_process
+   :version: 1
+   :responsible: rl__contributor[version==1]
+   :approved_by: rl__committer[version==1], rl__safety_manager[version==1], rl__security_manager[version==1]
+   :supported_by: rl__infrastructure_tooling_community[version==1]
+   :input: wp__tool_verification_report[version==1]
+   :output: wp__tool_verification_report[version==1]
+   :contains: gd_temp__tool_management_verif_rpt_template[version==1], gd_chklst__tool_cr_review[version==1]
+   :has: doc_concept__tool_process[version==1], doc_getstrt__tool_process[version==1]
 
    The identified tool is qualified, if applicable. During qualification the Tool
    Verification Report is updated accordingly.
@@ -78,13 +85,14 @@ For a detailed explanation of workflows and their role within the process model,
 .. workflow:: Approve Tool Verification Report
    :id: wf__tool_approve_tool_verification_report
    :status: valid
-   :responsible: rl__safety_manager, rl__security_manager
-   :approved_by: rl__project_lead
-   :supported_by: rl__infrastructure_tooling_community
-   :input: wp__tool_verification_report
-   :output: wp__tool_verification_report
-   :contains: gd_temp__tool_management_verif_rpt_template, gd_chklst__tool_cr_review
-   :has: doc_concept__tool_process, doc_getstrt__tool_process
+   :version: 1
+   :responsible: rl__safety_manager[version==1], rl__security_manager[version==1]
+   :approved_by: rl__project_lead[version==1]
+   :supported_by: rl__infrastructure_tooling_community[version==1]
+   :input: wp__tool_verification_report[version==1]
+   :output: wp__tool_verification_report[version==1]
+   :contains: gd_temp__tool_management_verif_rpt_template[version==1], gd_chklst__tool_cr_review[version==1]
+   :has: doc_concept__tool_process[version==1], doc_getstrt__tool_process[version==1]
 
    Finally the Tool Verification Report is verified and approved, and thus the status
    is set to released.

--- a/process/process_areas/tool_management/tool_management_workproducts.rst
+++ b/process/process_areas/tool_management/tool_management_workproducts.rst
@@ -18,16 +18,21 @@ Tool Management Work Products
 .. workproduct:: Platform Tool Management Plan
    :id: wp__tlm_plan
    :status: valid
+   :version: 1
    :tags: doc_lifecycle_model_2
-   :complies: std_wp__isosae21434__org_management_554, std_req__aspice_40__iic-16-03, std_req__aspice_40__iic-01-52, std_req__aspice_40__iic-10-52
+   :complies: std_wp__isosae21434__org_management_554[version==1],
+              std_req__aspice_40__iic-16-03[version==1],
+              std_req__aspice_40__iic-01-52[version==1],
+              std_req__aspice_40__iic-10-52[version==1]
 
    Tool Management Plan (Part of the Platform Management Plan)
 
 .. workproduct:: Tool Verification Report
    :id: wp__tool_verification_report
    :status: valid
+   :version: 1
    :tags: doc_lifecycle_model_2
-   :complies: std_wp__iso26262__support_1151, std_wp__iso26262__support_1152, std_wp__isosae21434__org_management_554
+   :complies: std_wp__iso26262__support_1151[version==1], std_wp__iso26262__support_1152[version==1], std_wp__isosae21434__org_management_554[version==1]
 
    According to the safety tool process, each tool's confidence level (TCL) must be determined.
    In addition security topics must be considered, as tool user manuals, access control for tools,

--- a/process/process_areas/verification/guidance/verification_guideline.rst
+++ b/process/process_areas/verification/guidance/verification_guideline.rst
@@ -17,7 +17,8 @@ Guideline
 .. gd_guidl:: Verification Guideline
    :id: gd_guidl__verification_guide
    :status: valid
-   :complies: std_req__isopas8926__445
+   :version: 1
+   :complies: std_req__isopas8926__445[version==1]
 
    This guideline outlines the responsibilities and procedures for developers performing
    verification activities (testcase creation, inspection, and review) for documentation,
@@ -151,9 +152,15 @@ Tailoring
 .. gd_guidl:: Verification Requirements Tailored
    :id: gd_guidl__verification_req_tailored
    :status: valid
-   :complies: std_req__iso26262__software_945,
-              std_req__iso26262__software_1045, std_req__iso26262__software_1046, std_req__iso26262__software_1047,
-              std_req__iso26262__software_1141, std_req__iso26262__software_1142, std_req__iso26262__software_1143, std_req__iso26262__software_1144
+   :version: 1
+   :complies: std_req__iso26262__software_945[version==1],
+              std_req__iso26262__software_1045[version==1],
+              std_req__iso26262__software_1046[version==1],
+              std_req__iso26262__software_1047[version==1],
+              std_req__iso26262__software_1141[version==1],
+              std_req__iso26262__software_1142[version==1],
+              std_req__iso26262__software_1143[version==1],
+              std_req__iso26262__software_1144[version==1]
 
    This part of the guideline links to all the requirements which are not fulfilled by the
    verification process. Make sure these are tailored out in the safety/security/quality plans

--- a/process/process_areas/verification/guidance/verification_methods.rst
+++ b/process/process_areas/verification/guidance/verification_methods.rst
@@ -26,7 +26,8 @@ Methods
 .. gd_method:: Verification Methods
    :id: gd_meth__verification_methods
    :status: valid
-   :complies: std_req__iso26262__software_942, std_req__iso26262__software_944, std_req__aspice_40__iic-08-58
+   :version: 1
+   :complies: std_req__iso26262__software_942[version==1], std_req__iso26262__software_944[version==1], std_req__aspice_40__iic-08-58[version==1]
 
    Following methods are explained
 
@@ -168,7 +169,8 @@ Derivation Techniques
 .. gd_method:: Verification Derivation Technique
    :id: gd_meth__verification_derivation
    :status: valid
-   :complies: std_req__iso26262__software_943, std_req__iso26262__software_1043
+   :version: 1
+   :complies: std_req__iso26262__software_943[version==1], std_req__iso26262__software_1043[version==1]
 
    Following derivation techniques are explained
 

--- a/process/process_areas/verification/guidance/verification_plan_template.rst
+++ b/process/process_areas/verification/guidance/verification_plan_template.rst
@@ -20,10 +20,20 @@ Verification Plan Template
 .. gd_temp:: Platform Verification Plan Template
     :id: gd_temp__verification_plan
     :status: valid
-    :complies: std_req__iso26262__support_9411, std_req__iso26262__support_9412, std_req__iso26262__support_12422, std_req__iso26262__support_12424, std_req__iso26262__support_12425,
-               std_req__aspice_40__SWE-4-BP1, std_req__aspice_40__SWE-5-BP1, std_req__aspice_40__SWE-6-BP1,
-               std_req__aspice_40__SWE-4-BP2, std_req__aspice_40__SWE-5-BP2, std_req__aspice_40__SWE-6-BP2,
-               std_req__aspice_40__SWE-5-BP3, std_req__aspice_40__iic-06-50
+    :version: 1
+    :complies: std_req__iso26262__support_9411[version==1],
+               std_req__iso26262__support_9412[version==1],
+               std_req__iso26262__support_12422[version==1],
+               std_req__iso26262__support_12424[version==1],
+               std_req__iso26262__support_12425[version==1],
+               std_req__aspice_40__SWE-4-BP1[version==1],
+               std_req__aspice_40__SWE-5-BP1[version==1],
+               std_req__aspice_40__SWE-6-BP1[version==1],
+               std_req__aspice_40__SWE-4-BP2[version==1],
+               std_req__aspice_40__SWE-5-BP2[version==1],
+               std_req__aspice_40__SWE-6-BP2[version==1],
+               std_req__aspice_40__SWE-5-BP3[version==1],
+               std_req__aspice_40__iic-06-50[version==1]
 
     This document implements :need:`wp__verification_plan`.
 
@@ -37,6 +47,7 @@ Verification Plan Template
          .. document:: Software Verification Plan
             :id: doc__verification_plan
             :status: draft
+            :version: 1
             :safety: ASIL_B
             :tags: platform_management
 

--- a/process/process_areas/verification/guidance/verification_process_reqs.rst
+++ b/process/process_areas/verification/guidance/verification_process_reqs.rst
@@ -20,9 +20,13 @@ Process Requirements
 .. gd_req:: Linking Requirements to Tests
     :id: gd_req__verification_link_tests
     :status: valid
+    :version: 1
     :tags: prio_1_automation, verification
-    :satisfies: wf__verification_unit_test, wf__verification_comp_int_test, wf__verification_feat_int_test, wf__verification_platform_int_test
-    :complies: std_req__iso26262__support_6432
+    :satisfies: wf__verification_unit_test[version==1],
+                wf__verification_comp_int_test[version==1],
+                wf__verification_feat_int_test[version==1],
+                wf__verification_platform_int_test[version==1]
+    :complies: std_req__iso26262__support_6432[version==1]
 
 
     For linking test suites to requirements following metadata shall be used:
@@ -52,9 +56,16 @@ Process Requirements
 .. gd_req:: Linking Requirements to Tests (C++)
     :id: gd_req__verification_link_tests_cpp
     :status: valid
+    :version: 1
     :tags: prio_1_automation, verification
-    :satisfies: wf__verification_unit_test, wf__verification_comp_int_test, wf__verification_feat_int_test, wf__verification_platform_int_test
-    :complies: std_req__iso26262__support_6432, std_req__aspice_40__SWE-4-BP4, std_req__aspice_40__SWE-5-BP6, std_req__aspice_40__SWE-6-BP4
+    :satisfies: wf__verification_unit_test[version==1],
+                wf__verification_comp_int_test[version==1],
+                wf__verification_feat_int_test[version==1],
+                wf__verification_platform_int_test[version==1]
+    :complies: std_req__iso26262__support_6432[version==1],
+               std_req__aspice_40__SWE-4-BP4[version==1],
+               std_req__aspice_40__SWE-5-BP6[version==1],
+               std_req__aspice_40__SWE-6-BP4[version==1]
 
 
     For linking C++ tests to requirements **record properties** shall be used. Attributes
@@ -67,9 +78,16 @@ Process Requirements
 .. gd_req:: Linking Requirements to Tests (Python)
     :id: gd_req__verification_link_tests_python
     :status: valid
+    :version: 1
     :tags: prio_1_automation, verification
-    :satisfies: wf__verification_unit_test, wf__verification_comp_int_test, wf__verification_feat_int_test, wf__verification_platform_int_test
-    :complies: std_req__iso26262__support_6432, std_req__aspice_40__SWE-4-BP4, std_req__aspice_40__SWE-5-BP6, std_req__aspice_40__SWE-6-BP4
+    :satisfies: wf__verification_unit_test[version==1],
+                wf__verification_comp_int_test[version==1],
+                wf__verification_feat_int_test[version==1],
+                wf__verification_platform_int_test[version==1]
+    :complies: std_req__iso26262__support_6432[version==1],
+               std_req__aspice_40__SWE-4-BP4[version==1],
+               std_req__aspice_40__SWE-5-BP6[version==1],
+               std_req__aspice_40__SWE-6-BP4[version==1]
 
 
     For linking python tests to requirements **metadata** shall be used.
@@ -89,9 +107,16 @@ Process Requirements
 .. gd_req:: Linking Requirements to Tests (Rust)
     :id: gd_req__verification_link_tests_rust
     :status: valid
+    :version: 1
     :tags: prio_1_automation, verification
-    :satisfies: wf__verification_unit_test, wf__verification_comp_int_test, wf__verification_feat_int_test, wf__verification_platform_int_test
-    :complies: std_req__iso26262__support_6432, std_req__aspice_40__SWE-4-BP4, std_req__aspice_40__SWE-5-BP6, std_req__aspice_40__SWE-6-BP4
+    :satisfies: wf__verification_unit_test[version==1],
+                wf__verification_comp_int_test[version==1],
+                wf__verification_feat_int_test[version==1],
+                wf__verification_platform_int_test[version==1]
+    :complies: std_req__iso26262__support_6432[version==1],
+               std_req__aspice_40__SWE-4-BP4[version==1],
+               std_req__aspice_40__SWE-5-BP6[version==1],
+               std_req__aspice_40__SWE-6-BP4[version==1]
 
     For linking Rust tests to requirements **#[record_property]** shall be used:
 
@@ -100,17 +125,22 @@ Process Requirements
 .. gd_req:: Independence
     :id: gd_req__verification_independence
     :status: valid
+    :version: 1
     :tags: done_automation, verification
-    :satisfies: wf__verification_unit_test, wf__verification_comp_int_test, wf__verification_feat_int_test, wf__verification_platform_int_test
-    :complies: std_req__aspice_40__SWE-4-BP4, std_req__aspice_40__SWE-5-BP6, std_req__aspice_40__SWE-6-BP4
+    :satisfies: wf__verification_unit_test[version==1],
+                wf__verification_comp_int_test[version==1],
+                wf__verification_feat_int_test[version==1],
+                wf__verification_platform_int_test[version==1]
+    :complies: std_req__aspice_40__SWE-4-BP4[version==1], std_req__aspice_40__SWE-5-BP6[version==1], std_req__aspice_40__SWE-6-BP4[version==1]
 
     The approver of a pull request shall differ from the author(s) of the pull request in all pull requests.
 
 .. gd_req:: Verification Reporting
     :id: gd_req__verification_reporting
     :status: valid
+    :version: 1
     :tags: prio_1_automation, verification
-    :satisfies: wf__verification_mod_ver_report
+    :satisfies: wf__verification_mod_ver_report[version==1]
     :complies:
 
     The tool automation shall automatically generate the Verification reports.
@@ -120,8 +150,9 @@ Process Requirements
 .. gd_req:: Verification Report Archiving
     :id: gd_req__verification_report_archiving
     :status: valid
+    :version: 1
     :tags: prio_1_automation, verification
-    :satisfies: wf__verification_mod_ver_report
+    :satisfies: wf__verification_mod_ver_report[version==1]
     :complies:
 
     The tool automation shall automatically archive the Verification reports for releases.
@@ -130,8 +161,12 @@ Process Requirements
 .. gd_req:: Verification Documentation Checks
     :id: gd_req__verification_checks
     :status: valid
+    :version: 1
     :tags: prio_1_automation, verification
-    :satisfies: wf__verification_unit_test, wf__verification_comp_int_test, wf__verification_feat_int_test, wf__verification_platform_int_test
+    :satisfies: wf__verification_unit_test[version==1],
+                wf__verification_comp_int_test[version==1],
+                wf__verification_feat_int_test[version==1],
+                wf__verification_platform_int_test[version==1]
     :complies:
 
     The following checks shall be implemented on test metadata:
@@ -146,8 +181,12 @@ Process Requirements
 .. gd_req:: Verification Documentation Checks Extended
     :id: gd_req__verification_checks_extended
     :status: valid
+    :version: 1
     :tags: verification
-    :satisfies: wf__verification_unit_test, wf__verification_comp_int_test, wf__verification_feat_int_test, wf__verification_platform_int_test
+    :satisfies: wf__verification_unit_test[version==1],
+                wf__verification_comp_int_test[version==1],
+                wf__verification_feat_int_test[version==1],
+                wf__verification_platform_int_test[version==1]
     :complies:
 
     The following checks shall be implemented on test metadata:
@@ -158,8 +197,9 @@ Process Requirements
 .. gd_req:: Verification of External Components AoUs
     :id: gd_req__verification_external_aou
     :status: valid
+    :version: 1
     :tags: prio_2_automation, verification
-    :satisfies: wf__verification_comp_int_test, wf__verification_feat_int_test
+    :satisfies: wf__verification_comp_int_test[version==1], wf__verification_feat_int_test[version==1]
     :complies:
 
     External components AoUs shall be verified by integration tests or static analysis tooling.
@@ -171,8 +211,12 @@ Process Requirements
 .. gd_req:: Static Code Analysis Classification
     :id: gd_req__verification_sca_classification
     :status: valid
+    :version: 1
     :tags: prio_2_automation, verification
-    :satisfies: wf__verification_unit_test, wf__verification_comp_int_test, wf__verification_feat_int_test, wf__verification_platform_int_test
+    :satisfies: wf__verification_unit_test[version==1],
+                wf__verification_comp_int_test[version==1],
+                wf__verification_feat_int_test[version==1],
+                wf__verification_platform_int_test[version==1]
     :complies:
 
     Static code analysis findings shall be classified according to the following categories:
@@ -189,8 +233,12 @@ Process Requirements
 .. gd_req:: CI reference integration execution
     :id: gd_req__verification_ci_reference_execution
     :status: valid
+    :version: 1
     :tags: prio_2_automation, verification
-    :satisfies: wf__verification_unit_test, wf__verification_comp_int_test, wf__verification_feat_int_test, wf__verification_platform_int_test
+    :satisfies: wf__verification_unit_test[version==1],
+                wf__verification_comp_int_test[version==1],
+                wf__verification_feat_int_test[version==1],
+                wf__verification_platform_int_test[version==1]
     :complies:
 
     The CI reference integration execution shall be triggered on regular basis to guarantee the inter-operation of all integrated components

--- a/process/process_areas/verification/guidance/verification_report_template.rst
+++ b/process/process_areas/verification/guidance/verification_report_template.rst
@@ -20,13 +20,34 @@ Verification Report Templates
 .. gd_temp:: Module Verification Report Template
     :id: gd_temp__mod_ver_report
     :status: valid
-    :complies: std_req__iso26262__software_942, std_req__iso26262__software_943, std_req__iso26262__software_944,
-      std_req__iso26262__software_1041, std_req__iso26262__software_1042, std_req__iso26262__software_1043,
-      std_req__iso26262__support_9431, std_req__iso26262__support_9432, std_req__iso26262__support_9433, std_req__iso26262__support_9434,
-      std_req__iso26262__support_12422, std_req__iso26262__support_12424, std_req__iso26262__support_12425, std_req__iso26262__support_1243,
-      std_req__iso26262__analysis_749, std_req__iso26262__analysis_848,
-      std_req__aspice_40__SWE-4-BP3, std_req__aspice_40__SWE-5-BP4, std_req__aspice_40__SWE-5-BP5, std_req__aspice_40__SWE-6-BP3, std_req__aspice_40__iic-03-50, std_req__aspice_40__iic-15-52,
-      std_req__aspice_40__SWE-4-BP5, std_req__aspice_40__SWE-5-BP7, std_req__aspice_40__SWE-6-BP5, std_req__aspice_40__iic-13-51, std_req__aspice_40__iic-13-52
+    :version: 1
+    :complies: std_req__iso26262__software_942[version==1],
+               std_req__iso26262__software_943[version==1],
+               std_req__iso26262__software_944[version==1],
+               std_req__iso26262__software_1041[version==1],
+               std_req__iso26262__software_1042[version==1],
+               std_req__iso26262__software_1043[version==1],
+               std_req__iso26262__support_9431[version==1],
+               std_req__iso26262__support_9432[version==1],
+               std_req__iso26262__support_9433[version==1],
+               std_req__iso26262__support_9434[version==1],
+               std_req__iso26262__support_12422[version==1],
+               std_req__iso26262__support_12424[version==1],
+               std_req__iso26262__support_12425[version==1],
+               std_req__iso26262__support_1243[version==1],
+               std_req__iso26262__analysis_749[version==1],
+               std_req__iso26262__analysis_848[version==1],
+               std_req__aspice_40__SWE-4-BP3[version==1],
+               std_req__aspice_40__SWE-5-BP4[version==1],
+               std_req__aspice_40__SWE-5-BP5[version==1],
+               std_req__aspice_40__SWE-6-BP3[version==1],
+               std_req__aspice_40__iic-03-50[version==1],
+               std_req__aspice_40__iic-15-52[version==1],
+               std_req__aspice_40__SWE-4-BP5[version==1],
+               std_req__aspice_40__SWE-5-BP7[version==1],
+               std_req__aspice_40__SWE-6-BP5[version==1],
+               std_req__aspice_40__iic-13-51[version==1],
+               std_req__aspice_40__iic-13-52[version==1]
 
     This document implements :need:`wp__verification_module_ver_report`.
 
@@ -35,9 +56,16 @@ Verification Report Templates
 .. gd_temp:: Platform Verification Report Template
     :id: gd_temp__platform_ver_report
     :status: valid
-    :complies: std_req__iso26262__software_1041, std_req__iso26262__software_1042, std_req__iso26262__software_1044,
-      std_req__iso26262__support_9431, std_req__iso26262__support_9432, std_req__iso26262__support_9433, std_req__iso26262__support_9434,
-      std_req__iso26262__analysis_749, std_req__iso26262__analysis_848
+    :version: 1
+    :complies: std_req__iso26262__software_1041[version==1],
+               std_req__iso26262__software_1042[version==1],
+               std_req__iso26262__software_1044[version==1],
+               std_req__iso26262__support_9431[version==1],
+               std_req__iso26262__support_9432[version==1],
+               std_req__iso26262__support_9433[version==1],
+               std_req__iso26262__support_9434[version==1],
+               std_req__iso26262__analysis_749[version==1],
+               std_req__iso26262__analysis_848[version==1]
 
     This document implements :need:`wp__verification_platform_ver_report`.
 

--- a/process/process_areas/verification/guidance/verification_specification.rst
+++ b/process/process_areas/verification/guidance/verification_specification.rst
@@ -18,11 +18,18 @@ Test Specification Guideline
 .. gd_guidl:: Test Specification Guideline
    :id: gd_guidl__verification_specification
    :status: valid
-   :complies: std_req__iso26262__software_941, std_req__iso26262__software_942, std_req__iso26262__software_943,
-              std_req__iso26262__support_9421, std_req__iso26262__support_9422,
-              std_req__iso26262__support_9423, std_req__iso26262__support_9424,
-              std_req__iso26262__software_app_c_42, std_req__iso26262__software_app_c_44, std_req__iso26262__software_app_c_45,
-              std_req__aspice_40__iic-08-60
+   :version: 1
+   :complies: std_req__iso26262__software_941[version==1],
+              std_req__iso26262__software_942[version==1],
+              std_req__iso26262__software_943[version==1],
+              std_req__iso26262__support_9421[version==1],
+              std_req__iso26262__support_9422[version==1],
+              std_req__iso26262__support_9423[version==1],
+              std_req__iso26262__support_9424[version==1],
+              std_req__iso26262__software_app_c_42[version==1],
+              std_req__iso26262__software_app_c_44[version==1],
+              std_req__iso26262__software_app_c_45[version==1],
+              std_req__aspice_40__iic-08-60[version==1]
 
 Test specification
 ------------------

--- a/process/process_areas/verification/guidance/verification_templates.rst
+++ b/process/process_areas/verification/guidance/verification_templates.rst
@@ -20,9 +20,14 @@ Verification Templates
 .. gd_temp:: Verification Specification Template
    :id: gd_temp__verification_specification
    :status: valid
-   :complies: std_req__iso26262__software_942, std_req__iso26262__software_943,
-              std_req__iso26262__software_1042, std_req__iso26262__software_1043, std_req__iso26262__software_1044,
-              std_req__iso26262__support_9421, std_req__iso26262__support_9422
+   :version: 1
+   :complies: std_req__iso26262__software_942[version==1],
+              std_req__iso26262__software_943[version==1],
+              std_req__iso26262__software_1042[version==1],
+              std_req__iso26262__software_1043[version==1],
+              std_req__iso26262__software_1044[version==1],
+              std_req__iso26262__support_9421[version==1],
+              std_req__iso26262__support_9422[version==1]
 
    The sections below are seen as typical ways when writing tests and their specification.
    Their usage differs based on the selected testing framework and the implementation language of the component(s).

--- a/process/process_areas/verification/verification_concept.rst
+++ b/process/process_areas/verification/verification_concept.rst
@@ -18,6 +18,7 @@ Concept Description
 .. doc_concept:: Verification Concept
    :id: doc_concept__verification_process
    :status: valid
+   :version: 1
    :tags: requirements_engineering
 
    In this section a concept for the verification activities will be discussed.

--- a/process/process_areas/verification/verification_getstrt.rst
+++ b/process/process_areas/verification/verification_getstrt.rst
@@ -18,6 +18,7 @@ Getting Started
 .. doc_getstrt:: Verification Get Started
    :id: doc_getstrt__verification_process
    :status: valid
+   :version: 1
    :tags: verification
 
    This document guides you through the initial steps of the software verification process,

--- a/process/process_areas/verification/verification_workflows.rst
+++ b/process/process_areas/verification/verification_workflows.rst
@@ -22,15 +22,22 @@ For a detailed explanation of workflows and their role within the process model,
 .. workflow:: Create/Perform Unit Test
    :id: wf__verification_unit_test
    :status: valid
+   :version: 1
    :tags: implementation
-   :responsible: rl__contributor
-   :approved_by: rl__committer
-   :supported_by: rl__safety_manager
-   :input: wp__sw_implementation, wp__verification_plan
-   :output: wp__verification_sw_unit_test
-   :contains: gd_req__verification_link_tests, gd_req__verification_link_tests_cpp, gd_req__verification_link_tests_python, gd_req__verification_link_tests_rust, gd_req__verification_independence
-   :has: doc_concept__verification_process, doc_getstrt__verification_process,
-         doc_concept__imp_concept, doc_getstrt__imp_getstrt
+   :responsible: rl__contributor[version==1]
+   :approved_by: rl__committer[version==1]
+   :supported_by: rl__safety_manager[version==1]
+   :input: wp__sw_implementation[version==1], wp__verification_plan[version==1]
+   :output: wp__verification_sw_unit_test[version==1]
+   :contains: gd_req__verification_link_tests[version==1],
+              gd_req__verification_link_tests_cpp[version==1],
+              gd_req__verification_link_tests_python[version==1],
+              gd_req__verification_link_tests_rust[version==1],
+              gd_req__verification_independence[version==1]
+   :has: doc_concept__verification_process[version==1],
+         doc_getstrt__verification_process[version==1],
+         doc_concept__imp_concept[version==1],
+         doc_getstrt__imp_getstrt[version==1]
 
    Every Unit shall have at least one Unit Test. They verify the detailed design of the implementation.
    Unit tests are automatically executed as part of the CI after PR merge.
@@ -52,14 +59,24 @@ For a detailed explanation of workflows and their role within the process model,
 .. workflow:: Create/Maintain Component Integration Test
    :id: wf__verification_comp_int_test
    :status: valid
+   :version: 1
    :tags: verification
-   :responsible: rl__contributor
-   :approved_by: rl__committer, rl__testing_community
-   :supported_by: rl__safety_manager
-   :input: wp__component_arch, wp__sw_implementation, wp__requirements_comp, wp__requirements_comp_aou, wp__verification_plan
-   :output: wp__verification_comp_int_test
-   :contains: gd_req__verification_link_tests, gd_req__verification_link_tests_cpp, gd_req__verification_link_tests_python, gd_req__verification_link_tests_rust, gd_req__verification_independence, gd_guidl__verification_specification
-   :has: doc_concept__verification_process, doc_getstrt__verification_process
+   :responsible: rl__contributor[version==1]
+   :approved_by: rl__committer[version==1], rl__testing_community[version==1]
+   :supported_by: rl__safety_manager[version==1]
+   :input: wp__component_arch[version==1],
+           wp__sw_implementation[version==1],
+           wp__requirements_comp[version==1],
+           wp__requirements_comp_aou[version==1],
+           wp__verification_plan[version==1]
+   :output: wp__verification_comp_int_test[version==1]
+   :contains: gd_req__verification_link_tests[version==1],
+              gd_req__verification_link_tests_cpp[version==1],
+              gd_req__verification_link_tests_python[version==1],
+              gd_req__verification_link_tests_rust[version==1],
+              gd_req__verification_independence[version==1],
+              gd_guidl__verification_specification[version==1]
+   :has: doc_concept__verification_process[version==1], doc_getstrt__verification_process[version==1]
 
    Component Integration test cases are based on component architecture and component requirements.
    They also cover the detailed design and integration of units forming a component.
@@ -75,15 +92,23 @@ For a detailed explanation of workflows and their role within the process model,
 .. workflow:: Create/Maintain Feature Integration Test
    :id: wf__verification_feat_int_test
    :status: valid
+   :version: 1
    :tags: verification
-   :responsible: rl__contributor
-   :approved_by: rl__committer, rl__testing_community
-   :supported_by: rl__safety_manager
-   :input: wp__feature_arch, wp__requirements_feat, wp__requirements_feat_aou,
-           wp__verification_plan
-   :output: wp__verification_feat_int_test
-   :contains: gd_req__verification_link_tests, gd_req__verification_link_tests_cpp, gd_req__verification_link_tests_python, gd_req__verification_link_tests_rust, gd_req__verification_independence, gd_guidl__verification_specification
-   :has: doc_concept__verification_process, doc_getstrt__verification_process
+   :responsible: rl__contributor[version==1]
+   :approved_by: rl__committer[version==1], rl__testing_community[version==1]
+   :supported_by: rl__safety_manager[version==1]
+   :input: wp__feature_arch[version==1],
+           wp__requirements_feat[version==1],
+           wp__requirements_feat_aou[version==1],
+           wp__verification_plan[version==1]
+   :output: wp__verification_feat_int_test[version==1]
+   :contains: gd_req__verification_link_tests[version==1],
+              gd_req__verification_link_tests_cpp[version==1],
+              gd_req__verification_link_tests_python[version==1],
+              gd_req__verification_link_tests_rust[version==1],
+              gd_req__verification_independence[version==1],
+              gd_guidl__verification_specification[version==1]
+   :has: doc_concept__verification_process[version==1], doc_getstrt__verification_process[version==1]
 
    Feature Integration test cases are based on feature requirements and architecture of a specific feature.
    Any contributor can create a feature integration test and create a PR for it.
@@ -95,14 +120,20 @@ For a detailed explanation of workflows and their role within the process model,
 .. workflow:: Create/Maintain Platform Integration Test
    :id: wf__verification_platform_int_test
    :status: valid
+   :version: 1
    :tags: verification
-   :responsible: rl__contributor
-   :approved_by: rl__committer, rl__testing_community
-   :supported_by: rl__safety_manager
-   :input: wp__requirements_stkh, wp__verification_plan
-   :output: wp__verification_platform_int_test
-   :contains: gd_req__verification_link_tests, gd_req__verification_link_tests_cpp, gd_req__verification_link_tests_python, gd_req__verification_link_tests_rust, gd_req__verification_independence, gd_guidl__verification_specification
-   :has: doc_concept__verification_process, doc_getstrt__verification_process
+   :responsible: rl__contributor[version==1]
+   :approved_by: rl__committer[version==1], rl__testing_community[version==1]
+   :supported_by: rl__safety_manager[version==1]
+   :input: wp__requirements_stkh[version==1], wp__verification_plan[version==1]
+   :output: wp__verification_platform_int_test[version==1]
+   :contains: gd_req__verification_link_tests[version==1],
+              gd_req__verification_link_tests_cpp[version==1],
+              gd_req__verification_link_tests_python[version==1],
+              gd_req__verification_link_tests_rust[version==1],
+              gd_req__verification_independence[version==1],
+              gd_guidl__verification_specification[version==1]
+   :has: doc_concept__verification_process[version==1], doc_getstrt__verification_process[version==1]
 
    Platform Integration Test cases are based on Stakeholder requirements. This is the highest test level.
    Any contributor can create a platform integration test and create a PR for it.
@@ -114,14 +145,15 @@ For a detailed explanation of workflows and their role within the process model,
 .. workflow:: Create Verification Plan
    :id: wf__verification_plan
    :status: valid
+   :version: 1
    :tags: verification
-   :responsible: rl__committer, rl__testing_community
-   :approved_by: rl__project_lead
-   :supported_by: rl__safety_manager, rl__infrastructure_tooling_community
-   :input: wp__requirements_stkh, wp__platform_mgmt, wp__tool_verification_report
-   :output: wp__verification_plan
-   :contains: gd_guidl__verification_guide, gd_temp__verification_plan
-   :has: doc_concept__verification_process, doc_getstrt__verification_process
+   :responsible: rl__committer[version==1], rl__testing_community[version==1]
+   :approved_by: rl__project_lead[version==1]
+   :supported_by: rl__safety_manager[version==1], rl__infrastructure_tooling_community[version==1]
+   :input: wp__requirements_stkh[version==1], wp__platform_mgmt[version==1], wp__tool_verification_report[version==1]
+   :output: wp__verification_plan[version==1]
+   :contains: gd_guidl__verification_guide[version==1], gd_temp__verification_plan[version==1]
+   :has: doc_concept__verification_process[version==1], doc_getstrt__verification_process[version==1]
 
    The verification plan is created by :need:`rl__committer`. It clearly
    outlines all aspects of the verification activities, provide a roadmap for the verification
@@ -131,17 +163,24 @@ For a detailed explanation of workflows and their role within the process model,
 .. workflow:: Maintain Verification Plan
    :id: wf__verification_plan_maintain
    :status: valid
+   :version: 1
    :tags: verification
-   :responsible: rl__committer, rl__testing_community
-   :approved_by: rl__project_lead
-   :supported_by: rl__safety_manager, rl__infrastructure_tooling_community
-   :input: wp__verification_plan, wp__requirements_stkh, wp__platform_mgmt,
-           wp__feature_arch, wp__requirements_feat, wp__requirements_feat_aou,
-           wp__component_arch, wp__requirements_comp, wp__requirements_comp_aou,
-           wp__tool_verification_report
-   :output: wp__verification_plan
-   :contains: gd_guidl__verification_guide, gd_temp__verification_plan
-   :has: doc_concept__verification_process, doc_getstrt__verification_process
+   :responsible: rl__committer[version==1], rl__testing_community[version==1]
+   :approved_by: rl__project_lead[version==1]
+   :supported_by: rl__safety_manager[version==1], rl__infrastructure_tooling_community[version==1]
+   :input: wp__verification_plan[version==1],
+           wp__requirements_stkh[version==1],
+           wp__platform_mgmt[version==1],
+           wp__feature_arch[version==1],
+           wp__requirements_feat[version==1],
+           wp__requirements_feat_aou[version==1],
+           wp__component_arch[version==1],
+           wp__requirements_comp[version==1],
+           wp__requirements_comp_aou[version==1],
+           wp__tool_verification_report[version==1]
+   :output: wp__verification_plan[version==1]
+   :contains: gd_guidl__verification_guide[version==1], gd_temp__verification_plan[version==1]
+   :has: doc_concept__verification_process[version==1], doc_getstrt__verification_process[version==1]
 
    The verification plan is maintained by :need:`rl__committer`. The plan should be dynamic and updated
    as needed throughout the project lifecycle, as verification activities may be impacted, by new
@@ -153,18 +192,28 @@ For a detailed explanation of workflows and their role within the process model,
 .. workflow:: Set Requirement Test Coverage
    :id: wf__verification_req_test_coverage
    :status: valid
+   :version: 1
    :tags: verification
-   :responsible: rl__committer, rl__testing_community
-   :approved_by: rl__project_lead
-   :supported_by: rl__safety_manager, rl__security_manager,
-   :input: wp__requirements_stkh, wp__requirements_feat, wp__requirements_feat_aou,
-           wp__requirements_comp, wp__requirements_comp_aou,
-           wp__verification_plan, wp__verification_sw_unit_test,
-           wp__verification_comp_int_test, wp__verification_feat_int_test, wp__verification_platform_int_test
-   :output: wp__requirements_stkh, wp__requirements_feat, wp__requirements_feat_aou,
-            wp__requirements_comp, wp__requirements_comp_aou
-   :contains: gd_req__req_attr_test_covered, gd_req__req_suspicious, gd_guidl__verification_guide
-   :has: doc_concept__verification_process, doc_getstrt__verification_process
+   :responsible: rl__committer[version==1], rl__testing_community[version==1]
+   :approved_by: rl__project_lead[version==1]
+   :supported_by: rl__safety_manager[version==1], rl__security_manager[version==1]
+   :input: wp__requirements_stkh[version==1],
+           wp__requirements_feat[version==1],
+           wp__requirements_feat_aou[version==1],
+           wp__requirements_comp[version==1],
+           wp__requirements_comp_aou[version==1],
+           wp__verification_plan[version==1],
+           wp__verification_sw_unit_test[version==1],
+           wp__verification_comp_int_test[version==1],
+           wp__verification_feat_int_test[version==1],
+           wp__verification_platform_int_test[version==1]
+   :output: wp__requirements_stkh[version==1],
+            wp__requirements_feat[version==1],
+            wp__requirements_feat_aou[version==1],
+            wp__requirements_comp[version==1],
+            wp__requirements_comp_aou[version==1]
+   :contains: gd_req__req_attr_test_covered[version==1], gd_req__req_suspicious[version==1], gd_guidl__verification_guide[version==1]
+   :has: doc_concept__verification_process[version==1], doc_getstrt__verification_process[version==1]
 
    The requirement attribute `complete test coverage` is set to `yes` by a :need:`rl__committer` when it is verified
    that the requirement is fully covered by test cases. This means the linked test cases in sum fully satisfy the requirement.
@@ -175,18 +224,27 @@ For a detailed explanation of workflows and their role within the process model,
 .. workflow:: Create Module Verification Report
    :id: wf__verification_mod_ver_report
    :status: valid
+   :version: 1
    :tags: verification
-   :responsible: rl__committer, rl__testing_community
-   :approved_by: rl__project_lead
-   :supported_by: rl__safety_manager, rl__infrastructure_tooling_community, rl__contributor
-   :input: wp__verification_plan, wp__requirements_comp, wp__requirements_comp_aou,
-           wp__component_arch, wp__module_sw_release_note, wp__platform_mgmt,
-           wp__sw_component_fmea, wp__sw_component_dfa,
-           wp__sw_arch_verification, wp__sw_implementation_inspection, wp__requirements_inspect,
-           wp__verification_comp_int_test, wp__verification_sw_unit_test
-   :output: wp__verification_module_ver_report
-   :contains: gd_temp__mod_ver_report
-   :has: doc_concept__verification_process, doc_getstrt__verification_process
+   :responsible: rl__committer[version==1], rl__testing_community[version==1]
+   :approved_by: rl__project_lead[version==1]
+   :supported_by: rl__safety_manager[version==1], rl__infrastructure_tooling_community[version==1], rl__contributor[version==1]
+   :input: wp__verification_plan[version==1],
+           wp__requirements_comp[version==1],
+           wp__requirements_comp_aou[version==1],
+           wp__component_arch[version==1],
+           wp__module_sw_release_note[version==1],
+           wp__platform_mgmt[version==1],
+           wp__sw_component_fmea[version==1],
+           wp__sw_component_dfa[version==1],
+           wp__sw_arch_verification[version==1],
+           wp__sw_implementation_inspection[version==1],
+           wp__requirements_inspect[version==1],
+           wp__verification_comp_int_test[version==1],
+           wp__verification_sw_unit_test[version==1]
+   :output: wp__verification_module_ver_report[version==1]
+   :contains: gd_temp__mod_ver_report[version==1]
+   :has: doc_concept__verification_process[version==1], doc_getstrt__verification_process[version==1]
 
    The verification report is created and maintained by a :need:`rl__committer`.
    It is based on the :need:`wp__verification_plan` and covers all the components of a developed module.
@@ -206,18 +264,28 @@ For a detailed explanation of workflows and their role within the process model,
 .. workflow:: Create Platform Verification Report
    :id: wf__verification_platform_ver_report
    :status: valid
+   :version: 1
    :tags: verification
-   :responsible: rl__committer, rl__testing_community
-   :approved_by: rl__project_lead
-   :supported_by: rl__safety_manager, rl__infrastructure_tooling_community
-   :input: wp__verification_plan, wp__requirements_stkh, wp__requirements_feat, wp__requirements_feat_aou,
-           wp__feature_arch, wp__platform_sw_release_note, wp__platform_mgmt,
-           wp__feature_fmea, wp__feature_dfa, wp__platform_dfa,
-           wp__sw_arch_verification, wp__requirements_inspect,
-           wp__verification_feat_int_test, wp__verification_platform_int_test
-   :output: wp__verification_platform_ver_report
-   :contains: gd_temp__platform_ver_report
-   :has: doc_concept__verification_process, doc_getstrt__verification_process
+   :responsible: rl__committer[version==1], rl__testing_community[version==1]
+   :approved_by: rl__project_lead[version==1]
+   :supported_by: rl__safety_manager[version==1], rl__infrastructure_tooling_community[version==1]
+   :input: wp__verification_plan[version==1],
+           wp__requirements_stkh[version==1],
+           wp__requirements_feat[version==1],
+           wp__requirements_feat_aou[version==1],
+           wp__feature_arch[version==1],
+           wp__platform_sw_release_note[version==1],
+           wp__platform_mgmt[version==1],
+           wp__feature_fmea[version==1],
+           wp__feature_dfa[version==1],
+           wp__platform_dfa[version==1],
+           wp__sw_arch_verification[version==1],
+           wp__requirements_inspect[version==1],
+           wp__verification_feat_int_test[version==1],
+           wp__verification_platform_int_test[version==1]
+   :output: wp__verification_platform_ver_report[version==1]
+   :contains: gd_temp__platform_ver_report[version==1]
+   :has: doc_concept__verification_process[version==1], doc_getstrt__verification_process[version==1]
 
    The verification report is created and maintained by a :need:`rl__committer`.
    It is based on the :need:`wp__verification_plan` and covers all the selected features of a SW platform.

--- a/process/process_areas/verification/verification_workproducts.rst
+++ b/process/process_areas/verification/verification_workproducts.rst
@@ -23,8 +23,12 @@ Platform
 .. workproduct:: Verification Plan
    :id: wp__verification_plan
    :status: valid
+   :version: 1
    :tags: doc_lifecycle_model_2
-   :complies: std_wp__iso26262__support_951, std_wp__iso26262__support_952, std_wp__iso26262__support_1252, std_wp__isosae21434__development_1056
+   :complies: std_wp__iso26262__support_951[version==1],
+              std_wp__iso26262__support_952[version==1],
+              std_wp__iso26262__support_1252[version==1],
+              std_wp__isosae21434__development_1056[version==1]
 
    Verification planning for each phase of the safety lifecycle must detail the work products,
    objectives, methods, criteria, environments, equipment, resources, actions for anomalies, and
@@ -35,8 +39,9 @@ Platform
 .. workproduct:: Platform Integration Test
    :id: wp__verification_platform_int_test
    :status: valid
+   :version: 1
    :tags: doc_lifecycle_model_2
-   :complies: std_wp__iso26262__support_952, std_wp__isosae21434__development_1057
+   :complies: std_wp__iso26262__support_952[version==1], std_wp__isosae21434__development_1057[version==1]
 
    Platform Integration Testing verifies Stakeholder Requirements performed on reference HW.
    Depending on the nature of the project, respective tailoring (e.g. for reduced requirements
@@ -49,8 +54,14 @@ Platform
 .. workproduct:: Platform Verification Report
    :id: wp__verification_platform_ver_report
    :status: valid
+   :version: 1
    :tags: doc_lifecycle_model_2
-   :complies: std_wp__iso26262__software_1053, std_wp__iso26262__support_953, std_wp__iso26262__analysis_752, std_wp__iso26262__analysis_852, std_wp__isosae21434__development_1054, std_wp__isosae21434__development_1057
+   :complies: std_wp__iso26262__software_1053[version==1],
+              std_wp__iso26262__support_953[version==1],
+              std_wp__iso26262__analysis_752[version==1],
+              std_wp__iso26262__analysis_852[version==1],
+              std_wp__isosae21434__development_1054[version==1],
+              std_wp__isosae21434__development_1057[version==1]
 
    Verification Report contains:
 
@@ -73,8 +84,9 @@ Feature
 .. workproduct:: Feature Integration test
    :id: wp__verification_feat_int_test
    :status: valid
+   :version: 1
    :tags: doc_lifecycle_model_2
-   :complies: std_wp__iso26262__software_1051, std_wp__iso26262__support_952
+   :complies: std_wp__iso26262__software_1051[version==1], std_wp__iso26262__support_952[version==1]
 
    Integration Testing verifies feature requirements and architecture:
 
@@ -92,8 +104,17 @@ Module
 .. workproduct:: Module Verification Report
    :id: wp__verification_module_ver_report
    :status: valid
+   :version: 1
    :tags: doc_lifecycle_model_2
-   :complies: std_wp__iso26262__software_952, std_wp__iso26262__software_1053, std_wp__iso26262__support_953, std_wp__iso26262__support_1253, std_wp__iso26262__analysis_752, std_wp__iso26262__analysis_852, std_wp__iso26262__support_1252, std_wp__isopas8926__4526, std_wp__iso26262__software_app_c_56
+   :complies: std_wp__iso26262__software_952[version==1],
+              std_wp__iso26262__software_1053[version==1],
+              std_wp__iso26262__support_953[version==1],
+              std_wp__iso26262__support_1253[version==1],
+              std_wp__iso26262__analysis_752[version==1],
+              std_wp__iso26262__analysis_852[version==1],
+              std_wp__iso26262__support_1252[version==1],
+              std_wp__isopas8926__4526[version==1],
+              std_wp__iso26262__software_app_c_56[version==1]
 
    Verification Report contains:
 
@@ -124,8 +145,12 @@ Component
 .. workproduct:: Component Integration test
    :id: wp__verification_comp_int_test
    :status: valid
+   :version: 1
    :tags: doc_lifecycle_model_2
-   :complies: std_wp__iso26262__software_1051, std_wp__iso26262__support_952, std_wp__isopas8926__4525, std_wp__iso26262__software_app_c_55
+   :complies: std_wp__iso26262__software_1051[version==1],
+              std_wp__iso26262__support_952[version==1],
+              std_wp__isopas8926__4525[version==1],
+              std_wp__iso26262__software_app_c_55[version==1]
 
    Component Integration Testing verifies the component architecture and component requirements:
 
@@ -143,8 +168,12 @@ Component
 .. workproduct:: Unit test
    :id: wp__verification_sw_unit_test
    :status: valid
+   :version: 1
    :tags: doc_lifecycle_model_2
-   :complies: std_wp__iso26262__software_951, std_wp__iso26262__support_952, std_wp__isopas8926__4525, std_wp__iso26262__software_app_c_55
+   :complies: std_wp__iso26262__software_951[version==1],
+              std_wp__iso26262__support_952[version==1],
+              std_wp__isopas8926__4525[version==1],
+              std_wp__iso26262__software_app_c_55[version==1]
 
    Unit testing verifies detailed design (traced to).
    Respective tooling is defined in :need:`wp__platform_mgmt`, :need:`wp__verification_plan` and integrated in CI/Build.

--- a/process/release_notes/release_note_v_1_5_3.rst
+++ b/process/release_notes/release_note_v_1_5_3.rst
@@ -18,9 +18,10 @@ Release Note v1.5.3
 .. document:: Process description Release Note v1.5.3
    :id: doc__process_description_release_note_v152
    :status: valid
+   :version: 1
    :safety: ASIL_B
    :security: YES
-   :realizes: wp__module_sw_release_note
+   :realizes: wp__module_sw_release_note[version==1]
    :tags:
 
 | **Module Name:** Process description

--- a/process/roles/index.rst
+++ b/process/roles/index.rst
@@ -23,6 +23,7 @@ Project Management Roles
 .. role:: Project Lead
    :id: rl__project_lead
    :status: valid
+   :version: 1
    :tags: process_management
 
    The Project Leads decide about strategy, approve feature requests and perform the
@@ -61,8 +62,9 @@ Project Process Roles
 .. role:: Process Community Member
    :id: rl__process_community
    :status: valid
+   :version: 1
    :tags: process_management
-   :contains: rl__committer
+   :contains: rl__committer[version==1]
 
    The process community members are responsible for the definition of the process architecture of the project integrated management system and how they processes interact.
    The approval and release of the process is done by the safety, quality and security managers and the project leads (for the parts which affect them).
@@ -73,14 +75,16 @@ Project Development Roles
 .. role:: Infrastructure Tooling Community Member
    :id: rl__infrastructure_tooling_community
    :status: valid
+   :version: 1
    :tags: development
-   :contains: rl__committer
+   :contains: rl__committer[version==1]
 
    The infrastructure and tooling community members are responsible for the infrastructure and tooling setup for development, but also the rest of the tool chain.
 
 .. role:: Contributor
    :id: rl__contributor
    :status: valid
+   :version: 1
    :tags: development
 
    (Eclipse) Open Source Role, person(s) who provide(s) possible contribution(s) as pull request(s) to the main line.
@@ -92,6 +96,7 @@ Project Development Roles
 .. role:: Committer
    :id: rl__committer
    :status: valid
+   :version: 1
    :tags: development
 
    (Eclipse) Open Source Role, person(s) who accept(s) possible contribution(s) as pull request(s) to the main line and maintains the product.
@@ -102,8 +107,9 @@ Project Development Roles
 .. role:: Testing Community Member
    :id: rl__testing_community
    :status: valid
+   :version: 1
    :tags: verification
-   :contains: rl__committer
+   :contains: rl__committer[version==1]
 
    The testing community members are responsible for the test case development from component to
    platform level. They shall be included in any requirements reviews. They can also improve
@@ -113,8 +119,9 @@ Project Development Roles
 .. role:: Architecture Community Member
    :id: rl__architecture_community
    :status: valid
+   :version: 1
    :tags: architecture_design
-   :contains: rl__committer
+   :contains: rl__committer[version==1]
 
    The architecture community members are responsible for the features and components of
    the platform. Feature and Components requests, which add new ones or modifications, are
@@ -123,8 +130,9 @@ Project Development Roles
 .. role:: Project Security Team
    :id: rl__security_team
    :status: valid
+   :version: 1
    :tags: verification, security_analysis
-   :contains: rl__committer, rl__security_engineer
+   :contains: rl__committer[version==1], rl__security_engineer[version==1]
 
    (Eclipse) Open Source Role, person(s) who is(are) responsible for coordinating the resolution of Vulnerabilities within the Project.
    By default, the project Security Team includes all Committers. However, the Project may choose a different arrangement and establish specific criteria for team nominations.
@@ -135,8 +143,17 @@ Project Teams
 .. role:: Platform Team
    :id: rl__platform_team
    :status: valid
+   :version: 1
    :tags: cross_functional
-   :contains: rl__project_lead, rl__safety_manager, rl__quality_manager, rl__security_manager, rl__contributor, rl__committer, rl__infrastructure_tooling_community, rl__process_community, rl__architecture_community
+   :contains: rl__project_lead[version==1],
+              rl__safety_manager[version==1],
+              rl__quality_manager[version==1],
+              rl__security_manager[version==1],
+              rl__contributor[version==1],
+              rl__committer[version==1],
+              rl__infrastructure_tooling_community[version==1],
+              rl__process_community[version==1],
+              rl__architecture_community[version==1]
 
    The platform team is responsible for all artifacts within the platform SEooC.
    Additionally it is also responsible for the overall process including its support
@@ -146,8 +163,13 @@ Project Teams
 .. role:: Delivery Team
    :id: rl__delivery_team
    :status: valid
+   :version: 1
    :tags: cross_functional
-   :contains: rl__safety_manager, rl__quality_manager, rl__security_manager, rl__contributor, rl__committer
+   :contains: rl__safety_manager[version==1],
+              rl__quality_manager[version==1],
+              rl__security_manager[version==1],
+              rl__contributor[version==1],
+              rl__committer[version==1]
 
    The delivery team is responsible for all artifacts within the Delivery Container
    SEooCs containing the Dependable Elements. Each Delivery Container has only one
@@ -159,8 +181,13 @@ Project Teams
 .. role:: Release Team
    :id: rl__release_team
    :status: valid
+   :version: 1
    :tags: cross_functional
-   :contains: rl__safety_manager, rl__quality_manager, rl__security_manager, rl__contributor, rl__committer
+   :contains: rl__safety_manager[version==1],
+              rl__quality_manager[version==1],
+              rl__security_manager[version==1],
+              rl__contributor[version==1],
+              rl__committer[version==1]
 
    The release team is responsible for the release. The release team consists of different stakeholders like
    module leads, project leads and quality managers.

--- a/process/standards/aspice_40/aspice.rst
+++ b/process/standards/aspice_40/aspice.rst
@@ -102,7 +102,8 @@ Generic practices
 .. std_req:: GP2.1.1: Identify the objectives and define a strategy for the performance of the process.
    :id: std_req__aspice_40__gp-211
    :status: valid
-   :links: std_req__aspice_40__iic-19-01
+   :version: 1
+   :links: std_req__aspice_40__iic-19-01[version==1]
 
    The scope of the process activities including the management of process performance and the management of work products are determined.
    Corresponding results to be achieved are determined.
@@ -126,7 +127,8 @@ Generic practices
 .. std_req:: GP2.1.2: Plan the performance of the process.
    :id: std_req__aspice_40__gp-212
    :status: valid
-   :links: std_req__aspice_40__iic-08-56,std_req__aspice_40__iic-14-10
+   :version: 1
+   :links: std_req__aspice_40__iic-08-56[version==1], std_req__aspice_40__iic-14-10[version==1]
 
    The planning for the performance of the process is established according to the defined objectives, criteria, and strategy.
    Process activities and work packages are defined.
@@ -139,7 +141,8 @@ Generic practices
 .. std_req:: GP2.1.3: Determine resource needs.
    :id: std_req__aspice_40__gp-213
    :status: valid
-   :links: std_req__aspice_40__iic-17-55
+   :version: 1
+   :links: std_req__aspice_40__iic-17-55[version==1]
 
    The required amount of human resources, and experience, knowledge and skill needs for the for process performance are determined based on the planning.
    The needs for physical and material resources are determined based on the planning.
@@ -157,7 +160,8 @@ Generic practices
 .. std_req:: GP2.1.4: Identify and make available resources.
    :id: std_req__aspice_40__gp-214
    :status: valid
-   :links: std_req__aspice_40__iic-08-61
+   :version: 1
+   :links: std_req__aspice_40__iic-08-61[version==1]
 
    The individuals performing and managing the process are identified and allocated according to the determined needs.
    The individuals performing and managing the process are being qualified to execute their responsibilities.
@@ -171,7 +175,8 @@ Generic practices
 .. std_req:: GP2.1.5: Monitor and adjust the performance of the process.
    :id: std_req__aspice_40__gp-215
    :status: valid
-   :links: std_req__aspice_40__iic-08-56,std_req__aspice_40__iic-13-14
+   :version: 1
+   :links: std_req__aspice_40__iic-08-56[version==1], std_req__aspice_40__iic-13-14[version==1]
 
    Process performance is monitored to identify deviations from the planning.
    Appropriate actions in case of deviations from the planning are taken.
@@ -180,7 +185,8 @@ Generic practices
 .. std_req:: GP2.1.6: Manage the interfaces between involved parties.
    :id: std_req__aspice_40__gp-216
    :status: valid
-   :links: std_req__aspice_40__iic-08-62,std_req__aspice_40__iic-13-52
+   :version: 1
+   :links: std_req__aspice_40__iic-08-62[version==1], std_req__aspice_40__iic-13-52[version==1]
 
    The individuals and groups including required external parties involved in the process performance are determined.
    Responsibilities are assigned to the relevant individuals or parties.
@@ -209,7 +215,8 @@ Generic practices
 .. std_req:: GP2.2.1: Define the requirements for the work products.
    :id: std_req__aspice_40__gp-221
    :status: valid
-   :links: std_req__aspice_40__iic-17-05,std_req__aspice_40__iic-18-07,std_req__aspice_40__iic-18-59
+   :version: 1
+   :links: std_req__aspice_40__iic-17-05[version==1], std_req__aspice_40__iic-18-07[version==1], std_req__aspice_40__iic-18-59[version==1]
 
    The requirements for the content and structure of the work products to be produced are defined.
    Quality criteria for the work products are identified.
@@ -229,7 +236,8 @@ Generic practices
 .. std_req:: GP2.2.2: Define the requirements for storage and control of the work products.
    :id: std_req__aspice_40__gp-222
    :status: valid
-   :links: std_req__aspice_40__iic-17-05
+   :version: 1
+   :links: std_req__aspice_40__iic-17-05[version==1]
 
    Requirements for the storage and control of the work products are defined, including their identification and distribution.
 
@@ -248,7 +256,8 @@ Generic practices
 .. std_req:: GP2.2.3: Identify, store and control the work products.
    :id: std_req__aspice_40__gp-223
    :status: valid
-   :links: std_req__aspice_40__iic-13-08,std_req__aspice_40__iic-16-00
+   :version: 1
+   :links: std_req__aspice_40__iic-13-08[version==1], std_req__aspice_40__iic-16-00[version==1]
 
    The work products to be controlled are identified.
    The work products are stored and controlled in accordance with the requirements.
@@ -259,7 +268,8 @@ Generic practices
 .. std_req:: GP2.2.4: Review and adjust work products.
    :id: std_req__aspice_40__gp-224
    :status: valid
-   :links: std_req__aspice_40__iic-13-19
+   :version: 1
+   :links: std_req__aspice_40__iic-13-19[version==1]
 
    The work products are reviewed against the defined requirements and criteria.
    Resolution of issues arising from work products reviews is ensured.
@@ -288,7 +298,11 @@ Generic practices
 .. std_req:: GP3.1.1: Establish and maintain the standard process.
    :id: std_req__aspice_40__gp-311
    :status: valid
-   :links: std_req__aspice_40__iic-06-51,std_req__aspice_40__iic-10-00,std_req__aspice_40__iic-10-50,std_req__aspice_40__iic-10-51
+   :version: 1
+   :links: std_req__aspice_40__iic-06-51[version==1],
+           std_req__aspice_40__iic-10-00[version==1],
+           std_req__aspice_40__iic-10-50[version==1],
+           std_req__aspice_40__iic-10-51[version==1]
 
    A suitable standard process is developed including required activities and their interactions.
    Inputs and outputs of the standard process are defined including the corresponding entry and
@@ -315,7 +329,8 @@ Generic practices
 .. std_req:: GP3.1.2: Determine the required competencies.
    :id: std_req__aspice_40__gp-312
    :status: valid
-   :links: std_req__aspice_40__iic-10-50,std_req__aspice_40__iic-10-51
+   :version: 1
+   :links: std_req__aspice_40__iic-10-50[version==1], std_req__aspice_40__iic-10-51[version==1]
 
    Required competencies, skills, and experience for performing the standard process are determined for the identified roles.
    Appropriate qualification methods to acquire the necessary competencies and skills are determined, maintained, and made available for the identified roles.
@@ -331,7 +346,8 @@ Generic practices
 .. std_req:: GP3.1.3: Determine the required resources.
    :id: std_req__aspice_40__gp-313
    :status: valid
-   :links: std_req__aspice_40__iic-10-52
+   :version: 1
+   :links: std_req__aspice_40__iic-10-52[version==1]
 
    Required physical and material resources and process infrastructure needs for performing the standard process are determined.
 
@@ -342,7 +358,8 @@ Generic practices
 .. std_req:: GP3.1.4: Determine suitable methods to monitor the standard process.
    :id: std_req__aspice_40__gp-314
    :status: valid
-   :links: std_req__aspice_40__iic-08-63
+   :version: 1
+   :links: std_req__aspice_40__iic-08-63[version==1]
 
    Methods and required activities for monitoring the effectiveness and adequacy of the standard process are determined.
 
@@ -379,7 +396,8 @@ Generic practices
 .. std_req:: GP3.2.1: Deploy a defined process that satisfies the context specific requirements of the use of the standard process.
    :id: std_req__aspice_40__gp-321
    :status: valid
-   :links: std_req__aspice_40__iic-10-00,std_req__aspice_40__iic-15-54
+   :version: 1
+   :links: std_req__aspice_40__iic-10-00[version==1], std_req__aspice_40__iic-15-54[version==1]
 
    The defined process is appropriately selected and/or tailored from the standard process.
    Conformance of defined process with standard process requirements and tailoring criteria is verified.
@@ -392,7 +410,8 @@ Generic practices
 .. std_req:: GP3.2.2: Ensure required competencies for the defined roles.
    :id: std_req__aspice_40__gp-322
    :status: valid
-   :links: std_req__aspice_40__iic-14-53
+   :version: 1
+   :links: std_req__aspice_40__iic-14-53[version==1]
 
    Human resources are allocated to the defined roles according to the required competencies and skills.
    Assignment of persons to roles and corresponding responsibilities and authorities for performing the defined process are communicated.
@@ -402,7 +421,8 @@ Generic practices
 .. std_req:: GP3.2.3: Ensure required resources to support the performance of the defined process.
    :id: std_req__aspice_40__gp-323
    :status: valid
-   :links: std_req__aspice_40__iic-13-55
+   :version: 1
+   :links: std_req__aspice_40__iic-13-55[version==1]
 
    Required information to perform the defined process is made available, allocated and used.
    Required physical and material resources, process infrastructure and work environment are made available, allocated and used.
@@ -411,7 +431,8 @@ Generic practices
 .. std_req:: GP3.2.4: Monitor the performance of the defined process.
    :id: std_req__aspice_40__gp-324
    :status: valid
-   :links: std_req__aspice_40__iic-03-06
+   :version: 1
+   :links: std_req__aspice_40__iic-03-06[version==1]
 
    Information is collected and analyzed according to the determined process monitoring methods to understand the effectiveness and adequacy of the defined process.
    Results of the analysis are made available to all effected parties and used to identify where continual improvement of the standard and/or defined process can be made.

--- a/process/standards/aspice_40/iic/iic-01.rst
+++ b/process/standards/aspice_40/iic/iic-01.rst
@@ -18,6 +18,7 @@
 .. std_req:: 01-03 Software Component
    :id: std_req__aspice_40__iic-01-03
    :status: valid
+   :version: 1
 
    Software Component may have the following characteristics:
 
@@ -30,6 +31,7 @@
 .. std_req:: 01-50 Integrated Software
    :id: std_req__aspice_40__iic-01-50
    :status: valid
+   :version: 1
 
    Integrated Software may have the following characteristics:
 
@@ -42,6 +44,7 @@
 .. std_req:: 01-52 Configuration item list
    :id: std_req__aspice_40__iic-01-52
    :status: valid
+   :version: 1
 
    Configuration item list may have the following characteristics:
 
@@ -52,12 +55,14 @@
 .. std_req:: 01-53 Trained ML model
    :id: std_req__aspice_40__iic-01-53
    :status: valid
+   :version: 1
 
    - The trained ML model is the output of the training process. It consists of the software representing the ML architecture, the set of weights which were optimized during the training, and the final set of hyperparameters.
 
 .. std_req:: 01-54 Hyperparameter
    :id: std_req__aspice_40__iic-01-54
    :status: valid
+   :version: 1
 
 
    - Hyperparameters are used to control the ML model which has to be trained, e.g.:

--- a/process/standards/aspice_40/iic/iic-02.rst
+++ b/process/standards/aspice_40/iic/iic-02.rst
@@ -18,6 +18,7 @@
 .. std_req:: 02-01 Commitment / agreement
    :id: std_req__aspice_40__iic-02-01
    :status: valid
+   :version: 1
 
    Commitment / agreement may have the following characteristics:
 

--- a/process/standards/aspice_40/iic/iic-03.rst
+++ b/process/standards/aspice_40/iic/iic-03.rst
@@ -18,6 +18,7 @@
 .. std_req:: 03-06 Process performance information
    :id: std_req__aspice_40__iic-03-06
    :status: valid
+   :version: 1
 
    Process performance information may have the following characteristics:
 
@@ -46,6 +47,7 @@
 .. std_req:: 03-50 Verification Measure Data
    :id: std_req__aspice_40__iic-03-50
    :status: valid
+   :version: 1
 
    Verification Measure Data may have the following characteristics:
 
@@ -62,12 +64,14 @@
 .. std_req:: 03-51 ML data set
    :id: std_req__aspice_40__iic-03-51
    :status: valid
+   :version: 1
 
    - Selection of ML Data for e.g., ML model training (ML Training and Validation Data Set) or test of the trained and deployed ML model (ML Test Data Set).
 
 .. std_req:: 03-53 ML data
    :id: std_req__aspice_40__iic-03-53
    :status: valid
+   :version: 1
 
    - Datum to be used for Machine Learning. The datum has to be attributed by metadata, e.g., unique ID and data characteristics. Examples:
       - Visual data like a photo or videos (but a video could also be considered as sequence of photos depending on the intended use)

--- a/process/standards/aspice_40/iic/iic-04.rst
+++ b/process/standards/aspice_40/iic/iic-04.rst
@@ -18,12 +18,14 @@
 .. std_req:: 04-02 Domain architecture
    :id: std_req__aspice_40__iic-04-02
    :status: valid
+   :version: 1
 
    Definition not available yet in PAM4.0 document.
 
 .. std_req:: 04-04 Software Architecture
    :id: std_req__aspice_40__iic-04-04
    :status: valid
+   :version: 1
 
    Software Architecture may have the following characteristics:
 
@@ -57,6 +59,7 @@
 .. std_req:: 04-05 Software detailed design
    :id: std_req__aspice_40__iic-04-05
    :status: valid
+   :version: 1
 
    Software detailed design may have the following characteristics:
 
@@ -79,6 +82,7 @@
 .. std_req:: 04-51 ML architecture
    :id: std_req__aspice_40__iic-04-51
    :status: valid
+   :version: 1
 
    - An ML architecture is basically a special part of a software architecture (see 04-04). Additionally
 

--- a/process/standards/aspice_40/iic/iic-06.rst
+++ b/process/standards/aspice_40/iic/iic-06.rst
@@ -18,6 +18,7 @@
 .. std_req:: 06-04 Training material
    :id: std_req__aspice_40__iic-06-04
    :status: valid
+   :version: 1
 
    Training material may have the following characteristics:
 
@@ -28,6 +29,7 @@
 .. std_req:: 06-50 Integration Sequence Instruction
    :id: std_req__aspice_40__iic-06-50
    :status: valid
+   :version: 1
 
    Integration Sequence Instruction may have the following characteristics:
 
@@ -41,6 +43,7 @@
 .. std_req:: 06-51 Tailoring guideline
    :id: std_req__aspice_40__iic-06-51
    :status: valid
+   :version: 1
 
    Tailoring guideline may have the following characteristics:
 
@@ -53,6 +56,7 @@
 .. std_req:: 06-52 Backup and recovery mechanism information
    :id: std_req__aspice_40__iic-06-52
    :status: valid
+   :version: 1
 
    Backup and recovery mechanism information may have the following characteristics:
 

--- a/process/standards/aspice_40/iic/iic-07.rst
+++ b/process/standards/aspice_40/iic/iic-07.rst
@@ -18,6 +18,7 @@
 .. std_req:: 07-04 Process metric
    :id: std_req__aspice_40__iic-07-04
    :status: valid
+   :version: 1
 
    Process metric may have the following characteristics:
 
@@ -32,6 +33,7 @@
 .. std_req:: 07-05 Project metric
    :id: std_req__aspice_40__iic-07-05
    :status: valid
+   :version: 1
 
    Project metric may have the following characteristics:
 
@@ -50,6 +52,7 @@
 .. std_req:: 07-06 Quality metric
    :id: std_req__aspice_40__iic-07-06
    :status: valid
+   :version: 1
 
    Quality metric may have the following characteristics:
 
@@ -69,6 +72,7 @@
 .. std_req:: 07-08 Service level metric
    :id: std_req__aspice_40__iic-07-08
    :status: valid
+   :version: 1
 
    Service level metric may have the following characteristics:
 
@@ -85,6 +89,7 @@
 .. std_req:: 07-51 Measurement result
    :id: std_req__aspice_40__iic-07-51
    :status: valid
+   :version: 1
 
    Measurement result may have the following characteristics:
 
@@ -124,6 +129,7 @@
 .. std_req:: 07-61 Quantitative process metric
    :id: std_req__aspice_40__iic-07-61
    :status: valid
+   :version: 1
 
    Quantitative process metric may have the following characteristics:
 
@@ -136,6 +142,7 @@
 .. std_req:: 07-62 Process analysis technique
    :id: std_req__aspice_40__iic-07-62
    :status: valid
+   :version: 1
 
    Process analysis technique may have the following characteristics:
 
@@ -145,6 +152,7 @@
 .. std_req:: 07-63 Process control limits
    :id: std_req__aspice_40__iic-07-63
    :status: valid
+   :version: 1
 
    Process control limits may have the following characteristics:
 
@@ -153,6 +161,7 @@
 .. std_req:: 07-64 Process measurement data
    :id: std_req__aspice_40__iic-07-64
    :status: valid
+   :version: 1
 
    Process measurement data may have the following characteristics:
 

--- a/process/standards/aspice_40/iic/iic-08.rst
+++ b/process/standards/aspice_40/iic/iic-08.rst
@@ -18,6 +18,7 @@
 .. std_req:: 08-53 Scope of work
    :id: std_req__aspice_40__iic-08-53
    :status: valid
+   :version: 1
 
    Scope of work may have the following characteristics:
 
@@ -34,6 +35,7 @@
 .. std_req:: 08-54 Feasibility analysis
    :id: std_req__aspice_40__iic-08-54
    :status: valid
+   :version: 1
 
    Feasibility analysis may have the following characteristics:
 
@@ -43,6 +45,7 @@
 .. std_req:: 08-55 Risk measure
    :id: std_req__aspice_40__iic-08-55
    :status: valid
+   :version: 1
 
    Risk measure may have the following characteristics:
 
@@ -62,6 +65,7 @@
 .. std_req:: 08-56 Schedule
    :id: std_req__aspice_40__iic-08-56
    :status: valid
+   :version: 1
 
    Schedule may have the following characteristics:
 
@@ -78,6 +82,7 @@
 .. std_req:: 08-58 Verification Measure Selection Set
    :id: std_req__aspice_40__iic-08-58
    :status: valid
+   :version: 1
 
    Verification Measure Selection Set may have the following characteristics:
 
@@ -87,6 +92,7 @@
 .. std_req:: 08-60 Verification Measure
    :id: std_req__aspice_40__iic-08-60
    :status: valid
+   :version: 1
 
    Verification Measure may have the following characteristics:
 
@@ -106,6 +112,7 @@
 .. std_req:: 08-61 Resource allocation
    :id: std_req__aspice_40__iic-08-61
    :status: valid
+   :version: 1
 
    Resource allocation may have the following characteristics:
 
@@ -127,6 +134,7 @@
 .. std_req:: 08-62 Communication matrix
    :id: std_req__aspice_40__iic-08-62
    :status: valid
+   :version: 1
 
    Communication matrix may have the following characteristics:
 
@@ -140,6 +148,7 @@
 .. std_req:: 08-63 Process Monitoring Method
    :id: std_req__aspice_40__iic-08-63
    :status: valid
+   :version: 1
 
    Process Monitoring Method may have the following characteristics:
 
@@ -149,6 +158,7 @@
 .. std_req:: 08-64 ML test approach
    :id: std_req__aspice_40__iic-08-64
    :status: valid
+   :version: 1
 
    - The ML test approach describes
         - ML test scenarios with distribution of data characteristics (e.g., gender, weather conditions, street conditions within the ODD) defined by ML requirements
@@ -161,6 +171,7 @@
 .. std_req:: 08-65 ML training and validation approach
    :id: std_req__aspice_40__iic-08-65
    :status: valid
+   :version: 1
 
    Process Monitoring Method may have the following characteristics:
 
@@ -176,6 +187,7 @@
 .. std_req:: 08-66 Measures against deviations in quantitative process analysis
    :id: std_req__aspice_40__iic-08-66
    :status: valid
+   :version: 1
 
    Measures against deviations in quantitative process analysis may have the following characteristics:
 

--- a/process/standards/aspice_40/iic/iic-10.rst
+++ b/process/standards/aspice_40/iic/iic-10.rst
@@ -18,6 +18,7 @@
 .. std_req:: 10-00 Process description
    :id: std_req__aspice_40__iic-10-00
    :status: valid
+   :version: 1
 
    Process description may have the following characteristics:
 
@@ -33,6 +34,7 @@
 .. std_req:: 10-50 Role description
    :id: std_req__aspice_40__iic-10-50
    :status: valid
+   :version: 1
 
    Role description may have the following characteristics:
 
@@ -44,6 +46,7 @@
 .. std_req:: 10-51 Qualification method description
    :id: std_req__aspice_40__iic-10-51
    :status: valid
+   :version: 1
 
    Qualification method description may have the following characteristics:
 
@@ -55,6 +58,7 @@
 .. std_req:: 10-52 Process resource and infrastructure description
    :id: std_req__aspice_40__iic-10-52
    :status: valid
+   :version: 1
 
    Process resource and infrastructure description may have the following characteristics:
 

--- a/process/standards/aspice_40/iic/iic-11.rst
+++ b/process/standards/aspice_40/iic/iic-11.rst
@@ -18,6 +18,7 @@
 .. std_req:: 11-03 Release note
    :id: std_req__aspice_40__iic-11-03
    :status: valid
+   :version: 1
 
    Release note may have the following characteristics:
 
@@ -46,6 +47,7 @@
 .. std_req:: 11-04 Product release package
    :id: std_req__aspice_40__iic-11-04
    :status: valid
+   :version: 1
 
    Product release package may have the following characteristics:
 
@@ -61,6 +63,7 @@
 .. std_req:: 11-05 Software Unit
    :id: std_req__aspice_40__iic-11-05
    :status: valid
+   :version: 1
 
    Software Unit may have the following characteristics:
 
@@ -74,6 +77,7 @@
 .. std_req:: 11-50 Deployed ML model
    :id: std_req__aspice_40__iic-11-50
    :status: valid
+   :version: 1
 
    -  It is derived from the trained ML model (see 01-53) and is to be integrated into the target system.
    - It may differ from the trained ML model which often requires powerful hardware and uses interpretative languages.

--- a/process/standards/aspice_40/iic/iic-12.rst
+++ b/process/standards/aspice_40/iic/iic-12.rst
@@ -18,6 +18,7 @@
 .. std_req:: 12-03 Reuse candidate
    :id: std_req__aspice_40__iic-12-03
    :status: valid
+   :version: 1
 
    Reuse candidate may have the following characteristics:
 

--- a/process/standards/aspice_40/iic/iic-13.rst
+++ b/process/standards/aspice_40/iic/iic-13.rst
@@ -18,6 +18,7 @@
 .. std_req:: 13-06 Delivery evidence
    :id: std_req__aspice_40__iic-13-06
    :status: valid
+   :version: 1
 
    Delivery evidence may have the following characteristics:
 
@@ -31,6 +32,7 @@
 .. std_req:: 13-07 Problem
    :id: std_req__aspice_40__iic-13-07
    :status: valid
+   :version: 1
 
    Problem may have the following characteristics:
 
@@ -46,6 +48,7 @@
 .. std_req:: 13-08 Baseline
    :id: std_req__aspice_40__iic-13-08
    :status: valid
+   :version: 1
 
    Baseline may have the following characteristics:
 
@@ -60,6 +63,7 @@
 .. std_req:: 13-09 Meeting support evidence
    :id: std_req__aspice_40__iic-13-09
    :status: valid
+   :version: 1
 
    Meeting support evidence may have the following characteristics:
 
@@ -76,6 +80,7 @@
 .. std_req:: 13-13 Product release approval
    :id: std_req__aspice_40__iic-13-13
    :status: valid
+   :version: 1
 
    Product release approval support evidence may have the following characteristics:
 
@@ -89,6 +94,7 @@
 .. std_req:: 13-14 Progress status
    :id: std_req__aspice_40__iic-13-14
    :status: valid
+   :version: 1
 
    Progress status may have the following characteristics:
 
@@ -104,6 +110,7 @@
 .. std_req:: 13-16 Change request
    :id: std_req__aspice_40__iic-13-16
    :status: valid
+   :version: 1
 
    Change request may have the following characteristics:
 
@@ -122,6 +129,7 @@
 .. std_req:: 13-18 Quality conformance evidence
    :id: std_req__aspice_40__iic-13-18
    :status: valid
+   :version: 1
 
    Quality conformance evidence may have the following characteristics:
 
@@ -134,6 +142,7 @@
 .. std_req:: 13-19 Review evidence
    :id: std_req__aspice_40__iic-13-19
    :status: valid
+   :version: 1
 
    Review evidence may have the following characteristics:
 
@@ -156,6 +165,7 @@
 .. std_req:: 13-25 Verification results
    :id: std_req__aspice_40__iic-13-25
    :status: valid
+   :version: 1
 
    Verification results may have the following characteristics:
 
@@ -169,6 +179,7 @@
 .. std_req:: 13-50 ML test results
    :id: std_req__aspice_40__iic-13-50
    :status: valid
+   :version: 1
 
    - Test data and logs
    - Test data with correct results
@@ -180,6 +191,7 @@
 .. std_req:: 13-51 Consistency Evidence
    :id: std_req__aspice_40__iic-13-51
    :status: valid
+   :version: 1
 
    Consistency Evidence may have the following characteristics:
 
@@ -208,6 +220,7 @@
 .. std_req:: 13-52 Communication Evidence
    :id: std_req__aspice_40__iic-13-52
    :status: valid
+   :version: 1
 
    Communication Evidence may have the following characteristics:
 
@@ -227,12 +240,14 @@
 .. std_req:: 13-53 Qualification evidence
    :id: std_req__aspice_40__iic-13-53
    :status: valid
+   :version: 1
 
    Definition not available yet in PAM4.0 document.
 
 .. std_req:: 13-55 Process resource and infrastructure documentation
    :id: std_req__aspice_40__iic-13-55
    :status: valid
+   :version: 1
 
    Process resource and infrastructure documentation may have the following characteristics:
 

--- a/process/standards/aspice_40/iic/iic-14.rst
+++ b/process/standards/aspice_40/iic/iic-14.rst
@@ -18,6 +18,7 @@
 .. std_req:: 14-01 Change history
    :id: std_req__aspice_40__iic-14-01
    :status: valid
+   :version: 1
 
    Change history may have the following characteristics:
 
@@ -31,6 +32,7 @@
 .. std_req:: 14-02 Corrective action
    :id: std_req__aspice_40__iic-14-02
    :status: valid
+   :version: 1
 
    Corrective action may have the following characteristics:
 
@@ -44,6 +46,7 @@
 .. std_req:: 14-10 Work package
    :id: std_req__aspice_40__iic-14-10
    :status: valid
+   :version: 1
 
    Work package may have the following characteristics:
 
@@ -62,6 +65,7 @@
 .. std_req:: 14-50 Stakeholder groups list
    :id: std_req__aspice_40__iic-14-50
    :status: valid
+   :version: 1
 
    Stakeholder groups list may have the following characteristics:
 
@@ -74,6 +78,7 @@
 .. std_req:: 14-53 Role Assignment
    :id: std_req__aspice_40__iic-14-53
    :status: valid
+   :version: 1
 
    Role Assignment may have the following characteristics:
 
@@ -85,6 +90,7 @@
 .. std_req:: 14-55 Software Bill of materials
    :id: std_req__aspice_40__iic-14-55
    :status: valid
+   :version: 1
 
    Software Bill of materials may have the following characteristics:
 

--- a/process/standards/aspice_40/iic/iic-15.rst
+++ b/process/standards/aspice_40/iic/iic-15.rst
@@ -18,6 +18,7 @@
 .. std_req:: 15-06 Project status
    :id: std_req__aspice_40__iic-15-06
    :status: valid
+   :version: 1
 
    Project status may have the following characteristics:
 
@@ -32,6 +33,7 @@
 .. std_req:: 15-07 Reuse analysis evidence
    :id: std_req__aspice_40__iic-15-07
    :status: valid
+   :version: 1
 
    Reuse analysis evidence may have the following characteristics:
 
@@ -44,6 +46,7 @@
 .. std_req:: 15-09 Risk status
    :id: std_req__aspice_40__iic-15-09
    :status: valid
+   :version: 1
 
    Risk status may have the following characteristics:
 
@@ -57,6 +60,7 @@
 .. std_req:: 15-12 Problem status
    :id: std_req__aspice_40__iic-15-12
    :status: valid
+   :version: 1
 
    Problem status may have the following characteristics:
 
@@ -68,6 +72,7 @@
 .. std_req:: 15-13 Assessment/audit report
    :id: std_req__aspice_40__iic-15-13
    :status: valid
+   :version: 1
 
    Assessment/audit report may have the following characteristics:
    - States the purpose of assessment
@@ -90,6 +95,7 @@
 .. std_req:: 15-16 Improvement opportunity
    :id: std_req__aspice_40__iic-15-16
    :status: valid
+   :version: 1
 
    Improvement opportunity may have the following characteristics:
 
@@ -102,6 +108,7 @@
 .. std_req:: 15-51 Analysis Results
    :id: std_req__aspice_40__iic-15-51
    :status: valid
+   :version: 1
 
    Analysis Results may have the following characteristics:
 
@@ -130,6 +137,7 @@
 .. std_req:: 15-52 Verification Results
    :id: std_req__aspice_40__iic-15-52
    :status: valid
+   :version: 1
 
    Verification Results may have the following characteristics:
 
@@ -143,6 +151,7 @@
 .. std_req:: 15-54 Tailoring documentation
    :id: std_req__aspice_40__iic-15-54
    :status: valid
+   :version: 1
 
    Tailoring documentation results may have the following characteristics:
 
@@ -153,6 +162,7 @@
 .. std_req:: 15-55 Problem analysis evidence
    :id: std_req__aspice_40__iic-15-55
    :status: valid
+   :version: 1
 
    Problem analysis evidence may have the following characteristics:
 
@@ -168,6 +178,7 @@
 .. std_req:: 15-56 Configuration status
    :id: std_req__aspice_40__iic-15-56
    :status: valid
+   :version: 1
 
    Configuration status may have the following characteristics:
 
@@ -178,6 +189,7 @@
 .. std_req:: 15-57 Quantitative process analysis results
    :id: std_req__aspice_40__iic-15-57
    :status: valid
+   :version: 1
 
    Quantitative process analysis results may have the following characteristics:
 
@@ -187,6 +199,7 @@
 .. std_req:: 15-58 Common cause of variation analysis results
    :id: std_req__aspice_40__iic-15-58
    :status: valid
+   :version: 1
 
    Common cause of variation analysis results may have the following characteristics:
 

--- a/process/standards/aspice_40/iic/iic-16.rst
+++ b/process/standards/aspice_40/iic/iic-16.rst
@@ -18,6 +18,7 @@
 .. std_req:: 16-00 Repository
    :id: std_req__aspice_40__iic-16-00
    :status: valid
+   :version: 1
 
    Repository may have the following characteristics:
 
@@ -30,6 +31,7 @@
 .. std_req:: 16-03 Configuration management system
    :id: std_req__aspice_40__iic-16-03
    :status: valid
+   :version: 1
 
    Configuration management system may have the following characteristics:
 
@@ -42,6 +44,7 @@
 .. std_req:: 16-06 Process repository
    :id: std_req__aspice_40__iic-16-06
    :status: valid
+   :version: 1
 
    Process repository may have the following characteristics:
 
@@ -51,6 +54,7 @@
 .. std_req:: 16-50 Organizational structure
    :id: std_req__aspice_40__iic-16-50
    :status: valid
+   :version: 1
 
    Organizational structure may have the following characteristics:
 
@@ -60,6 +64,7 @@
 .. std_req:: 16-52 ML data management system
    :id: std_req__aspice_40__iic-16-52
    :status: valid
+   :version: 1
 
    - The ML data management system is part of the configuration management system (see 16-03) and
    - Supports data management activities like data collection, description, ingestion, exploration, profiling, labeling/annotation, selection, structuring and cleansing

--- a/process/standards/aspice_40/iic/iic-17.rst
+++ b/process/standards/aspice_40/iic/iic-17.rst
@@ -18,6 +18,7 @@
 .. std_req:: 17-00 Requirement
    :id: std_req__aspice_40__iic-17-00
    :status: valid
+   :version: 1
 
    Requirements may have the following characteristics:
 
@@ -68,6 +69,7 @@
 .. std_req:: 17-05 Requirements for work products
    :id: std_req__aspice_40__iic-17-05
    :status: valid
+   :version: 1
 
    Requirements for work products may have the following characteristics:
 
@@ -86,6 +88,7 @@
 .. std_req:: 17-54 Requirement Attribute
    :id: std_req__aspice_40__iic-17-54
    :status: valid
+   :version: 1
 
    Requirement Attributes may have the following characteristics:
 
@@ -101,6 +104,7 @@
 .. std_req:: 17-55 Resource needs
    :id: std_req__aspice_40__iic-17-55
    :status: valid
+   :version: 1
 
    Resource needs may have the following characteristics:
 

--- a/process/standards/aspice_40/iic/iic-18.rst
+++ b/process/standards/aspice_40/iic/iic-18.rst
@@ -18,6 +18,7 @@
 .. std_req:: 18-00 Standard
    :id: std_req__aspice_40__iic-18-00
    :status: valid
+   :version: 1
 
    Standard may have the following characteristics:
 
@@ -29,6 +30,7 @@
 .. std_req:: 18-06 Product release criteria
    :id: std_req__aspice_40__iic-18-06
    :status: valid
+   :version: 1
 
    Product release criteria may have the following characteristics:
 
@@ -43,6 +45,7 @@
 .. std_req:: 18-07 Quality criteria
    :id: std_req__aspice_40__iic-18-07
    :status: valid
+   :version: 1
 
    Quality criteria may have the following characteristics:
 
@@ -56,6 +59,7 @@
 .. std_req:: 18-52 Escalation path
    :id: std_req__aspice_40__iic-18-52
    :status: valid
+   :version: 1
 
    Escalation path may have the following characteristics:
 
@@ -66,6 +70,7 @@
 .. std_req:: 18-53 Configuration item selection criteria
    :id: std_req__aspice_40__iic-18-53
    :status: valid
+   :version: 1
 
    Configuration item selection criteria may have the following characteristics:
 
@@ -74,6 +79,7 @@
 .. std_req:: 18-57 Change analysis criteria
    :id: std_req__aspice_40__iic-18-57
    :status: valid
+   :version: 1
 
    Change analysis criteria may have the following characteristics:
 
@@ -86,6 +92,7 @@
 .. std_req:: 18-58 Process performance objectives
    :id: std_req__aspice_40__iic-18-58
    :status: valid
+   :version: 1
 
    Process performance objectives may have the following characteristics:
 
@@ -100,6 +107,7 @@
 .. std_req:: 18-59 Review and approval criteria for work products
    :id: std_req__aspice_40__iic-18-59
    :status: valid
+   :version: 1
 
    Process performance objectives may have the following characteristics:
 
@@ -113,6 +121,7 @@
 .. std_req:: 18-70 Business goals
    :id: std_req__aspice_40__iic-18-70
    :status: valid
+   :version: 1
 
    Business goals may have the following characteristics:
 
@@ -127,6 +136,7 @@
 .. std_req:: 18-80 Improvement opportunity
    :id: std_req__aspice_40__iic-18-80
    :status: valid
+   :version: 1
 
    Improvement opportunity may have the following characteristics:
 
@@ -142,6 +152,7 @@
 .. std_req:: 18-81 Improvement evaluation results
    :id: std_req__aspice_40__iic-18-81
    :status: valid
+   :version: 1
 
    Improvement evaluation results may have the following characteristics:
 

--- a/process/standards/aspice_40/iic/iic-19.rst
+++ b/process/standards/aspice_40/iic/iic-19.rst
@@ -18,6 +18,7 @@
 .. std_req:: 19-01 Process performance strategy
    :id: std_req__aspice_40__iic-19-01
    :status: valid
+   :version: 1
 
    Process performance strategy may have the following characteristics:
 
@@ -33,6 +34,7 @@
 .. std_req:: 19-50 ML data quality approach
    :id: std_req__aspice_40__iic-19-50
    :status: valid
+   :version: 1
 
    - The ML data quality approach
    - Defines Quality criteria (see 18-07) e.g., the relevant data sources, reliability and consistency of labelling, completeness against ML data requirements

--- a/process/standards/aspice_40/man/man.3.rst
+++ b/process/standards/aspice_40/man/man.3.rst
@@ -36,14 +36,19 @@ Base practices
 .. std_req:: MAN.3.BP1: Define the scope of work
    :id: std_req__aspice_40__MAN-3-BP1
    :status: valid
-   :links: std_req__aspice_40__iic-08-53
+   :version: 1
+   :links: std_req__aspice_40__iic-08-53[version==1]
 
    Identify the project's goals, motivation and boundaries.
 
 .. std_req:: MAN.3.BP2: Define project life cycle
    :id: std_req__aspice_40__MAN-3-BP2
    :status: valid
-   :links: std_req__aspice_40__iic-08-53,std_req__aspice_40__iic-08-54,std_req__aspice_40__iic-13-51,std_req__aspice_40__iic-13-52
+   :version: 1
+   :links: std_req__aspice_40__iic-08-53[version==1],
+           std_req__aspice_40__iic-08-54[version==1],
+           std_req__aspice_40__iic-13-51[version==1],
+           std_req__aspice_40__iic-13-52[version==1]
 
    Define the life cycle for the project, which is appropriate to the scope, context, and
    complexity of the project. Define a release scope for relevant milestones.
@@ -55,7 +60,8 @@ Base practices
 .. std_req:: MAN.3.BP3: Evaluate feasibility of the project
    :id: std_req__aspice_40__MAN-3-BP3
    :status: valid
-   :links: std_req__aspice_40__iic-08-54,std_req__aspice_40__iic-13-51,std_req__aspice_40__iic-13-52
+   :version: 1
+   :links: std_req__aspice_40__iic-08-54[version==1], std_req__aspice_40__iic-13-51[version==1], std_req__aspice_40__iic-13-52[version==1]
 
    Evaluate the feasibility of achieving the goals of the project with respect to time, project estimates, and available resources.
 
@@ -67,7 +73,17 @@ Base practices
 .. std_req:: MAN.3.BP4: Define and monitor work packages
    :id: std_req__aspice_40__MAN-3-BP4
    :status: valid
-   :links: std_req__aspice_40__iic-08-54,std_req__aspice_40__iic-08-56,std_req__aspice_40__iic-13-16,std_req__aspice_40__iic-13-51,std_req__aspice_40__iic-13-52,std_req__aspice_40__iic-14-02,std_req__aspice_40__iic-14-10,std_req__aspice_40__iic-14-50,std_req__aspice_40__iic-15-06,std_req__aspice_40__iic-18-52
+   :version: 1
+   :links: std_req__aspice_40__iic-08-54[version==1],
+           std_req__aspice_40__iic-08-56[version==1],
+           std_req__aspice_40__iic-13-16[version==1],
+           std_req__aspice_40__iic-13-51[version==1],
+           std_req__aspice_40__iic-13-52[version==1],
+           std_req__aspice_40__iic-14-02[version==1],
+           std_req__aspice_40__iic-14-10[version==1],
+           std_req__aspice_40__iic-14-50[version==1],
+           std_req__aspice_40__iic-15-06[version==1],
+           std_req__aspice_40__iic-18-52[version==1]
 
    Define and monitor work packages and their dependencies according to defined project life cycle and estimations.
 
@@ -82,7 +98,15 @@ Base practices
 .. std_req:: MAN.3.BP5: Define and monitor project estimates and resources
    :id: std_req__aspice_40__MAN-3-BP5
    :status: valid
-   :links: std_req__aspice_40__iic-08-54,std_req__aspice_40__iic-08-56,std_req__aspice_40__iic-13-16,std_req__aspice_40__iic-13-51,std_req__aspice_40__iic-13-52,std_req__aspice_40__iic-14-02,std_req__aspice_40__iic-14-10,std_req__aspice_40__iic-18-52
+   :version: 1
+   :links: std_req__aspice_40__iic-08-54[version==1],
+           std_req__aspice_40__iic-08-56[version==1],
+           std_req__aspice_40__iic-13-16[version==1],
+           std_req__aspice_40__iic-13-51[version==1],
+           std_req__aspice_40__iic-13-52[version==1],
+           std_req__aspice_40__iic-14-02[version==1],
+           std_req__aspice_40__iic-14-10[version==1],
+           std_req__aspice_40__iic-18-52[version==1]
 
    Define and monitor project estimates of effort and resources based on project's goals, project risks, motivation and boundaries.
 
@@ -101,7 +125,14 @@ Base practices
 .. std_req:: MAN.3.BP6: Define and monitor required skills, knowledge, and experience
    :id: std_req__aspice_40__MAN-3-BP6
    :status: valid
-   :links: std_req__aspice_40__iic-08-56,std_req__aspice_40__iic-13-16,std_req__aspice_40__iic-13-51,std_req__aspice_40__iic-13-52,std_req__aspice_40__iic-14-02,std_req__aspice_40__iic-14-10,std_req__aspice_40__iic-18-52
+   :version: 1
+   :links: std_req__aspice_40__iic-08-56[version==1],
+           std_req__aspice_40__iic-13-16[version==1],
+           std_req__aspice_40__iic-13-51[version==1],
+           std_req__aspice_40__iic-13-52[version==1],
+           std_req__aspice_40__iic-14-02[version==1],
+           std_req__aspice_40__iic-14-10[version==1],
+           std_req__aspice_40__iic-18-52[version==1]
 
    Identify and monitor the required skills, knowledge, and experience for the project in line with the estimates and work packages.
 
@@ -112,7 +143,14 @@ Base practices
 .. std_req:: MAN.3.BP7: Define and monitor project interfaces and agreed commitments
    :id: std_req__aspice_40__MAN-3-BP7
    :status: valid
-   :links: std_req__aspice_40__iic-08-56,std_req__aspice_40__iic-13-16,std_req__aspice_40__iic-13-51,std_req__aspice_40__iic-13-52,std_req__aspice_40__iic-14-02,std_req__aspice_40__iic-14-10,std_req__aspice_40__iic-18-52
+   :version: 1
+   :links: std_req__aspice_40__iic-08-56[version==1],
+           std_req__aspice_40__iic-13-16[version==1],
+           std_req__aspice_40__iic-13-51[version==1],
+           std_req__aspice_40__iic-13-52[version==1],
+           std_req__aspice_40__iic-14-02[version==1],
+           std_req__aspice_40__iic-14-10[version==1],
+           std_req__aspice_40__iic-18-52[version==1]
 
    Identify and agree interfaces of the project with affected stakeholders and monitor agreed commitments. Define an escalation mechanism for commitments that are not fulfilled.
 
@@ -123,14 +161,30 @@ Base practices
 .. std_req:: MAN.3.BP8: Define and monitor project schedule
    :id: std_req__aspice_40__MAN-3-BP8
    :status: valid
-   :links: std_req__aspice_40__iic-13-16,std_req__aspice_40__iic-13-51,std_req__aspice_40__iic-14-02,std_req__aspice_40__iic-14-10,std_req__aspice_40__iic-15-06,std_req__aspice_40__iic-18-52
+   :version: 1
+   :links: std_req__aspice_40__iic-13-16[version==1],
+           std_req__aspice_40__iic-13-51[version==1],
+           std_req__aspice_40__iic-14-02[version==1],
+           std_req__aspice_40__iic-14-10[version==1],
+           std_req__aspice_40__iic-15-06[version==1],
+           std_req__aspice_40__iic-18-52[version==1]
 
    Allocate resources to work packages and schedule each activity of the project. Monitor the performance of activities against schedule.
 
 .. std_req:: MAN.3.BP9: Ensure consistency
    :id: std_req__aspice_40__MAN-3-BP9
    :status: valid
-   :links: std_req__aspice_40__iic-08-54,std_req__aspice_40__iic-08-56,std_req__aspice_40__iic-13-16,std_req__aspice_40__iic-13-51,std_req__aspice_40__iic-13-52,std_req__aspice_40__iic-14-02,std_req__aspice_40__iic-14-10,std_req__aspice_40__iic-14-50,std_req__aspice_40__iic-15-06,std_req__aspice_40__iic-18-52
+   :version: 1
+   :links: std_req__aspice_40__iic-08-54[version==1],
+           std_req__aspice_40__iic-08-56[version==1],
+           std_req__aspice_40__iic-13-16[version==1],
+           std_req__aspice_40__iic-13-51[version==1],
+           std_req__aspice_40__iic-13-52[version==1],
+           std_req__aspice_40__iic-14-02[version==1],
+           std_req__aspice_40__iic-14-10[version==1],
+           std_req__aspice_40__iic-14-50[version==1],
+           std_req__aspice_40__iic-15-06[version==1],
+           std_req__aspice_40__iic-18-52[version==1]
 
    Regularly adjust estimates, resources, skills, work packages and their dependencies, schedules, plans, interfaces, and
    commitments for the project to ensure consistency with the scope of work.
@@ -142,7 +196,13 @@ Base practices
 .. std_req:: MAN.3.BP10: Review and report progress of the project
    :id: std_req__aspice_40__MAN-3-BP10
    :status: valid
-   :links: std_req__aspice_40__iic-13-16,std_req__aspice_40__iic-13-51,std_req__aspice_40__iic-14-02,std_req__aspice_40__iic-14-10,std_req__aspice_40__iic-15-06,std_req__aspice_40__iic-18-52
+   :version: 1
+   :links: std_req__aspice_40__iic-13-16[version==1],
+           std_req__aspice_40__iic-13-51[version==1],
+           std_req__aspice_40__iic-14-02[version==1],
+           std_req__aspice_40__iic-14-10[version==1],
+           std_req__aspice_40__iic-15-06[version==1],
+           std_req__aspice_40__iic-18-52[version==1]
 
    Regularly review and report the status of the project and the fulfillment of work packages against
    estimated effort and duration to all affected parties. Prevent recurrence of identified problems.

--- a/process/standards/aspice_40/man/man.5.rst
+++ b/process/standards/aspice_40/man/man.5.rst
@@ -32,7 +32,8 @@ Base practices
 .. std_req:: MAN.5.BP1: Identify sources of risks
    :id: std_req__aspice_40__MAN-5-BP1
    :status: valid
-   :links: std_req__aspice_40__iic-15-09,std_req__aspice_40__iic-15-51
+   :version: 1
+   :links: std_req__aspice_40__iic-15-09[version==1], std_req__aspice_40__iic-15-51[version==1]
 
    Identify and regularly update the sources of risks with affected parties.
 
@@ -51,14 +52,16 @@ Base practices
 .. std_req:: MAN.5.BP2: Identify potential undesirable events
    :id: std_req__aspice_40__MAN-5-BP2
    :status: valid
-   :links: std_req__aspice_40__iic-15-51
+   :version: 1
+   :links: std_req__aspice_40__iic-15-51[version==1]
 
    Identify potential undesirable events within the scope of the risk management for the project.
 
 .. std_req:: MAN.5.BP3: Determine risks
    :id: std_req__aspice_40__MAN-5-BP3
    :status: valid
-   :links: std_req__aspice_40__iic-15-09,std_req__aspice_40__iic-15-51
+   :version: 1
+   :links: std_req__aspice_40__iic-15-09[version==1], std_req__aspice_40__iic-15-51[version==1]
 
    Determine the probability and severity of the undesirable events to support priorities for the mitigation of the risks.
 
@@ -69,21 +72,30 @@ Base practices
 .. std_req:: MAN.5.BP4: Define risk treatment options
    :id: std_req__aspice_40__MAN-5-BP4
    :status: valid
-   :links: std_req__aspice_40__iic-08-55,std_req__aspice_40__iic-14-02,std_req__aspice_40__iic-15-09,std_req__aspice_40__iic-15-51
+   :version: 1
+   :links: std_req__aspice_40__iic-08-55[version==1],
+           std_req__aspice_40__iic-14-02[version==1],
+           std_req__aspice_40__iic-15-09[version==1],
+           std_req__aspice_40__iic-15-51[version==1]
 
    For each risk select a treatment option to accept, mitigate, avoid, or share (transfer) the risk.
 
 .. std_req:: MAN.5.BP5: Define and perform risk treatment activities
    :id: std_req__aspice_40__MAN-5-BP5
    :status: valid
-   :links: std_req__aspice_40__iic-08-55,std_req__aspice_40__iic-14-02,std_req__aspice_40__iic-15-09,std_req__aspice_40__iic-15-51
+   :version: 1
+   :links: std_req__aspice_40__iic-08-55[version==1],
+           std_req__aspice_40__iic-14-02[version==1],
+           std_req__aspice_40__iic-15-09[version==1],
+           std_req__aspice_40__iic-15-51[version==1]
 
    Define and perform risk activities for risk treatment options.
 
 .. std_req:: MAN.5.BP6: Monitor risks
    :id: std_req__aspice_40__MAN-5-BP6
    :status: valid
-   :links: std_req__aspice_40__iic-08-55,std_req__aspice_40__iic-14-02,std_req__aspice_40__iic-15-09
+   :version: 1
+   :links: std_req__aspice_40__iic-08-55[version==1], std_req__aspice_40__iic-14-02[version==1], std_req__aspice_40__iic-15-09[version==1]
 
    Regularly re-evaluate the risk related to the identified potential undesirable events to determine
    changes in the status of a risk and to evaluate the progress of the risk treatment activities.
@@ -95,7 +107,11 @@ Base practices
 .. std_req:: MAN.5.BP7: Take corrective action
    :id: std_req__aspice_40__MAN-5-BP7
    :status: valid
-   :links: std_req__aspice_40__iic-08-55,std_req__aspice_40__iic-14-02,std_req__aspice_40__iic-15-09,std_req__aspice_40__iic-15-51
+   :version: 1
+   :links: std_req__aspice_40__iic-08-55[version==1],
+           std_req__aspice_40__iic-14-02[version==1],
+           std_req__aspice_40__iic-15-09[version==1],
+           std_req__aspice_40__iic-15-51[version==1]
 
    When risk treatment activities are not effective, take appropriate corrective action.
 

--- a/process/standards/aspice_40/mle/mle.1.rst
+++ b/process/standards/aspice_40/mle/mle.1.rst
@@ -36,7 +36,8 @@ Base practices
 .. std_req:: MLE.1.BP1: Specify ML requirements
    :id: std_req__aspice_40__MLE-1-BP1
    :status: valid
-   :links: std_req__aspice_40__iic-17-00
+   :version: 1
+   :links: std_req__aspice_40__iic-17-00[version==1]
 
    Use the software requirements and the software architecture to identify and specify functional and non-functional ML requirements, as well as ML data requirements specifying data characteristics (e.g., gender, weather conditions, street conditions within the ODD) and their expected distributions.
 
@@ -55,7 +56,8 @@ Base practices
 .. std_req:: MLE.1.BP2: Structure ML requirements
    :id: std_req__aspice_40__MLE-1-BP2
    :status: valid
-   :links: std_req__aspice_40__iic-17-00, std_req__aspice_40__iic-17-54
+   :version: 1
+   :links: std_req__aspice_40__iic-17-00[version==1], std_req__aspice_40__iic-17-54[version==1]
 
    Structure and prioritize the ML requirements.
 
@@ -70,7 +72,8 @@ Base practices
 .. std_req:: MLE.1.BP3: Analyze ML requirements
    :id: std_req__aspice_40__MLE-1-BP3
    :status: valid
-   :links: std_req__aspice_40__iic-17-54,std_req__aspice_40__iic-15-51
+   :version: 1
+   :links: std_req__aspice_40__iic-17-54[version==1], std_req__aspice_40__iic-15-51[version==1]
 
    Analyze the specified ML requirements including their interdependencies to ensure correctness, technical feasibility, and ability for machine learning model testing, and to support project management regarding project estimates.
 
@@ -81,7 +84,8 @@ Base practices
 .. std_req:: MLE.1.BP4: Analyze the impact on the ML operating environment
    :id: std_req__aspice_40__MLE-1-BP4
    :status: valid
-   :links: std_req__aspice_40__iic-15-51
+   :version: 1
+   :links: std_req__aspice_40__iic-15-51[version==1]
 
    Analyze the impact that the ML requirements will have on interfaces of software components and the ML operating environment.
 
@@ -92,7 +96,8 @@ Base practices
 .. std_req:: MLE.1.BP5: Ensure consistency and establish bidirectional traceability
    :id: std_req__aspice_40__MLE-1-BP5
    :status: valid
-   :links: std_req__aspice_40__iic-13-51
+   :version: 1
+   :links: std_req__aspice_40__iic-13-51[version==1]
 
    Ensure consistency and establish bidirectional traceability between ML requirements and software requirements and between ML requirements and the software architecture.
 
@@ -107,7 +112,8 @@ Base practices
 .. std_req:: MLE.1.BP6: Communicate agreed ML requirements and impact on the operating environment
    :id: std_req__aspice_40__MLE-1-BP6
    :status: valid
-   :links: std_req__aspice_40__iic-13-52
+   :version: 1
+   :links: std_req__aspice_40__iic-13-52[version==1]
 
    Communicate the agreed ML requirements, and the results of the impact analysis on the ML operating environment to all affected parties.
 

--- a/process/standards/aspice_40/mle/mle.2.rst
+++ b/process/standards/aspice_40/mle/mle.2.rst
@@ -36,7 +36,8 @@ Base practices
 .. std_req:: MLE.2.BP1: Develop ML architecture
    :id: std_req__aspice_40__MLE-2-BP1
    :status: valid
-   :links: std_req__aspice_40__iic-04-51, std_req__aspice_40__iic-01-54, std_req__aspice_40__iic-15-51
+   :version: 1
+   :links: std_req__aspice_40__iic-04-51[version==1], std_req__aspice_40__iic-01-54[version==1], std_req__aspice_40__iic-15-51[version==1]
 
    Develop and document the ML architecture that specifies ML architectural elements including details of the ML model, pre- and postprocessing, and hyperparameters which are required to create, train, test, and deploy the ML model.
 
@@ -51,14 +52,16 @@ Base practices
 .. std_req:: MLE.2.BP2: Determine hyperparameter ranges and initial values
    :id: std_req__aspice_40__MLE-2-BP2
    :status: valid
-   :links: std_req__aspice_40__iic-04-51,std_req__aspice_40__iic-01-54
+   :version: 1
+   :links: std_req__aspice_40__iic-04-51[version==1], std_req__aspice_40__iic-01-54[version==1]
 
    Determine and document the hyperparameter ranges and the initial values as a basis for the training.
 
 .. std_req:: MLE.2.BP3: Analyze ML architectural elements
    :id: std_req__aspice_40__MLE-2-BP3
    :status: valid
-   :links: std_req__aspice_40__iic-04-51,std_req__aspice_40__iic-15-51
+   :version: 1
+   :links: std_req__aspice_40__iic-04-51[version==1], std_req__aspice_40__iic-15-51[version==1]
 
    Define criteria for analysis of the ML architectural elements. Analyze ML architectural elements according to the defined criteria.
 
@@ -69,21 +72,24 @@ Base practices
 .. std_req:: MLE.2.BP4: Define interfaces of the ML architectural elements
    :id: std_req__aspice_40__MLE-2-BP4
    :status: valid
-   :links: std_req__aspice_40__iic-04-51
+   :version: 1
+   :links: std_req__aspice_40__iic-04-51[version==1]
 
    Determine and document the internal and external interfaces of each ML architectural element including its interfaces to related software components.
 
 .. std_req:: MLE.2.BP5: Define resource consumption objectives for the ML architectural elements
    :id: std_req__aspice_40__MLE-2-BP5
    :status: valid
-   :links: std_req__aspice_40__iic-04-51
+   :version: 1
+   :links: std_req__aspice_40__iic-04-51[version==1]
 
    Determine and document the resource consumption objectives for all relevant ML architectural elements during training and deployment.
 
 .. std_req:: MLE.2.BP6: Ensure consistency and establish bidirectional traceability
    :id: std_req__aspice_40__MLE-2-BP6
    :status: valid
-   :links: std_req__aspice_40__iic-13-51
+   :version: 1
+   :links: std_req__aspice_40__iic-13-51[version==1]
 
    Ensure consistency and establish bidirectional traceability between the ML architectural elements and the ML requirements.
 
@@ -98,7 +104,8 @@ Base practices
 .. std_req:: MLE.2.BP7: Communicate agreed ML architecture
    :id: std_req__aspice_40__MLE-2-BP7
    :status: valid
-   :links: std_req__aspice_40__iic-13-52
+   :version: 1
+   :links: std_req__aspice_40__iic-13-52[version==1]
 
    Inform all affected parties about the agreed ML architecture including the details of the ML model and the initial hyperparameter values.
 

--- a/process/standards/aspice_40/mle/mle.3.rst
+++ b/process/standards/aspice_40/mle/mle.3.rst
@@ -35,7 +35,8 @@ Base practices
 .. std_req:: MLE.3.BP1: Specify ML training and validation approach
    :id: std_req__aspice_40__MLE-3-BP1
    :status: valid
-   :links: std_req__aspice_40__iic-08-65
+   :version: 1
+   :links: std_req__aspice_40__iic-08-65[version==1]
 
    Specify an approach which supports the training and validation of the ML model to meet the defined ML requirements. The ML training and validation approach includes
 
@@ -59,7 +60,8 @@ Base practices
 .. std_req:: MLE.3.BP2: Create ML training and validation data set
    :id: std_req__aspice_40__MLE-3-BP2
    :status: valid
-   :links: std_req__aspice_40__iic-03-51
+   :version: 1
+   :links: std_req__aspice_40__iic-03-51[version==1]
 
    Select data from the ML data collection provided by SUP.11 and assign them to the data set for training and validation of the ML model according to the specified ML training and validation approach.
 
@@ -74,14 +76,16 @@ Base practices
 .. std_req:: MLE.3.BP3: Create and optimize ML model
    :id: std_req__aspice_40__MLE-3-BP3
    :status: valid
-   :links: std_req__aspice_40__iic-01-53,std_req__aspice_40__iic-01-54
+   :version: 1
+   :links: std_req__aspice_40__iic-01-53[version==1], std_req__aspice_40__iic-01-54[version==1]
 
    Create the ML model according to the ML architecture and train it, using the identified ML training and validation data set according to the ML training and validation approach to meet the defined ML requirements, and training and validation exit criteria.
 
 .. std_req:: MLE.3.BP4: Ensure consistency and establish bidirectional traceability
    :id: std_req__aspice_40__MLE-3-BP4
    :status: valid
-   :links: std_req__aspice_40__iic-13-51
+   :version: 1
+   :links: std_req__aspice_40__iic-13-51[version==1]
 
    Ensure consistency and establish bidirectional traceability between the ML training and validation data set and the ML data requirements.
 
@@ -92,7 +96,8 @@ Base practices
 .. std_req:: MLE.3.BP5: Summarize and communicate agreed trained ML model
    :id: std_req__aspice_40__MLE-3-BP5
    :status: valid
-   :links: std_req__aspice_40__iic-13-52
+   :version: 1
+   :links: std_req__aspice_40__iic-13-52[version==1]
 
    Summarize the results of the optimization and inform all affected parties about the agreed trained ML model.
 

--- a/process/standards/aspice_40/mle/mle.4.rst
+++ b/process/standards/aspice_40/mle/mle.4.rst
@@ -37,7 +37,8 @@ Base practices
 .. std_req:: MLE.4.BP1: Specify an ML test approach
    :id: std_req__aspice_40__MLE-4-BP1
    :status: valid
-   :links: std_req__aspice_40__iic-08-64
+   :version: 1
+   :links: std_req__aspice_40__iic-08-64[version==1]
 
    Specify an ML test approach suitable to provide evidence for compliance of the trained ML model and the deployed ML model with the ML requirements. The ML test approach includes
 
@@ -67,7 +68,8 @@ Base practices
 .. std_req:: MLE.4.BP2: Create ML test data set
    :id: std_req__aspice_40__MLE-4-BP2
    :status: valid
-   :links: std_req__aspice_40__iic-03-51
+   :version: 1
+   :links: std_req__aspice_40__iic-03-51[version==1]
 
    Create the ML test data set needed for testing of the trained ML model and testing of the deployed ML model from the ML data collection provided by SUP.11 considering the ML test approach. The ML test data set shall not be used for training.
 
@@ -82,7 +84,8 @@ Base practices
 .. std_req:: MLE.4.BP3: Test trained ML model
    :id: std_req__aspice_40__MLE-4-BP3
    :status: valid
-   :links: std_req__aspice_40__iic-13-50
+   :version: 1
+   :links: std_req__aspice_40__iic-13-50[version==1]
 
    Test the trained ML model according to the ML test approach using the created ML test data set. Record and evaluate the ML test results.
 
@@ -93,7 +96,8 @@ Base practices
 .. std_req:: MLE.4.BP4: Derive deployed ML model
    :id: std_req__aspice_40__MLE-4-BP4
    :status: valid
-   :links: std_req__aspice_40__iic-11-50, std_req__aspice_40__iic-13-50
+   :version: 1
+   :links: std_req__aspice_40__iic-11-50[version==1], std_req__aspice_40__iic-13-50[version==1]
 
    Derive the deployed ML model from the trained ML model according to the ML architecture. The deployed ML model shall be used for testing and delivery to software integration.
 
@@ -104,14 +108,16 @@ Base practices
 .. std_req:: MLE.4.BP5: Test deployed ML model
    :id: std_req__aspice_40__MLE-4-BP5
    :status: valid
-   :links: std_req__aspice_40__iic-11-50, std_req__aspice_40__iic-13-50
+   :version: 1
+   :links: std_req__aspice_40__iic-11-50[version==1], std_req__aspice_40__iic-13-50[version==1]
 
    Test the deployed ML model according to the ML test approach using the created ML test data set. Record and evaluate the ML test results.
 
 .. std_req:: MLE.4.BP6: Ensure consistency and establish bidirectional traceability
    :id: std_req__aspice_40__MLE-4-BP6
    :status: valid
-   :links: std_req__aspice_40__iic-13-51
+   :version: 1
+   :links: std_req__aspice_40__iic-13-51[version==1]
 
    Ensure consistency and establish bidirectional traceability between the ML test approach and the ML requirements, and the ML test data set and the ML data requirements; and bidirectional traceability is established between the ML test approach and ML test results.
 
@@ -122,7 +128,8 @@ Base practices
 .. std_req:: MLE.4.BP7: Summarize and communicate results
    :id: std_req__aspice_40__MLE-4-BP7
    :status: valid
-   :links: std_req__aspice_40__iic-13-52
+   :version: 1
+   :links: std_req__aspice_40__iic-13-52[version==1]
 
    Summarize the ML test results of the ML model. Inform all affected parties about the agreed results and the deployed ML model.
 

--- a/process/standards/aspice_40/pim/pim.3.rst
+++ b/process/standards/aspice_40/pim/pim.3.rst
@@ -34,7 +34,8 @@ Base practices
 .. std_req:: PIM.3.BP1: Establish commitment
    :id: std_req__aspice_40__PIM-3-BP1
    :status: valid
-   :links: std_req__aspice_40__iic-02-01
+   :version: 1
+   :links: std_req__aspice_40__iic-02-01[version==1]
 
    Establish commitment to support the process improvement staff, to provide resources and further enablers to sustain improvement actions.
 
@@ -53,7 +54,11 @@ Base practices
 .. std_req:: PIM.3.BP2: Identify improvement measures
    :id: std_req__aspice_40__PIM-3-BP2
    :status: valid
-   :links: std_req__aspice_40__iic-13-16,std_req__aspice_40__iic-15-51,std_req__aspice_40__iic-15-13,std_req__aspice_40__iic-15-16
+   :version: 1
+   :links: std_req__aspice_40__iic-13-16[version==1],
+           std_req__aspice_40__iic-15-51[version==1],
+           std_req__aspice_40__iic-15-13[version==1],
+           std_req__aspice_40__iic-15-16[version==1]
 
 Identify issues from the analysis of process performance and derive improvement opportunities with justified reasons for change.
 
@@ -73,7 +78,12 @@ Identify issues from the analysis of process performance and derive improvement 
  .. std_req:: PIM.3.BP3: Establish process improvement goals
    :id: std_req__aspice_40__PIM-3-BP3
    :status: valid
-   :links: std_req__aspice_40__iic-06-04,std_req__aspice_40__iic-10-00,std_req__aspice_40__iic-15-51,std_req__aspice_40__iic-15-13,std_req__aspice_40__iic-16-06
+   :version: 1
+   :links: std_req__aspice_40__iic-06-04[version==1],
+           std_req__aspice_40__iic-10-00[version==1],
+           std_req__aspice_40__iic-15-51[version==1],
+           std_req__aspice_40__iic-15-13[version==1],
+           std_req__aspice_40__iic-16-06[version==1]
 
    Analyze the current status of the existing processes and establish improvement goals.
 
@@ -84,14 +94,24 @@ Identify issues from the analysis of process performance and derive improvement 
  .. std_req:: PIM.3.BP4: Prioritize improvements
    :id: std_req__aspice_40__PIM-3-BP4
    :status: valid
-   :links: std_req__aspice_40__iic-06-04,std_req__aspice_40__iic-10-00,std_req__aspice_40__iic-15-51,std_req__aspice_40__iic-15-13,std_req__aspice_40__iic-16-06
+   :version: 1
+   :links: std_req__aspice_40__iic-06-04[version==1],
+           std_req__aspice_40__iic-10-00[version==1],
+           std_req__aspice_40__iic-15-51[version==1],
+           std_req__aspice_40__iic-15-13[version==1],
+           std_req__aspice_40__iic-16-06[version==1]
 
    Prioritize the improvement goals and improvement measures.
 
  .. std_req:: PIM.3.BP5: Define process improvement measures
    :id: std_req__aspice_40__PIM-3-BP5
    :status: valid
-   :links: std_req__aspice_40__iic-06-04,std_req__aspice_40__iic-10-00,std_req__aspice_40__iic-15-51,std_req__aspice_40__iic-15-13,std_req__aspice_40__iic-16-06
+   :version: 1
+   :links: std_req__aspice_40__iic-06-04[version==1],
+           std_req__aspice_40__iic-10-00[version==1],
+           std_req__aspice_40__iic-15-51[version==1],
+           std_req__aspice_40__iic-15-13[version==1],
+           std_req__aspice_40__iic-16-06[version==1]
 
    Process improvement measures are defined.
 
@@ -102,7 +122,12 @@ Identify issues from the analysis of process performance and derive improvement 
  .. std_req:: PIM.3.BP6: Implement process improvement measures
    :id: std_req__aspice_40__PIM-3-BP6
    :status: valid
-   :links: std_req__aspice_40__iic-06-04,std_req__aspice_40__iic-10-00,std_req__aspice_40__iic-15-51,std_req__aspice_40__iic-15-13,std_req__aspice_40__iic-16-06
+   :version: 1
+   :links: std_req__aspice_40__iic-06-04[version==1],
+           std_req__aspice_40__iic-10-00[version==1],
+           std_req__aspice_40__iic-15-51[version==1],
+           std_req__aspice_40__iic-15-13[version==1],
+           std_req__aspice_40__iic-16-06[version==1]
 
    Implement and apply the improvements to the processes. Update the Process documentation and train people as needed.
 
@@ -118,14 +143,16 @@ Identify issues from the analysis of process performance and derive improvement 
  .. std_req:: PIM.3.BP7: Confirm process improvement
    :id: std_req__aspice_40__PIM-3-BP7
    :status: valid
-   :links: std_req__aspice_40__iic-07-04,std_req__aspice_40__iic-15-51,std_req__aspice_40__iic-15-13
+   :version: 1
+   :links: std_req__aspice_40__iic-07-04[version==1], std_req__aspice_40__iic-15-51[version==1], std_req__aspice_40__iic-15-13[version==1]
 
    The effects of process implementation are monitored and measured, and the achievement of defined improvement goals is confirmed.
 
  .. std_req:: PIM.3.BP8: Communicate results of improvement
    :id: std_req__aspice_40__PIM-3-BP8
    :status: valid
-   :links: std_req__aspice_40__iic-06-04,std_req__aspice_40__iic-07-04,std_req__aspice_40__iic-13-52
+   :version: 1
+   :links: std_req__aspice_40__iic-06-04[version==1], std_req__aspice_40__iic-07-04[version==1], std_req__aspice_40__iic-13-52[version==1]
 
    Knowledge gained from the improvements and progress of the improvement implementation is communicated to affected parties.
 

--- a/process/standards/aspice_40/reu/reu.2.rst
+++ b/process/standards/aspice_40/reu/reu.2.rst
@@ -34,7 +34,8 @@ Base practices
 .. std_req:: REU.2.BP1: Select products for reuse
    :id: std_req__aspice_40__REU-2-BP1
    :status: valid
-   :links: std_req__aspice_40__iic-12-03
+   :version: 1
+   :links: std_req__aspice_40__iic-12-03[version==1]
 
    Select the products to be reused using defined criteria.
 
@@ -45,7 +46,8 @@ Base practices
 .. std_req:: REU.2.BP2: Analyze the reuse capability of the product
    :id: std_req__aspice_40__REU-2-BP2
    :status: valid
-   :links: std_req__aspice_40__iic-04-02,std_req__aspice_40__iic-15-07
+   :version: 1
+   :links: std_req__aspice_40__iic-04-02[version==1], std_req__aspice_40__iic-15-07[version==1]
 
    Analyze the designated target architecture and the product to be reused to determine its
    applicability in the target architecture according to relevant criteria.
@@ -57,7 +59,8 @@ Base practices
 .. std_req:: REU.2.BP3: Define limitations for reuse
    :id: std_req__aspice_40__REU-2-BP3
    :status: valid
-   :links: std_req__aspice_40__iic-04-02,std_req__aspice_40__iic-15-07
+   :version: 1
+   :links: std_req__aspice_40__iic-04-02[version==1], std_req__aspice_40__iic-15-07[version==1]
 
    Define and communicate limitations for the products to be reused.
 
@@ -68,7 +71,8 @@ Base practices
 .. std_req:: REU.2.BP4: Ensure qualification of products for reuse
    :id: std_req__aspice_40__REU-2-BP4
    :status: valid
-   :links: std_req__aspice_40__iic-13-53
+   :version: 1
+   :links: std_req__aspice_40__iic-13-53[version==1]
 
    Provide evidence that the product for reuse is qualified for the intended use of the deliverable.
 
@@ -83,7 +87,8 @@ Base practices
 .. std_req:: REU.2.BP5: Provide products for reuse
    :id: std_req__aspice_40__REU-2-BP5
    :status: valid
-   :links: std_req__aspice_40__iic-12-03
+   :version: 1
+   :links: std_req__aspice_40__iic-12-03[version==1]
 
    Make available the product to be reused to affected parties.
 
@@ -94,7 +99,8 @@ Base practices
 .. std_req:: REU.2.BP6: Communicate information about effectiveness of reuse activities
    :id: std_req__aspice_40__REU-2-BP6
    :status: valid
-   :links: std_req__aspice_40__iic-13-52
+   :version: 1
+   :links: std_req__aspice_40__iic-13-52[version==1]
 
    Establish communication and notification mechanism about experiences and technical outcomes to the provider of reused products.
 

--- a/process/standards/aspice_40/spl/spl.2.rst
+++ b/process/standards/aspice_40/spl/spl.2.rst
@@ -32,7 +32,8 @@ Base practices
 .. std_req:: SPL.2.BP1: Define the functional content of releases
    :id: std_req__aspice_40__SPL-2-BP1
    :status: valid
-   :links: std_req__aspice_40__iic-11-03,std_req__aspice_40__iic-18-06
+   :version: 1
+   :links: std_req__aspice_40__iic-11-03[version==1], std_req__aspice_40__iic-18-06[version==1]
 
    Define the functionality to be included and the release criteria for each release.
 
@@ -44,7 +45,8 @@ Base practices
 .. std_req:: SPL.2.BP2: Define release package
    :id: std_req__aspice_40__SPL-2-BP2
    :status: valid
-   :links: std_req__aspice_40__iic-11-03,std_req__aspice_40__iic-18-06
+   :version: 1
+   :links: std_req__aspice_40__iic-11-03[version==1], std_req__aspice_40__iic-18-06[version==1]
 
    Define the release as well as supporting tools and information.
 
@@ -55,7 +57,8 @@ Base practices
 .. std_req:: SPL.2.BP3: Ensure unique identification of releases
    :id: std_req__aspice_40__SPL-2-BP3
    :status: valid
-   :links: std_req__aspice_40__iic-11-03,std_req__aspice_40__iic-11-04,std_req__aspice_40__iic-13-06
+   :version: 1
+   :links: std_req__aspice_40__iic-11-03[version==1], std_req__aspice_40__iic-11-04[version==1], std_req__aspice_40__iic-13-06[version==1]
 
    Ensure a unique identification of the release based upon the intended purpose and expectations of the release.
 
@@ -66,7 +69,8 @@ Base practices
 .. std_req:: SPL.2.BP4: Build the release from items under configuration control
    :id: std_req__aspice_40__SPL-2-BP4
    :status: valid
-   :links: std_req__aspice_40__iic-11-04,std_req__aspice_40__iic-18-06
+   :version: 1
+   :links: std_req__aspice_40__iic-11-04[version==1], std_req__aspice_40__iic-18-06[version==1]
 
    Build the release from items under configuration control to ensure integrity.
 
@@ -77,14 +81,19 @@ Base practices
 .. std_req:: SPL.2.BP5: Ensure release approval before delivery
    :id: std_req__aspice_40__SPL-2-BP5
    :status: valid
-   :links: std_req__aspice_40__iic-11-03,std_req__aspice_40__iic-13-13,std_req__aspice_40__iic-18-06
+   :version: 1
+   :links: std_req__aspice_40__iic-11-03[version==1], std_req__aspice_40__iic-13-13[version==1], std_req__aspice_40__iic-18-06[version==1]
 
    Criteria for the release are satisfied before delivery takes place.
 
 .. std_req:: SPL.2.BP6: Provide a release note
    :id: std_req__aspice_40__SPL-2-BP6
    :status: valid
-   :links: std_req__aspice_40__iic-11-03,std_req__aspice_40__iic-11-04,std_req__aspice_40__iic-13-06,std_req__aspice_40__iic-13-13
+   :version: 1
+   :links: std_req__aspice_40__iic-11-03[version==1],
+           std_req__aspice_40__iic-11-04[version==1],
+           std_req__aspice_40__iic-13-06[version==1],
+           std_req__aspice_40__iic-13-13[version==1]
 
    A release is accompanied by information detailing key characteristics of the release.
 
@@ -96,14 +105,19 @@ Base practices
 .. std_req:: SPL.2.BP7: Communicate the type, service level and duration of support for a release
    :id: std_req__aspice_40__SPL-2-BP7
    :status: valid
-   :links: std_req__aspice_40__iic-11-03,std_req__aspice_40__iic-11-04,std_req__aspice_40__iic-13-06,std_req__aspice_40__iic-13-13
+   :version: 1
+   :links: std_req__aspice_40__iic-11-03[version==1],
+           std_req__aspice_40__iic-11-04[version==1],
+           std_req__aspice_40__iic-13-06[version==1],
+           std_req__aspice_40__iic-13-13[version==1]
 
    Identify and communicate the type, service level and duration of support for a release.
 
 .. std_req:: SPL.2.BP8: Deliver the release package to the intended customer
    :id: std_req__aspice_40__SPL-2-BP8
    :status: valid
-   :links: std_req__aspice_40__iic-11-03,std_req__aspice_40__iic-13-06,std_req__aspice_40__iic-13-13
+   :version: 1
+   :links: std_req__aspice_40__iic-11-03[version==1], std_req__aspice_40__iic-13-06[version==1], std_req__aspice_40__iic-13-13[version==1]
 
    Deliver the release package to the intended customer.
 

--- a/process/standards/aspice_40/sup/sup.1.rst
+++ b/process/standards/aspice_40/sup/sup.1.rst
@@ -35,7 +35,8 @@ Base practices
 .. std_req:: SUP.1.BP1: Ensure independence of quality assurance
    :id: std_req__aspice_40__SUP-1-BP1
    :status: valid
-   :links: std_req__aspice_40__iic-16-50
+   :version: 1
+   :links: std_req__aspice_40__iic-16-50[version==1]
 
    Ensure that quality assurance is performed independently and objectively without conflicts of interest.
 
@@ -47,7 +48,8 @@ Base practices
 .. std_req:: SUP.1.BP2: Define criteria for quality assurance
    :id: std_req__aspice_40__SUP-1-BP2
    :status: valid
-   :links: std_req__aspice_40__iic-18-07
+   :version: 1
+   :links: std_req__aspice_40__iic-18-07[version==1]
 
    Define quality criteria for work products as well as for process tasks and their performance.
 
@@ -58,7 +60,12 @@ Base practices
 .. std_req:: SUP.1.BP3: Assure quality of work products
    :id: std_req__aspice_40__SUP-1-BP3
    :status: valid
-   :links: std_req__aspice_40__iic-18-07,std_req__aspice_40__iic-13-52,std_req__aspice_40__iic-13-18,std_req__aspice_40__iic-13-19,std_req__aspice_40__iic-14-02
+   :version: 1
+   :links: std_req__aspice_40__iic-18-07[version==1],
+           std_req__aspice_40__iic-13-52[version==1],
+           std_req__aspice_40__iic-13-18[version==1],
+           std_req__aspice_40__iic-13-19[version==1],
+           std_req__aspice_40__iic-14-02[version==1]
 
    Identify work products subject to quality assurance according to the quality criteria.
    Perform appropriate activities to evaluate the work products against the defined quality criteria and document the results.
@@ -71,7 +78,12 @@ Base practices
 .. std_req:: SUP.1.BP4: Assure quality of process activities
    :id: std_req__aspice_40__SUP-1-BP4
    :status: valid
-   :links: std_req__aspice_40__iic-18-07,std_req__aspice_40__iic-13-52,std_req__aspice_40__iic-13-18,std_req__aspice_40__iic-13-19,std_req__aspice_40__iic-14-02
+   :version: 1
+   :links: std_req__aspice_40__iic-18-07[version==1],
+           std_req__aspice_40__iic-13-52[version==1],
+           std_req__aspice_40__iic-13-18[version==1],
+           std_req__aspice_40__iic-13-19[version==1],
+           std_req__aspice_40__iic-14-02[version==1]
 
    Identify processes subject to quality assurance according to the quality criteria.
    Perform appropriate activities to evaluate the processes against their defined quality criteria and
@@ -85,14 +97,27 @@ Base practices
 .. std_req:: SUP.1.BP5: Summarize and communicate quality assurance activities and results
    :id: std_req__aspice_40__SUP-1-BP5
    :status: valid
-   :links: std_req__aspice_40__iic-16-50,std_req__aspice_40__iic-18-52,std_req__aspice_40__iic-18-07,std_req__aspice_40__iic-13-52,std_req__aspice_40__iic-13-18,std_req__aspice_40__iic-13-19,std_req__aspice_40__iic-14-02
+   :version: 1
+   :links: std_req__aspice_40__iic-16-50[version==1],
+           std_req__aspice_40__iic-18-52[version==1],
+           std_req__aspice_40__iic-18-07[version==1],
+           std_req__aspice_40__iic-13-52[version==1],
+           std_req__aspice_40__iic-13-18[version==1],
+           std_req__aspice_40__iic-13-19[version==1],
+           std_req__aspice_40__iic-14-02[version==1]
 
    Regularly report performance, non-conformances, and trends of quality assurance activities to all affected parties.
 
 .. std_req:: SUP.1.BP6: Ensure resolution of non-conformances
    :id: std_req__aspice_40__SUP-1-BP6
    :status: valid
-   :links: std_req__aspice_40__iic-18-52,std_req__aspice_40__iic-18-07,std_req__aspice_40__iic-13-52,std_req__aspice_40__iic-13-18,std_req__aspice_40__iic-13-19,std_req__aspice_40__iic-14-02
+   :version: 1
+   :links: std_req__aspice_40__iic-18-52[version==1],
+           std_req__aspice_40__iic-18-07[version==1],
+           std_req__aspice_40__iic-13-52[version==1],
+           std_req__aspice_40__iic-13-18[version==1],
+           std_req__aspice_40__iic-13-19[version==1],
+           std_req__aspice_40__iic-14-02[version==1]
 
    Analyze, track, correct, resolve, and further prevent non-conformances found in quality assurance activities.
 
@@ -107,7 +132,11 @@ Base practices
 .. std_req:: SUP.1.BP7: Escalate non-conformances
    :id: std_req__aspice_40__SUP-1-BP7
    :status: valid
-   :links: std_req__aspice_40__iic-16-50,std_req__aspice_40__iic-18-52,std_req__aspice_40__iic-13-52,std_req__aspice_40__iic-14-02
+   :version: 1
+   :links: std_req__aspice_40__iic-16-50[version==1],
+           std_req__aspice_40__iic-18-52[version==1],
+           std_req__aspice_40__iic-13-52[version==1],
+           std_req__aspice_40__iic-14-02[version==1]
 
    Escalate relevant non-conformances to appropriate levels of management and other relevant stakeholders to facilitate their resolution.
 

--- a/process/standards/aspice_40/sup/sup.10.rst
+++ b/process/standards/aspice_40/sup/sup.10.rst
@@ -35,7 +35,8 @@ Base practices
 .. std_req:: SUP.10.BP1: Identify and record the change requests
    :id: std_req__aspice_40__SUP-10-BP1
    :status: valid
-   :links: std_req__aspice_40__iic-13-16
+   :version: 1
+   :links: std_req__aspice_40__iic-13-16[version==1]
 
    The scope for application of change requests is identified.
    Each change request is uniquely identified, described, and recorded, including the initiator and reason of the change request.
@@ -56,7 +57,8 @@ Base practices
 .. std_req:: SUP.10.BP2: Analyze and assess change requests
    :id: std_req__aspice_40__SUP-10-BP2
    :status: valid
-   :links: std_req__aspice_40__iic-18-57,std_req__aspice_40__iic-13-16
+   :version: 1
+   :links: std_req__aspice_40__iic-18-57[version==1], std_req__aspice_40__iic-13-16[version==1]
 
    Change requests are analyzed by relevant parties according to analysis criteria.
    Work products affected by the change request and dependencies to other change requests are determined.
@@ -69,7 +71,8 @@ Base practices
 .. std_req:: SUP.10.BP3: Approve change requests before implementation
    :id: std_req__aspice_40__SUP-10-BP3
    :status: valid
-   :links: std_req__aspice_40__iic-13-16
+   :version: 1
+   :links: std_req__aspice_40__iic-13-16[version==1]
 
    Change requests are prioritized and approved for implementation based on analysis results and availability of resources.
 
@@ -84,7 +87,8 @@ Base practices
 .. std_req:: SUP.10.BP4: Establish bidirectional traceability
    :id: std_req__aspice_40__SUP-10-BP4
    :status: valid
-   :links: std_req__aspice_40__iic-13-51
+   :version: 1
+   :links: std_req__aspice_40__iic-13-51[version==1]
 
    Establish bidirectional traceability between change requests and work products affected by the change requests.
    In case that the change request is initiated by a problem, establish bidirectional traceability between change requests
@@ -93,14 +97,16 @@ Base practices
 .. std_req:: SUP.10.BP5: Confirm the implementation of change requests
    :id: std_req__aspice_40__SUP-10-BP5
    :status: valid
-   :links: std_req__aspice_40__iic-13-16
+   :version: 1
+   :links: std_req__aspice_40__iic-13-16[version==1]
 
    The implementation of change requests is confirmed before closure by relevant stakeholders.
 
 .. std_req:: SUP.10.BP6: Track change requests to closure
    :id: std_req__aspice_40__SUP-10-BP6
    :status: valid
-   :links: std_req__aspice_40__iic-13-16
+   :version: 1
+   :links: std_req__aspice_40__iic-13-16[version==1]
 
    Change requests are tracked to closure. The status of change requests is communicated to all affected parties.
 

--- a/process/standards/aspice_40/sup/sup.11.rst
+++ b/process/standards/aspice_40/sup/sup.11.rst
@@ -33,7 +33,8 @@ Base practices
 .. std_req:: SUP.11.BP1: Establish an ML data management system
    :id: std_req__aspice_40__SUP-11-BP1
    :status: valid
-   :links: std_req__aspice_40__iic-16-52
+   :version: 1
+   :links: std_req__aspice_40__iic-16-52[version==1]
 
    Establish an ML data management system which supports
 
@@ -49,7 +50,8 @@ Base practices
 .. std_req:: SUP.11.BP2: Develop an ML data quality approach
    :id: std_req__aspice_40__SUP-11-BP2
    :status: valid
-   :links: std_req__aspice_40__iic-19-50
+   :version: 1
+   :links: std_req__aspice_40__iic-19-50[version==1]
 
    Develop an approach to ensure that the quality of ML data is analyzed based on defined ML data quality criteria and activities are performed to support avoidance of biases of data.
 
@@ -72,7 +74,8 @@ Base practices
 .. std_req:: SUP.11.BP3: Collect ML data
    :id: std_req__aspice_40__SUP-11-BP3
    :status: valid
-   :links: std_req__aspice_40__iic-03-53
+   :version: 1
+   :links: std_req__aspice_40__iic-03-53[version==1]
 
    Relevant sources for raw data are identified and continuously monitored for changes. The raw data is collected according to the ML data requirements.
 
@@ -87,14 +90,16 @@ Base practices
 .. std_req:: SUP.11.BP4: Process ML data
    :id: std_req__aspice_40__SUP-11-BP4
    :status: valid
-   :links: std_req__aspice_40__iic-03-53
+   :version: 1
+   :links: std_req__aspice_40__iic-03-53[version==1]
 
    The raw data are processed (annotated, analyzed, and structured) according to the ML data requirements.
 
 .. std_req:: SUP.11.BP5: Assure quality of ML data
    :id: std_req__aspice_40__SUP-11-BP5
    :status: valid
-   :links: std_req__aspice_40__iic-03-53
+   :version: 1
+   :links: std_req__aspice_40__iic-03-53[version==1]
 
    Perform the activities according to the ML data quality approach to ensure that the ML data meets the defined ML data quality criteria.
 
@@ -105,7 +110,8 @@ Base practices
 .. std_req:: SUP.11.BP6: Communicate agreed processed ML data
    :id: std_req__aspice_40__SUP-11-BP6
    :status: valid
-   :links: std_req__aspice_40__iic-13-52
+   :version: 1
+   :links: std_req__aspice_40__iic-13-52[version==1]
 
    Inform all affected parties about the agreed processed ML data and provide them to the affected parties.
 

--- a/process/standards/aspice_40/sup/sup.8.rst
+++ b/process/standards/aspice_40/sup/sup.8.rst
@@ -37,7 +37,8 @@ Base practices
 .. std_req:: SUP.8.BP1: Identify configuration items
    :id: std_req__aspice_40__SUP-8-BP1
    :status: valid
-   :links: std_req__aspice_40__iic-18-53,std_req__aspice_40__iic-01-52
+   :version: 1
+   :links: std_req__aspice_40__iic-18-53[version==1], std_req__aspice_40__iic-01-52[version==1]
 
    Define selection criteria for identifying relevant work products to be subject to configuration management.
    Identify and document configuration items according to the defined selection criteria.
@@ -59,7 +60,8 @@ Base practices
 .. std_req:: SUP.8.BP2: Define configuration item properties
    :id: std_req__aspice_40__SUP-8-BP2
    :status: valid
-   :links: std_req__aspice_40__iic-01-52
+   :version: 1
+   :links: std_req__aspice_40__iic-01-52[version==1]
 
    Define the necessary properties needed for the modification and control of configuration items.
 
@@ -78,7 +80,8 @@ Base practices
 .. std_req:: SUP.8.BP3: Establish configuration management
    :id: std_req__aspice_40__SUP-8-BP3
    :status: valid
-   :links: std_req__aspice_40__iic-16-03,std_req__aspice_40__iic-14-01
+   :version: 1
+   :links: std_req__aspice_40__iic-16-03[version==1], std_req__aspice_40__iic-14-01[version==1]
 
    Establish configuration management mechanisms for control of identified configuration items including the configuration item properties,
    including mechanisms for controlling parallel modifications of configuration items.
@@ -90,7 +93,8 @@ Base practices
 .. std_req:: SUP.8.BP4: Control modifications
    :id: std_req__aspice_40__SUP-8-BP4
    :status: valid
-   :links: std_req__aspice_40__iic-16-03,std_req__aspice_40__iic-14-01
+   :version: 1
+   :links: std_req__aspice_40__iic-16-03[version==1], std_req__aspice_40__iic-14-01[version==1]
 
    Control modifications using the configuration management mechanisms.
 
@@ -101,14 +105,16 @@ Base practices
 .. std_req:: SUP.8.BP5: Establish baselines
    :id: std_req__aspice_40__SUP-8-BP5
    :status: valid
-   :links: std_req__aspice_40__iic-16-03,std_req__aspice_40__iic-13-08
+   :version: 1
+   :links: std_req__aspice_40__iic-16-03[version==1], std_req__aspice_40__iic-13-08[version==1]
 
    Define and establish baselines for internal purposes, and for external product delivery, for all relevant configuration items.
 
 .. std_req:: SUP.8.BP6: Summarize and communicate configuration status
    :id: std_req__aspice_40__SUP-8-BP6
    :status: valid
-   :links: std_req__aspice_40__iic-14-01,std_req__aspice_40__iic-15-56
+   :version: 1
+   :links: std_req__aspice_40__iic-14-01[version==1], std_req__aspice_40__iic-15-56[version==1]
 
    Record, summarize, and communicate the status of configuration items and established baselines
    to affected parties in order to support the monitoring of progress and status.
@@ -121,7 +127,8 @@ Base practices
 .. std_req:: SUP.8.BP7: Ensure completeness and consistency
    :id: std_req__aspice_40__SUP-8-BP7
    :status: valid
-   :links: std_req__aspice_40__iic-01-52,std_req__aspice_40__iic-13-08,std_req__aspice_40__iic-13-51
+   :version: 1
+   :links: std_req__aspice_40__iic-01-52[version==1], std_req__aspice_40__iic-13-08[version==1], std_req__aspice_40__iic-13-51[version==1]
 
    Ensure that the information about configuration items is correct and complete including configuration item properties.
    Ensure the completeness and consistency of baselines.
@@ -134,7 +141,8 @@ Base practices
 .. std_req:: SUP.8.BP8: Verify backup and recovery mechanisms availability.
    :id: std_req__aspice_40__SUP-8-BP8
    :status: valid
-   :links: std_req__aspice_40__iic-06-52
+   :version: 1
+   :links: std_req__aspice_40__iic-06-52[version==1]
 
    Verify the availability of appropriate backup and recovery mechanisms for the configuration management including
    the controlled configuration items. Initiate measures in case of insufficient backup and recovery mechanisms.

--- a/process/standards/aspice_40/sup/sup.9.rst
+++ b/process/standards/aspice_40/sup/sup.9.rst
@@ -33,7 +33,8 @@ Base practices
 .. std_req:: SUP.9.BP1: Identify and record the problem
    :id: std_req__aspice_40__SUP-9-BP1
    :status: valid
-   :links: std_req__aspice_40__iic-13-07
+   :version: 1
+   :links: std_req__aspice_40__iic-13-07[version==1]
 
    Each problem is uniquely identified, described and recorded.
    A status is assigned to each problem to facilitate tracking.
@@ -56,7 +57,8 @@ Base practices
 .. std_req:: SUP.9.BP2: Determine the cause and the impact of the problem
    :id: std_req__aspice_40__SUP-9-BP2
    :status: valid
-   :links: std_req__aspice_40__iic-13-07,std_req__aspice_40__iic-15-55
+   :version: 1
+   :links: std_req__aspice_40__iic-13-07[version==1], std_req__aspice_40__iic-15-55[version==1]
 
    Analyze the problem, determine its cause, including common causes if existing, and impact.
    Involve relevant parties. Categorize the problem.
@@ -68,14 +70,16 @@ Base practices
 .. std_req:: SUP.9.BP3: Authorize urgent resolution action
    :id: std_req__aspice_40__SUP-9-BP3
    :status: valid
-   :links: std_req__aspice_40__iic-13-07
+   :version: 1
+   :links: std_req__aspice_40__iic-13-07[version==1]
 
    Obtain authorization for immediate action if a problem requires an urgent resolution according to the categorization.
 
 .. std_req:: SUP.9.BP4: Raise alert notifications
    :id: std_req__aspice_40__SUP-9-BP4
    :status: valid
-   :links: std_req__aspice_40__iic-13-07
+   :version: 1
+   :links: std_req__aspice_40__iic-13-07[version==1]
 
    If according to the categorization the problem has a high impact on other systems or
    other affected parties, an alert notification needs to be raised accordingly.
@@ -83,7 +87,8 @@ Base practices
 .. std_req:: SUP.9.BP5: Initiate problem resolution
    :id: std_req__aspice_40__SUP-9-BP5
    :status: valid
-   :links: std_req__aspice_40__iic-13-07
+   :version: 1
+   :links: std_req__aspice_40__iic-13-07[version==1]
 
    Initiate appropriate actions according to the categorization to resolve the problem long-term,
    including review of those actions or initiate a change request.
@@ -92,7 +97,8 @@ Base practices
 .. std_req:: SUP.9.BP6: Track problems to closure
    :id: std_req__aspice_40__SUP-9-BP6
    :status: valid
-   :links: std_req__aspice_40__iic-13-07,std_req__aspice_40__iic-15-12
+   :version: 1
+   :links: std_req__aspice_40__iic-13-07[version==1], std_req__aspice_40__iic-15-12[version==1]
 
    Track the status of problems to closure including all related change requests.
    The closure of problems is accepted by relevant stakeholders.
@@ -100,7 +106,8 @@ Base practices
 .. std_req:: SUP.9.BP7: Report the status of problem resolution activities
    :id: std_req__aspice_40__SUP-9-BP7
    :status: valid
-   :links: std_req__aspice_40__iic-15-12
+   :version: 1
+   :links: std_req__aspice_40__iic-15-12[version==1]
 
    Collect and analyze problem resolution management data, identify trends, and initiate related actions.
    Regularly report the results of data analysis, the identified trends and the status of problem resolution

--- a/process/standards/aspice_40/swe/swe.1.rst
+++ b/process/standards/aspice_40/swe/swe.1.rst
@@ -41,7 +41,8 @@ Base practices
 .. std_req:: SWE.1.BP1: Specify software requirements
    :id: std_req__aspice_40__SWE-1-BP1
    :status: valid
-   :links: std_req__aspice_40__iic-17-00
+   :version: 1
+   :links: std_req__aspice_40__iic-17-00[version==1]
 
    Use the system requirements and the system
    architecture to identify and document the functional and non-functional requirements for the
@@ -75,7 +76,8 @@ Base practices
 .. std_req:: SWE.1.BP2: Structure software requirements
    :id: std_req__aspice_40__SWE-1-BP2
    :status: valid
-   :links: std_req__aspice_40__iic-17-00;std_req__aspice_40__iic-17-54
+   :version: 1
+   :links: std_req__aspice_40__iic-17-00[version==1], std_req__aspice_40__iic-17-54[version==1]
 
    Structure and prioritize the software requirements.
 
@@ -93,7 +95,8 @@ Base practices
 .. std_req:: SWE.1.BP3: Analyze software requirements
    :id: std_req__aspice_40__SWE-1-BP3
    :status: valid
-   :links: std_req__aspice_40__iic-15-51
+   :version: 1
+   :links: std_req__aspice_40__iic-15-51[version==1]
 
    Analyze the specified software requirements
    including their interdependencies to ensure correctness, technical feasibility, and to support
@@ -112,7 +115,8 @@ Base practices
 .. std_req:: SWE.1.BP4: Analyze the impact on the operating environment
    :id: std_req__aspice_40__SWE-1-BP4
    :status: valid
-   :links: std_req__aspice_40__iic-15-51
+   :version: 1
+   :links: std_req__aspice_40__iic-15-51[version==1]
 
    Analyze the impact that the
    software requirements will have on elements in the operating environment.
@@ -120,7 +124,8 @@ Base practices
 .. std_req:: SWE.1.BP5: Ensure consistency and establish bidirectional traceability
    :id: std_req__aspice_40__SWE-1-BP5
    :status: valid
-   :links: std_req__aspice_40__iic-13-51
+   :version: 1
+   :links: std_req__aspice_40__iic-13-51[version==1]
 
    Ensure
    consistency and establish bidirectional traceability between software requirements and system
@@ -153,7 +158,8 @@ Base practices
 .. std_req:: SWE.1.BP6: Communicate agreed software requirements and impact on the operating environment
    :id: std_req__aspice_40__SWE-1-BP6
    :status: valid
-   :links: std_req__aspice_40__iic-13-52
+   :version: 1
+   :links: std_req__aspice_40__iic-13-52[version==1]
 
    Communicate the agreed software requirements, and the results of the analysis
    of impact on the operating environment, to all affected parties.

--- a/process/standards/aspice_40/swe/swe.2.rst
+++ b/process/standards/aspice_40/swe/swe.2.rst
@@ -38,7 +38,8 @@ Base practices
 .. std_req:: SWE.2.BP1: Specify static aspects of the software architecture
    :id: std_req__aspice_40__SWE-2-BP1
    :status: valid
-   :links: std_req__aspice_40__iic-04-04
+   :version: 1
+   :links: std_req__aspice_40__iic-04-04[version==1]
 
    Specify and document the static aspects of the software architecture
    with respect to the functional and non-functional software requirements,
@@ -54,7 +55,8 @@ Base practices
 .. std_req:: SWE.2.BP2: Specify dynamic aspects of the software architecture
    :id: std_req__aspice_40__SWE-2-BP2
    :status: valid
-   :links: std_req__aspice_40__iic-04-04
+   :version: 1
+   :links: std_req__aspice_40__iic-04-04[version==1]
 
    Specify and document
    the dynamic aspects of the software architecture with respect to the functional and non-
@@ -75,7 +77,8 @@ Base practices
 .. std_req:: SWE.2.BP3: Analyze software architecture
    :id: std_req__aspice_40__SWE-2-BP3
    :status: valid
-   :links: std_req__aspice_40__iic-15-51
+   :version: 1
+   :links: std_req__aspice_40__iic-15-51[version==1]
 
    Analyze the software architecture regarding
    relevant technical design aspects and to support project management regarding project
@@ -110,7 +113,8 @@ Base practices
 .. std_req:: SWE.2.BP4: Ensure consistency and establish bidirectional traceability
    :id: std_req__aspice_40__SWE-2-BP4
    :status: valid
-   :links: std_req__aspice_40__iic-13-51
+   :version: 1
+   :links: std_req__aspice_40__iic-13-51[version==1]
 
    Ensure consistency and establish bidirectional traceability between the software architecture and the
    software requirements.
@@ -131,7 +135,8 @@ Base practices
 .. std_req:: SWE.2.BP5: Communicate agreed software architecture
    :id: std_req__aspice_40__SWE-2-BP5
    :status: valid
-   :links: std_req__aspice_40__iic-13-52
+   :version: 1
+   :links: std_req__aspice_40__iic-13-52[version==1]
 
    Communicate the agreed software
    architecture to all affected parties.

--- a/process/standards/aspice_40/swe/swe.3.rst
+++ b/process/standards/aspice_40/swe/swe.3.rst
@@ -43,7 +43,8 @@ Base practices
 .. std_req:: SWE.3.BP1: Specify the static aspects of the detailed design
    :id: std_req__aspice_40__SWE-3-BP1
    :status: valid
-   :links: std_req__aspice_40__iic-04-05;std_req__aspice_40__iic-11-05
+   :version: 1
+   :links: std_req__aspice_40__iic-04-05[version==1], std_req__aspice_40__iic-11-05[version==1]
 
    For each software component
    specify the behavior of its software units, their static structure and relationships, their interfaces
@@ -86,7 +87,8 @@ Base practices
 .. std_req:: SWE.3.BP2: Specify dynamic aspects of the detailed design
    :id: std_req__aspice_40__SWE-3-BP2
    :status: valid
-   :links: std_req__aspice_40__iic-04-05;std_req__aspice_40__iic-11-05
+   :version: 1
+   :links: std_req__aspice_40__iic-04-05[version==1], std_req__aspice_40__iic-11-05[version==1]
 
    Specify and document the
    dynamic aspects of the detailed design with respect to the software architecture, including the
@@ -101,7 +103,8 @@ Base practices
 .. std_req:: SWE.3.BP3: Develop software units
    :id: std_req__aspice_40__SWE-3-BP3
    :status: valid
-   :links: std_req__aspice_40__iic-11-05
+   :version: 1
+   :links: std_req__aspice_40__iic-11-05[version==1]
 
    Develop and document the software units consistent
    with the detailed design, and according to coding principles.
@@ -116,7 +119,8 @@ Base practices
 .. std_req:: SWE.3.BP4: Ensure consistency and establish bidirectional traceability
    :id: std_req__aspice_40__SWE-3-BP4
    :status: valid
-   :links: std_req__aspice_40__iic-13-51
+   :version: 1
+   :links: std_req__aspice_40__iic-13-51[version==1]
 
    Ensure
    consistency and establish bidirectional traceability between the software detailed design and the
@@ -144,7 +148,8 @@ Base practices
 .. std_req:: SWE.3.BP5: Communicate agreed software detailed design and developed software units
    :id: std_req__aspice_40__SWE-3-BP5
    :status: valid
-   :links: std_req__aspice_40__iic-13-52
+   :version: 1
+   :links: std_req__aspice_40__iic-13-52[version==1]
 
    Communicate the agreed software detailed design and developed software units to all
    affected parties.

--- a/process/standards/aspice_40/swe/swe.4.rst
+++ b/process/standards/aspice_40/swe/swe.4.rst
@@ -42,7 +42,8 @@ Base practices
 .. std_req:: SWE.4.BP1: Specify software unit verification measures
    :id: std_req__aspice_40__SWE-4-BP1
    :status: valid
-   :links: std_req__aspice_40__iic-08-60
+   :version: 1
+   :links: std_req__aspice_40__iic-08-60[version==1]
 
    Specify verification measures for
    each software unit defined in the software detailed design, including
@@ -62,7 +63,8 @@ Base practices
 .. std_req:: SWE.4.BP2: Select software unit verification measures
    :id: std_req__aspice_40__SWE-4-BP2
    :status: valid
-   :links: std_req__aspice_40__iic-08-58
+   :version: 1
+   :links: std_req__aspice_40__iic-08-58[version==1]
 
    Document the selection of
    verification measures considering selection criteria including criteria for regression verification.
@@ -72,7 +74,8 @@ Base practices
 .. std_req:: SWE.4.BP3: Verify software units
    :id: std_req__aspice_40__SWE-4-BP3
    :status: valid
-   :links: std_req__aspice_40__iic-03-50;std_req__aspice_40__iic-15-52
+   :version: 1
+   :links: std_req__aspice_40__iic-03-50[version==1], std_req__aspice_40__iic-15-52[version==1]
 
    Perform software unit verification using the selected
    verification measures. Record the verification results including pass/fail status and
@@ -86,7 +89,8 @@ Base practices
 .. std_req:: SWE.4.BP4: Ensure consistency and establish bidirectional traceability
    :id: std_req__aspice_40__SWE-4-BP4
    :status: valid
-   :links: std_req__aspice_40__iic-13-51
+   :version: 1
+   :links: std_req__aspice_40__iic-13-51[version==1]
 
    Ensure
    consistency and establish bidirectional traceability between verification measures and the
@@ -103,7 +107,8 @@ Base practices
 .. std_req:: SWE.4.BP5: Summarize and communicate results
    :id: std_req__aspice_40__SWE-4-BP5
    :status: valid
-   :links: std_req__aspice_40__iic-13-52
+   :version: 1
+   :links: std_req__aspice_40__iic-13-52[version==1]
 
    Summarize the results of software unit
    verification and communicate them to all affected parties.

--- a/process/standards/aspice_40/swe/swe.5.rst
+++ b/process/standards/aspice_40/swe/swe.5.rst
@@ -56,7 +56,8 @@ Base practices
 .. std_req:: SWE.5.BP1: Specify software integration verification measures
    :id: std_req__aspice_40__SWE-5-BP1
    :status: valid
-   :links: std_req__aspice_40__iic-08-60
+   :version: 1
+   :links: std_req__aspice_40__iic-08-60[version==1]
 
    Specify verification
    measures, based on a defined sequence and preconditions for the integration of software
@@ -82,7 +83,8 @@ Base practices
 .. std_req:: SWE.5.BP2: Specify verification measures for verifying software component behavior
    :id: std_req__aspice_40__SWE-5-BP2
    :status: valid
-   :links: std_req__aspice_40__iic-08-60
+   :version: 1
+   :links: std_req__aspice_40__iic-08-60[version==1]
 
    Specify verification measures for software component verification against the defined software
    components’ behavior and their interfaces in the software architecture, including
@@ -100,7 +102,8 @@ Base practices
 .. std_req:: SWE.5.BP3: Select verification measures
    :id: std_req__aspice_40__SWE-5-BP3
    :status: valid
-   :links: std_req__aspice_40__iic-08-58
+   :version: 1
+   :links: std_req__aspice_40__iic-08-58[version==1]
 
    Document the selection of integration verification
    measures for each integration step considering selection criteria including criteria for regression
@@ -118,7 +121,8 @@ Base practices
 .. std_req:: SWE.5.BP4: Integrate software elements and perform integration verification
    :id: std_req__aspice_40__SWE-5-BP4
    :status: valid
-   :links: std_req__aspice_40__iic-06-50;std_req__aspice_40__iic-01-03;std_req__aspice_40__iic-01-50
+   :version: 1
+   :links: std_req__aspice_40__iic-06-50[version==1], std_req__aspice_40__iic-01-03[version==1], std_req__aspice_40__iic-01-50[version==1]
 
    Integrate the
    software elements until the software is fully integrated according to the specified interfaces and
@@ -146,7 +150,8 @@ Base practices
 .. std_req:: SWE.5.BP5: Perform software component verification
    :id: std_req__aspice_40__SWE-5-BP5
    :status: valid
-   :links: std_req__aspice_40__iic-03-50;std_req__aspice_40__iic-15-52
+   :version: 1
+   :links: std_req__aspice_40__iic-03-50[version==1], std_req__aspice_40__iic-15-52[version==1]
 
    Perform the selected verification
    measures for verifying software component behavior. Record the verification results including
@@ -160,7 +165,8 @@ Base practices
 .. std_req:: SWE.5.BP6: Ensure consistency and establish bidirectional traceability
    :id: std_req__aspice_40__SWE-5-BP6
    :status: valid
-   :links: std_req__aspice_40__iic-13-51
+   :version: 1
+   :links: std_req__aspice_40__iic-13-51[version==1]
 
    Ensure
    consistency and establish bidirectional traceability between verification measures and the static
@@ -177,7 +183,8 @@ Base practices
 .. std_req:: SWE.5.BP7: Summarize and communicate results
    :id: std_req__aspice_40__SWE-5-BP7
    :status: valid
-   :links: std_req__aspice_40__iic-13-52
+   :version: 1
+   :links: std_req__aspice_40__iic-13-52[version==1]
 
    Summarize the software component
    verification and the software integration verification results and communicate them to all affected

--- a/process/standards/aspice_40/swe/swe.6.rst
+++ b/process/standards/aspice_40/swe/swe.6.rst
@@ -43,7 +43,8 @@ Base practices
 .. std_req:: SWE.6.BP1: Specify verification measures for software verification
    :id: std_req__aspice_40__SWE-6-BP1
    :status: valid
-   :links: std_req__aspice_40__iic-08-60
+   :version: 1
+   :links: std_req__aspice_40__iic-08-60[version==1]
 
    Specify the verification
    measures for software verification suitable to provide evidence for compliance of the integrated
@@ -66,7 +67,8 @@ Base practices
 .. std_req:: SWE.6.BP2: Select verification measures
    :id: std_req__aspice_40__SWE-6-BP2
    :status: valid
-   :links: std_req__aspice_40__iic-08-58
+   :version: 1
+   :links: std_req__aspice_40__iic-08-58[version==1]
 
    Document the selection of verification measures
    considering selection criteria including criteria for regression verification. The documented
@@ -83,7 +85,8 @@ Base practices
 .. std_req:: SWE.6.BP3: Verify the integrated software
    :id: std_req__aspice_40__SWE-6-BP3
    :status: valid
-   :links: std_req__aspice_40__iic-03-50;std_req__aspice_40__iic-15-52
+   :version: 1
+   :links: std_req__aspice_40__iic-03-50[version==1], std_req__aspice_40__iic-15-52[version==1]
 
    Perform the verification of the integrated software
    using the selected verification measures. Record the verification results including pass/fail status
@@ -97,7 +100,8 @@ Base practices
 .. std_req:: SWE.6.BP4: Ensure consistency and establish bidirectional traceability
    :id: std_req__aspice_40__SWE-6-BP4
    :status: valid
-   :links: std_req__aspice_40__iic-13-51
+   :version: 1
+   :links: std_req__aspice_40__iic-13-51[version==1]
 
    Ensure
    consistency and establish bidirectional traceability between verification measures and software
@@ -114,7 +118,8 @@ Base practices
 .. std_req:: SWE.6.BP5: Summarize and communicate results
    :id: std_req__aspice_40__SWE-6-BP5
    :status: valid
-   :links: std_req__aspice_40__iic-13-52
+   :version: 1
+   :links: std_req__aspice_40__iic-13-52[version==1]
 
    Summarize the software verification
    results and communicate them to all affected parties.

--- a/process/standards/iso26262/iso26262.rst
+++ b/process/standards/iso26262/iso26262.rst
@@ -50,444 +50,518 @@ Part 2: Management of functional safety
     .. std_req:: management_5421
        :id: std_req__iso26262__management_5421
        :status: valid
+       :version: 1
        :tags: ok
 
 
     .. std_req:: management_5422
        :id: std_req__iso26262__management_5422
        :status: valid
+       :version: 1
        :tags: ok
 
 
     .. std_req:: management_5423
        :id: std_req__iso26262__management_5423
        :status: valid
+       :version: 1
        :tags: ok
 
 
     .. std_req:: management_5424
        :id: std_req__iso26262__management_5424
        :status: valid
+       :version: 1
        :tags: n/a
 
 
     .. std_req:: management_5425
        :id: std_req__iso26262__management_5425
        :status: valid
+       :version: 1
        :tags: open
 
 
     .. std_req:: management_5426
        :id: std_req__iso26262__management_5426
        :status: valid
+       :version: 1
        :tags: open
 
 
     .. std_req:: management_5427
        :id: std_req__iso26262__management_5427
        :status: valid
+       :version: 1
        :tags: open
 
 
     .. std_req:: management_5431
        :id: std_req__iso26262__management_5431
        :status: valid
+       :version: 1
        :tags: action
 
 
     .. std_req:: management_5432
        :id: std_req__iso26262__management_5432
        :status: valid
+       :version: 1
        :tags: action
 
 
     .. std_req:: management_5433
        :id: std_req__iso26262__management_5433
        :status: valid
+       :version: 1
        :tags: open
 
 
     .. std_req:: management_5434
        :id: std_req__iso26262__management_5434
        :status: valid
+       :version: 1
        :tags: open
 
 
     .. std_req:: management_5435
        :id: std_req__iso26262__management_5435
        :status: valid
+       :version: 1
        :tags: ok
 
 
     .. std_req:: management_5441
        :id: std_req__iso26262__management_5441
        :status: valid
+       :version: 1
        :tags: action
 
 
     .. std_req:: management_5451
        :id: std_req__iso26262__management_5451
        :status: valid
+       :version: 1
        :tags: action
 
 
     .. std_req:: management_5461
        :id: std_req__iso26262__management_5461
        :status: valid
+       :version: 1
        :tags: n/a
 
 
     .. std_req:: management_6421
        :id: std_req__iso26262__management_6421
        :status: valid
+       :version: 1
        :tags: ok
 
 
     .. std_req:: management_6422
        :id: std_req__iso26262__management_6422
        :status: valid
+       :version: 1
        :tags: open
 
 
     .. std_req:: management_6423
        :id: std_req__iso26262__management_6423
        :status: valid
+       :version: 1
        :tags: ok
 
 
     .. std_req:: management_6424
        :id: std_req__iso26262__management_6424
        :status: valid
+       :version: 1
        :tags: open
 
 
     .. std_req:: management_6431
        :id: std_req__iso26262__management_6431
        :status: valid
+       :version: 1
        :tags: n/a
 
 
     .. std_req:: management_6432
        :id: std_req__iso26262__management_6432
        :status: valid
+       :version: 1
        :tags: n/a
 
 
     .. std_req:: management_6433
        :id: std_req__iso26262__management_6433
        :status: valid
+       :version: 1
        :tags: n/a
 
 
     .. std_req:: management_644
        :id: std_req__iso26262__management_644
        :status: valid
+       :version: 1
        :tags: n/a
 
 
     .. std_req:: management_6451
        :id: std_req__iso26262__management_6451
        :status: valid
+       :version: 1
        :tags: ok
 
 
     .. std_req:: management_6452
        :id: std_req__iso26262__management_6452
        :status: valid
+       :version: 1
        :tags: n/a
 
 
     .. std_req:: management_6453
        :id: std_req__iso26262__management_6453
        :status: valid
+       :version: 1
        :tags: n/a
 
 
     .. std_req:: management_6454
        :id: std_req__iso26262__management_6454
        :status: valid
+       :version: 1
        :tags: n/a
 
 
     .. std_req:: management_6455
        :id: std_req__iso26262__management_6455
        :status: valid
+       :version: 1
        :tags: n/a
 
 
     .. std_req:: management_6456
        :id: std_req__iso26262__management_6456
        :status: valid
+       :version: 1
        :tags: n/a
 
 
     .. std_req:: management_6457
        :id: std_req__iso26262__management_6457
        :status: valid
+       :version: 1
        :tags: ok
 
 
     .. std_req:: management_6461
        :id: std_req__iso26262__management_6461
        :status: valid
+       :version: 1
        :tags: ok
 
 
     .. std_req:: management_6462
        :id: std_req__iso26262__management_6462
        :status: valid
+       :version: 1
        :tags: ok
 
 
     .. std_req:: management_6463
        :id: std_req__iso26262__management_6463
        :status: valid
+       :version: 1
        :tags: ok
 
 
     .. std_req:: management_6464
        :id: std_req__iso26262__management_6464
        :status: valid
+       :version: 1
        :tags: action
 
 
     .. std_req:: management_6465
        :id: std_req__iso26262__management_6465
        :status: valid
+       :version: 1
        :tags: ok
 
 
     .. std_req:: management_6466
        :id: std_req__iso26262__management_6466
        :status: valid
+       :version: 1
        :tags: ok
 
 
     .. std_req:: management_6467
        :id: std_req__iso26262__management_6467
        :status: valid
+       :version: 1
        :tags: ok
 
 
     .. std_req:: management_6468
        :id: std_req__iso26262__management_6468
        :status: valid
+       :version: 1
        :tags: ok
 
 
     .. std_req:: management_6469
        :id: std_req__iso26262__management_6469
        :status: valid
+       :version: 1
        :tags: ok
 
 
     .. std_req:: management_64610
        :id: std_req__iso26262__management_64610
        :status: valid
+       :version: 1
        :tags: n/a
 
 
     .. std_req:: management_6471
        :id: std_req__iso26262__management_6471
        :status: valid
+       :version: 1
        :tags: ok
 
 
     .. std_req:: management_6472
        :id: std_req__iso26262__management_6472
        :status: valid
+       :version: 1
        :tags: ok
 
 
     .. std_req:: management_6481
        :id: std_req__iso26262__management_6481
        :status: valid
+       :version: 1
        :tags: ok
 
 
     .. std_req:: management_6482
        :id: std_req__iso26262__management_6482
        :status: valid
+       :version: 1
        :tags: open
 
 
     .. std_req:: management_6491
        :id: std_req__iso26262__management_6491
        :status: valid
+       :version: 1
        :tags: action
 
 
     .. std_req:: management_6492
        :id: std_req__iso26262__management_6492
        :status: valid
+       :version: 1
        :tags: ok
 
 
     .. std_req:: management_6493
        :id: std_req__iso26262__management_6493
        :status: valid
+       :version: 1
        :tags: open
 
 
     .. std_req:: management_64101
        :id: std_req__iso26262__management_64101
        :status: valid
+       :version: 1
        :tags: open
 
 
     .. std_req:: management_64102
        :id: std_req__iso26262__management_64102
        :status: valid
+       :version: 1
        :tags: open
 
 
     .. std_req:: management_64103
        :id: std_req__iso26262__management_64103
        :status: valid
+       :version: 1
        :tags: open
 
 
     .. std_req:: management_64104
        :id: std_req__iso26262__management_64104
        :status: valid
+       :version: 1
        :tags: open
 
 
     .. std_req:: management_64105
        :id: std_req__iso26262__management_64105
        :status: valid
+       :version: 1
        :tags: open
 
 
     .. std_req:: management_64111
        :id: std_req__iso26262__management_64111
        :status: valid
+       :version: 1
        :tags: ok
 
 
     .. std_req:: management_64112
        :id: std_req__iso26262__management_64112
        :status: valid
+       :version: 1
        :tags: n/a
 
 
     .. std_req:: management_64113
        :id: std_req__iso26262__management_64113
        :status: valid
+       :version: 1
        :tags: n/a
 
 
     .. std_req:: management_64114
        :id: std_req__iso26262__management_64114
        :status: valid
+       :version: 1
        :tags: n/a
 
 
     .. std_req:: management_64121
        :id: std_req__iso26262__management_64121
        :status: valid
+       :version: 1
        :tags: n/a
 
 
     .. std_req:: management_64122
        :id: std_req__iso26262__management_64122
        :status: valid
+       :version: 1
        :tags: n/a
 
 
     .. std_req:: management_64123
        :id: std_req__iso26262__management_64123
        :status: valid
+       :version: 1
        :tags: n/a
 
 
     .. std_req:: management_64124
        :id: std_req__iso26262__management_64124
        :status: valid
+       :version: 1
        :tags: n/a
 
 
     .. std_req:: management_64125
        :id: std_req__iso26262__management_64125
        :status: valid
+       :version: 1
        :tags: n/a
 
 
     .. std_req:: management_64126
        :id: std_req__iso26262__management_64126
        :status: valid
+       :version: 1
        :tags: n/a
 
 
     .. std_req:: management_64127
        :id: std_req__iso26262__management_64127
        :status: valid
+       :version: 1
        :tags: n/a
 
 
     .. std_req:: management_64128
        :id: std_req__iso26262__management_64128
        :status: valid
+       :version: 1
        :tags: n/a
 
 
     .. std_req:: management_64129
        :id: std_req__iso26262__management_64129
        :status: valid
+       :version: 1
        :tags: n/a
 
 
     .. std_req:: management_641210
        :id: std_req__iso26262__management_641210
        :status: valid
+       :version: 1
        :tags: n/a
 
 
     .. std_req:: management_641211
        :id: std_req__iso26262__management_641211
        :status: valid
+       :version: 1
        :tags: n/a
 
 
     .. std_req:: management_641212
        :id: std_req__iso26262__management_641212
        :status: valid
+       :version: 1
        :tags: n/a
 
 
     .. std_req:: management_641213
        :id: std_req__iso26262__management_641213
        :status: valid
+       :version: 1
        :tags: n/a
 
 
     .. std_req:: management_64131
        :id: std_req__iso26262__management_64131
        :status: valid
+       :version: 1
        :tags: ok
 
 
     .. std_req:: management_64132
        :id: std_req__iso26262__management_64132
        :status: valid
+       :version: 1
        :tags: open
 
 
     .. std_req:: management_64133
        :id: std_req__iso26262__management_64133
        :status: valid
+       :version: 1
        :tags: ok
 
 
     .. std_req:: management_64134
        :id: std_req__iso26262__management_64134
        :status: valid
+       :version: 1
        :tags: ok
 
 
     .. std_req:: management_64135
        :id: std_req__iso26262__management_64135
        :status: valid
+       :version: 1
        :tags: open
 
 
@@ -495,57 +569,68 @@ Part 2: Management of functional safety
     .. std_wp:: management_551
        :id: std_wp__iso26262__management_551
        :status: valid
+       :version: 1
        :tags: open
 
 
     .. std_wp:: management_552
        :id: std_wp__iso26262__management_552
        :status: valid
+       :version: 1
 
 
     .. std_wp:: management_553
        :id: std_wp__iso26262__management_553
        :status: valid
+       :version: 1
 
 
     .. std_wp:: management_554
        :id: std_wp__iso26262__management_554
        :status: valid
+       :version: 1
 
 
     .. std_wp:: management_651
        :id: std_wp__iso26262__management_651
        :status: valid
+       :version: 1
 
 
     .. std_wp:: management_652
        :id: std_wp__iso26262__management_652
        :status: valid
+       :version: 1
 
 
     .. std_wp:: management_653
        :id: std_wp__iso26262__management_653
        :status: valid
+       :version: 1
 
 
     .. std_wp:: management_654
        :id: std_wp__iso26262__management_654
        :status: valid
+       :version: 1
 
 
     .. std_wp:: management_655
        :id: std_wp__iso26262__management_655
        :status: valid
+       :version: 1
 
 
     .. std_wp:: management_656
        :id: std_wp__iso26262__management_656
        :status: valid
+       :version: 1
 
 
     .. std_wp:: management_751
        :id: std_wp__iso26262__management_751
        :status: valid
+       :version: 1
 
 
 Part 4: Product development at the system level
@@ -555,54 +640,63 @@ Part 4: Product development at the system level
      .. std_req:: system_6411
        :id: std_req__iso26262__system_6411
        :status: valid
+       :version: 1
        :tags: ok
 
 
      .. std_req:: system_6412
        :id: std_req__iso26262__system_6412
        :status: valid
+       :version: 1
        :tags: n/a
 
 
      .. std_req:: system_6413
        :id: std_req__iso26262__system_6413
        :status: valid
+       :version: 1
        :tags: ok
 
 
      .. std_req:: system_6414
        :id: std_req__iso26262__system_6414
        :status: valid
+       :version: 1
        :tags: ok
 
 
      .. std_req:: system_6421
        :id: std_req__iso26262__system_6421
        :status: valid
+       :version: 1
        :tags: ok
 
 
      .. std_req:: system_6422
        :id: std_req__iso26262__system_6422
        :status: valid
+       :version: 1
        :tags: n/a
 
 
      .. std_req:: system_6423
        :id: std_req__iso26262__system_6423
        :status: valid
+       :version: 1
        :tags: n/a
 
 
      .. std_req:: system_6424
        :id: std_req__iso26262__system_6424
        :status: valid
+       :version: 1
        :tags: n/a
 
 
      .. std_req:: system_6425
        :id: std_req__iso26262__system_6425
        :status: valid
+       :version: 1
        :tags: n/a
 
 
@@ -610,56 +704,67 @@ Part 4: Product development at the system level
     .. std_wp:: system_651
        :id: std_wp__iso26262__system_651
        :status: valid
+       :version: 1
 
 
     .. std_wp:: system_652
        :id: std_wp__iso26262__system_652
        :status: valid
+       :version: 1
 
 
     .. std_wp:: system_653
        :id: std_wp__iso26262__system_653
        :status: valid
+       :version: 1
 
 
     .. std_wp:: system_654
        :id: std_wp__iso26262__system_654
        :status: valid
+       :version: 1
 
 
     .. std_wp:: system_655
        :id: std_wp__iso26262__system_655
        :status: valid
+       :version: 1
 
 
     .. std_wp:: system_656
        :id: std_wp__iso26262__system_656
        :status: valid
+       :version: 1
 
 
     .. std_wp:: system_657
        :id: std_wp__iso26262__system_657
        :status: valid
+       :version: 1
 
 
     .. std_wp:: system_751
        :id: std_wp__iso26262__system_751
        :status: valid
+       :version: 1
 
 
     .. std_wp:: system_752
        :id: std_wp__iso26262__system_752
        :status: valid
+       :version: 1
 
 
     .. std_wp:: system_851
        :id: std_wp__iso26262__system_851
        :status: valid
+       :version: 1
 
 
     .. std_wp:: system_852
        :id: std_wp__iso26262__system_852
        :status: valid
+       :version: 1
 
 
 
@@ -671,422 +776,497 @@ Part 6: Product development at the software level
      .. std_req:: software_541
        :id: std_req__iso26262__software_541
        :status: valid
+       :version: 1
        :tags: action
 
 
      .. std_req:: software_542
        :id: std_req__iso26262__software_542
        :status: valid
+       :version: 1
        :tags: ok
 
 
      .. std_req:: software_543
        :id: std_req__iso26262__software_543
        :status: valid
+       :version: 1
        :tags: action
 
 
      .. std_req:: software_641
        :id: std_req__iso26262__software_641
        :status: valid
+       :version: 1
        :tags: ok
 
 
      .. std_req:: software_642
        :id: std_req__iso26262__software_642
        :status: valid
+       :version: 1
        :tags: ok
 
 
      .. std_req:: software_643
        :id: std_req__iso26262__software_643
        :status: valid
+       :version: 1
        :tags: n/a
 
 
      .. std_req:: software_644
        :id: std_req__iso26262__software_644
        :status: valid
+       :version: 1
        :tags: n/a
 
 
      .. std_req:: software_645
        :id: std_req__iso26262__software_645
        :status: valid
+       :version: 1
        :tags: ok
 
 
      .. std_req:: software_646
        :id: std_req__iso26262__software_646
        :status: valid
+       :version: 1
        :tags: n/a
 
 
      .. std_req:: software_647
        :id: std_req__iso26262__software_647
        :status: valid
+       :version: 1
        :tags: ok
 
 
      .. std_req:: software_741
        :id: std_req__iso26262__software_741
        :status: valid
+       :version: 1
        :tags: ok
 
 
      .. std_req:: software_742
        :id: std_req__iso26262__software_742
        :status: valid
+       :version: 1
        :tags: ok
 
 
      .. std_req:: software_743
        :id: std_req__iso26262__software_743
        :status: valid
+       :version: 1
        :tags: ok
 
 
      .. std_req:: software_744
        :id: std_req__iso26262__software_744
        :status: valid
+       :version: 1
        :tags: ok
 
 
      .. std_req:: software_745
        :id: std_req__iso26262__software_745
        :status: valid
+       :version: 1
        :tags: ok
 
 
      .. std_req:: software_746
        :id: std_req__iso26262__software_746
        :status: valid
+       :version: 1
        :tags: ok
 
 
      .. std_req:: software_747
        :id: std_req__iso26262__software_747
        :status: valid
+       :version: 1
        :tags: open
 
 
      .. std_req:: software_748
        :id: std_req__iso26262__software_748
        :status: valid
+       :version: 1
        :tags: ok
 
 
      .. std_req:: software_749
        :id: std_req__iso26262__software_749
        :status: valid
+       :version: 1
        :tags: n/a
 
 
      .. std_req:: software_7410
        :id: std_req__iso26262__software_7410
        :status: valid
+       :version: 1
        :tags: ok
 
 
      .. std_req:: software_7411
        :id: std_req__iso26262__software_7411
        :status: valid
+       :version: 1
        :tags: ok
 
 
      .. std_req:: software_7412
        :id: std_req__iso26262__software_7412
        :status: valid
+       :version: 1
        :tags: ok
 
 
      .. std_req:: software_7413
        :id: std_req__iso26262__software_7413
        :status: valid
+       :version: 1
        :tags: n/a
 
 
      .. std_req:: software_7414
        :id: std_req__iso26262__software_7414
        :status: valid
+       :version: 1
        :tags: recommendation
 
 
      .. std_req:: software_841
        :id: std_req__iso26262__software_841
        :status: valid
+       :version: 1
        :tags: ok
 
 
      .. std_req:: software_842
        :id: std_req__iso26262__software_842
        :status: valid
+       :version: 1
        :tags: ok
 
 
      .. std_req:: software_843
        :id: std_req__iso26262__software_843
        :status: valid
+       :version: 1
        :tags: ok
 
 
      .. std_req:: software_844
        :id: std_req__iso26262__software_844
        :status: valid
+       :version: 1
        :tags: ok
 
 
      .. std_req:: software_845
        :id: std_req__iso26262__software_845
        :status: valid
+       :version: 1
        :tags: action
 
 
      .. std_req:: software_941
        :id: std_req__iso26262__software_941
        :status: valid
+       :version: 1
        :tags: ok
 
 
      .. std_req:: software_942
        :id: std_req__iso26262__software_942
        :status: valid
+       :version: 1
        :tags: ok
 
 
      .. std_req:: software_943
        :id: std_req__iso26262__software_943
        :status: valid
+       :version: 1
        :tags: ok
 
 
      .. std_req:: software_944
        :id: std_req__iso26262__software_944
        :status: valid
+       :version: 1
        :tags: ok
 
 
      .. std_req:: software_945
        :id: std_req__iso26262__software_945
        :status: valid
+       :version: 1
        :tags: ok
 
 
      .. std_req:: software_1041
        :id: std_req__iso26262__software_1041
        :status: valid
+       :version: 1
        :tags: ok
 
 
      .. std_req:: software_1042
        :id: std_req__iso26262__software_1042
        :status: valid
+       :version: 1
        :tags: ok
 
 
      .. std_req:: software_1043
        :id: std_req__iso26262__software_1043
        :status: valid
+       :version: 1
        :tags: ok
 
 
      .. std_req:: software_1044
        :id: std_req__iso26262__software_1044
        :status: valid
+       :version: 1
        :tags: ok
 
 
      .. std_req:: software_1045
        :id: std_req__iso26262__software_1045
        :status: valid
+       :version: 1
        :tags: n/a
 
 
      .. std_req:: software_1046
        :id: std_req__iso26262__software_1046
        :status: valid
+       :version: 1
        :tags: n/a
 
 
      .. std_req:: software_1047
        :id: std_req__iso26262__software_1047
        :status: valid
+       :version: 1
        :tags: n/a
 
 
      .. std_req:: software_1141
        :id: std_req__iso26262__software_1141
        :status: valid
+       :version: 1
        :tags: ok
 
 
      .. std_req:: software_1142
        :id: std_req__iso26262__software_1142
        :status: valid
+       :version: 1
        :tags: n/a
 
 
      .. std_req:: software_1143
        :id: std_req__iso26262__software_1143
        :status: valid
+       :version: 1
        :tags: n/a
 
 
      .. std_req:: software_1144
        :id: std_req__iso26262__software_1144
        :status: valid
+       :version: 1
        :tags: n/a
 
 
      .. std_req:: software_app_c_41
        :id: std_req__iso26262__software_app_c_41
        :status: valid
+       :version: 1
 
 
      .. std_req:: software_app_c_42
        :id: std_req__iso26262__software_app_c_42
        :status: valid
+       :version: 1
 
 
      .. std_req:: software_app_c_43
        :id: std_req__iso26262__software_app_c_43
        :status: valid
+       :version: 1
 
 
      .. std_req:: software_app_c_44
        :id: std_req__iso26262__software_app_c_44
        :status: valid
+       :version: 1
 
 
      .. std_req:: software_app_c_45
        :id: std_req__iso26262__software_app_c_45
        :status: valid
+       :version: 1
 
 
 * Workproducts
      .. std_wp:: software_551
        :id: std_wp__iso26262__software_551
        :status: valid
+       :version: 1
 
 
      .. std_wp:: software_651
        :id: std_wp__iso26262__software_651
        :status: valid
+       :version: 1
 
 
      .. std_wp:: software_652
        :id: std_wp__iso26262__software_652
        :status: valid
+       :version: 1
 
 
      .. std_wp:: software_653
        :id: std_wp__iso26262__software_653
        :status: valid
+       :version: 1
 
 
      .. std_wp:: software_751
        :id: std_wp__iso26262__software_751
        :status: valid
+       :version: 1
 
 
      .. std_wp:: software_752
        :id: std_wp__iso26262__software_752
        :status: valid
+       :version: 1
 
 
      .. std_wp:: software_753
        :id: std_wp__iso26262__software_753
        :status: valid
+       :version: 1
 
 
      .. std_wp:: software_754
        :id: std_wp__iso26262__software_754
        :status: valid
+       :version: 1
 
 
      .. std_wp:: software_851
        :id: std_wp__iso26262__software_851
        :status: valid
+       :version: 1
 
 
      .. std_wp:: software_852
        :id: std_wp__iso26262__software_852
        :status: valid
+       :version: 1
 
 
      .. std_wp:: software_951
        :id: std_wp__iso26262__software_951
        :status: valid
+       :version: 1
 
 
      .. std_wp:: software_952
        :id: std_wp__iso26262__software_952
        :status: valid
+       :version: 1
 
 
      .. std_wp:: software_1051
        :id: std_wp__iso26262__software_1051
        :status: valid
+       :version: 1
 
 
      .. std_wp:: software_1052
        :id: std_wp__iso26262__software_1052
        :status: valid
+       :version: 1
 
 
      .. std_wp:: software_1053
        :id: std_wp__iso26262__software_1053
        :status: valid
+       :version: 1
 
 
      .. std_wp:: software_1151
        :id: std_wp__iso26262__software_1151
        :status: valid
+       :version: 1
 
 
      .. std_wp:: software_1152
        :id: std_wp__iso26262__software_1152
        :status: valid
+       :version: 1
 
 
      .. std_wp:: software_C51
        :id: std_wp__iso26262__software_app_c_51
        :status: valid
+       :version: 1
 
 
      .. std_wp:: software_C52
        :id: std_wp__iso26262__software_app_c_52
        :status: valid
+       :version: 1
 
 
      .. std_wp:: software_C53
        :id: std_wp__iso26262__software_app_c_53
        :status: valid
+       :version: 1
 
 
      .. std_wp:: software_C54
        :id: std_wp__iso26262__software_app_c_54
        :status: valid
+       :version: 1
 
 
      .. std_wp:: software_C55
        :id: std_wp__iso26262__software_app_c_55
        :status: valid
+       :version: 1
 
 
      .. std_wp:: software_C56
        :id: std_wp__iso26262__software_app_c_56
        :status: valid
+       :version: 1
 
 
      .. std_wp:: software_C57
        :id: std_wp__iso26262__software_app_c_57
        :status: valid
+       :version: 1
 
 
      .. std_wp:: software_C58
        :id: std_wp__iso26262__software_app_c_58
        :status: valid
+       :version: 1
 
 
 
@@ -1097,420 +1277,490 @@ Part 8: Supporting processes
     .. std_req:: support_641
        :id: std_req__iso26262__support_641
        :status: valid
+       :version: 1
        :tags: ok
 
 
     .. std_req:: support_6421
        :id: std_req__iso26262__support_6421
        :status: valid
+       :version: 1
        :tags: ok
 
 
     .. std_req:: support_6422
        :id: std_req__iso26262__support_6422
        :status: valid
+       :version: 1
        :tags: recommendation
 
 
     .. std_req:: support_6423
        :id: std_req__iso26262__support_6423
        :status: valid
+       :version: 1
        :tags: n/a
 
 
     .. std_req:: support_6424
        :id: std_req__iso26262__support_6424
        :status: valid
+       :version: 1
        :tags: ok
 
 
     .. std_req:: support_6425
        :id: std_req__iso26262__support_6425
        :status: valid
+       :version: 1
        :tags: ok
 
 
     .. std_req:: support_6431
        :id: std_req__iso26262__support_6431
        :status: valid
+       :version: 1
        :tags: ok
 
 
     .. std_req:: support_6432
        :id: std_req__iso26262__support_6432
        :status: valid
+       :version: 1
        :tags: ok
 
 
     .. std_req:: support_6433
        :id: std_req__iso26262__support_6433
        :status: valid
+       :version: 1
        :tags: ok
 
 
     .. std_req:: support_6434
        :id: std_req__iso26262__support_6434
        :status: valid
+       :version: 1
        :tags: ok
 
 
     .. std_req:: support_741
        :id: std_req__iso26262__support_741
        :status: valid
+       :version: 1
        :tags: ok
 
 
     .. std_req:: support_742
        :id: std_req__iso26262__support_742
        :status: valid
+       :version: 1
        :tags: ok
 
 
     .. std_req:: support_743
        :id: std_req__iso26262__support_743
        :status: valid
+       :version: 1
        :tags: ok
 
 
     .. std_req:: support_744
        :id: std_req__iso26262__support_744
        :status: valid
+       :version: 1
        :tags: ok
 
 
     .. std_req:: support_745
        :id: std_req__iso26262__support_745
        :status: valid
+       :version: 1
        :tags: ok
 
 
     .. std_req:: support_8411
        :id: std_req__iso26262__support_8411
        :status: valid
+       :version: 1
        :tags: ok
 
 
     .. std_req:: support_8412
        :id: std_req__iso26262__support_8412
        :status: valid
+       :version: 1
        :tags: open
 
 
     .. std_req:: support_8413
        :id: std_req__iso26262__support_8413
        :status: valid
+       :version: 1
        :tags: open
 
 
     .. std_req:: support_8414
        :id: std_req__iso26262__support_8414
        :status: valid
+       :version: 1
        :tags: deviation
 
 
     .. std_req:: support_8421
        :id: std_req__iso26262__support_8421
        :status: valid
+       :version: 1
        :tags: ok
 
 
     .. std_req:: support_8422
        :id: std_req__iso26262__support_8422
        :status: valid
+       :version: 1
        :tags: ok
 
 
     .. std_req:: support_8431
        :id: std_req__iso26262__support_8431
        :status: valid
+       :version: 1
        :tags: open
 
 
     .. std_req:: support_8432
        :id: std_req__iso26262__support_8432
        :status: valid
+       :version: 1
        :tags: open
 
 
     .. std_req:: support_8441
        :id: std_req__iso26262__support_8441
        :status: valid
+       :version: 1
        :tags: action
 
 
     .. std_req:: support_8442
        :id: std_req__iso26262__support_8442
        :status: valid
+       :version: 1
        :tags: open
 
 
     .. std_req:: support_8451
        :id: std_req__iso26262__support_8451
        :status: valid
+       :version: 1
        :tags: open
 
 
     .. std_req:: support_8452
        :id: std_req__iso26262__support_8452
        :status: valid
+       :version: 1
        :tags: open
 
 
     .. std_req:: support_8453
        :id: std_req__iso26262__support_8453
        :status: valid
+       :version: 1
        :tags: open
 
 
     .. std_req:: support_9411
        :id: std_req__iso26262__support_9411
        :status: valid
+       :version: 1
        :tags: action
 
 
     .. std_req:: support_9412
        :id: std_req__iso26262__support_9412
        :status: valid
+       :version: 1
        :tags: action
 
 
     .. std_req:: support_9421
        :id: std_req__iso26262__support_9421
        :status: valid
+       :version: 1
        :tags: ok
 
 
     .. std_req:: support_9422
        :id: std_req__iso26262__support_9422
        :status: valid
+       :version: 1
        :tags: open
 
 
     .. std_req:: support_9423
        :id: std_req__iso26262__support_9423
        :status: valid
+       :version: 1
        :tags: open
 
 
     .. std_req:: support_9424
        :id: std_req__iso26262__support_9424
        :status: valid
+       :version: 1
        :tags: open
 
 
     .. std_req:: support_9431
        :id: std_req__iso26262__support_9431
        :status: valid
+       :version: 1
        :tags: ok
 
 
     .. std_req:: support_9432
        :id: std_req__iso26262__support_9432
        :status: valid
+       :version: 1
        :tags: open
 
 
     .. std_req:: support_9433
        :id: std_req__iso26262__support_9433
        :status: valid
+       :version: 1
        :tags: open
 
 
     .. std_req:: support_9434
        :id: std_req__iso26262__support_9434
        :status: valid
+       :version: 1
        :tags: ok
 
 
     .. std_req:: support_1041
        :id: std_req__iso26262__support_1041
        :status: valid
+       :version: 1
        :tags: ok
 
 
     .. std_req:: support_1042
        :id: std_req__iso26262__support_1042
        :status: valid
+       :version: 1
        :tags: ok
 
 
     .. std_req:: support_1043
        :id: std_req__iso26262__support_1043
        :status: valid
+       :version: 1
        :tags: ok
 
 
     .. std_req:: support_1044
        :id: std_req__iso26262__support_1044
        :status: valid
+       :version: 1
        :tags: ok
 
 
     .. std_req:: support_1045
        :id: std_req__iso26262__support_1045
        :status: valid
+       :version: 1
        :tags: ok
 
 
     .. std_req:: support_1046
        :id: std_req__iso26262__support_1046
        :status: valid
+       :version: 1
        :tags: ok
 
 
     .. std_req:: support_1141
        :id: std_req__iso26262__support_1141
        :status: valid
+       :version: 1
        :tags: action
 
 
     .. std_req:: support_1142
        :id: std_req__iso26262__support_1142
        :status: valid
+       :version: 1
        :tags: open
 
 
     .. std_req:: support_1143
        :id: std_req__iso26262__support_1143
        :status: valid
+       :version: 1
        :tags: open
 
 
     .. std_req:: support_11441
        :id: std_req__iso26262__support_11441
        :status: valid
+       :version: 1
        :tags: action
 
 
     .. std_req:: support_11442
        :id: std_req__iso26262__support_11442
        :status: valid
+       :version: 1
        :tags: open
 
 
     .. std_req:: support_11451
        :id: std_req__iso26262__support_11451
        :status: valid
+       :version: 1
        :tags: open
 
 
     .. std_req:: support_11452
        :id: std_req__iso26262__support_11452
        :status: valid
+       :version: 1
        :tags: open
 
 
     .. std_req:: support_11453
        :id: std_req__iso26262__support_11453
        :status: valid
+       :version: 1
        :tags: open
 
 
     .. std_req:: support_11454
        :id: std_req__iso26262__support_11454
        :status: valid
+       :version: 1
        :tags: open
 
 
     .. std_req:: support_11461
        :id: std_req__iso26262__support_11461
        :status: valid
+       :version: 1
        :tags: open
 
 
     .. std_req:: support_11462
        :id: std_req__iso26262__support_11462
        :status: valid
+       :version: 1
        :tags: open
 
 
     .. std_req:: support_11471
        :id: std_req__iso26262__support_11471
        :status: valid
+       :version: 1
        :tags: n/a
 
 
     .. std_req:: support_11472
        :id: std_req__iso26262__support_11472
        :status: valid
+       :version: 1
        :tags: n/a
 
 
     .. std_req:: support_11473
        :id: std_req__iso26262__support_11473
        :status: valid
+       :version: 1
        :tags: n/a
 
 
     .. std_req:: support_11474
        :id: std_req__iso26262__support_11474
        :status: valid
+       :version: 1
        :tags: n/a
 
 
     .. std_req:: support_11481
        :id: std_req__iso26262__support_11481
        :status: valid
+       :version: 1
        :tags: open
 
 
     .. std_req:: support_11482
        :id: std_req__iso26262__support_11482
        :status: valid
+       :version: 1
        :tags: open
 
 
     .. std_req:: support_11483
        :id: std_req__iso26262__support_11483
        :status: valid
+       :version: 1
        :tags: open
 
 
     .. std_req:: support_11491
        :id: std_req__iso26262__support_11491
        :status: valid
+       :version: 1
        :tags: open
 
 
     .. std_req:: support_11492
        :id: std_req__iso26262__support_11492
        :status: valid
+       :version: 1
        :tags: open
 
 
     .. std_req:: support_12421
        :id: std_req__iso26262__support_12421
        :status: valid
+       :version: 1
        :tags: action
 
 
     .. std_req:: support_12422
        :id: std_req__iso26262__support_12422
        :status: valid
+       :version: 1
        :tags: open
 
 
     .. std_req:: support_12423
        :id: std_req__iso26262__support_12423
        :status: valid
+       :version: 1
        :tags: open
 
 
     .. std_req:: support_12424
        :id: std_req__iso26262__support_12424
        :status: valid
+       :version: 1
        :tags: open
 
 
     .. std_req:: support_12425
        :id: std_req__iso26262__support_12425
        :status: valid
+       :version: 1
        :tags: open
 
 
     .. std_req:: support_1243
        :id: std_req__iso26262__support_1243
        :status: valid
+       :version: 1
        :tags: open
 
 
@@ -1518,136 +1768,163 @@ Part 8: Supporting processes
     .. std_wp:: support_551
        :id: std_wp__iso26262__support_551
        :status: valid
+       :version: 1
 
 
     .. std_wp:: support_552
        :id: std_wp__iso26262__support_552
        :status: valid
+       :version: 1
 
 
     .. std_wp:: support_553
        :id: std_wp__iso26262__support_553
        :status: valid
+       :version: 1
 
 
     .. std_wp:: support_554
        :id: std_wp__iso26262__support_554
        :status: valid
+       :version: 1
 
 
     .. std_wp:: support_555
        :id: std_wp__iso26262__support_555
        :status: valid
+       :version: 1
 
 
     .. std_wp:: support_751
        :id: std_wp__iso26262__support_751
        :status: valid
+       :version: 1
 
 
     .. std_wp:: support_851
        :id: std_wp__iso26262__support_851
        :status: valid
+       :version: 1
 
 
     .. std_wp:: support_852
        :id: std_wp__iso26262__support_852
        :status: valid
+       :version: 1
 
 
     .. std_wp:: support_853
        :id: std_wp__iso26262__support_853
        :status: valid
+       :version: 1
 
 
     .. std_wp:: support_854
        :id: std_wp__iso26262__support_854
        :status: valid
+       :version: 1
 
 
     .. std_wp:: support_951
        :id: std_wp__iso26262__support_951
        :status: valid
+       :version: 1
 
 
     .. std_wp:: support_952
        :id: std_wp__iso26262__support_952
        :status: valid
+       :version: 1
 
 
     .. std_wp:: support_953
        :id: std_wp__iso26262__support_953
        :status: valid
+       :version: 1
 
 
     .. std_wp:: support_1051
        :id: std_wp__iso26262__support_1051
        :status: valid
+       :version: 1
 
 
     .. std_wp:: support_1052
        :id: std_wp__iso26262__support_1052
        :status: valid
+       :version: 1
 
 
     .. std_wp:: support_1151
        :id: std_wp__iso26262__support_1151
        :status: valid
+       :version: 1
 
 
     .. std_wp:: support_1152
        :id: std_wp__iso26262__support_1152
        :status: valid
+       :version: 1
 
 
     .. std_wp:: support_1251
        :id: std_wp__iso26262__support_1251
        :status: valid
+       :version: 1
 
 
     .. std_wp:: support_1252
        :id: std_wp__iso26262__support_1252
        :status: valid
+       :version: 1
 
 
     .. std_wp:: support_1253
        :id: std_wp__iso26262__support_1253
        :status: valid
+       :version: 1
 
 
     .. std_wp:: support_1351
        :id: std_wp__iso26262__support_1351
        :status: valid
+       :version: 1
 
 
     .. std_wp:: support_1352
        :id: std_wp__iso26262__support_1352
        :status: valid
+       :version: 1
 
 
     .. std_wp:: support_1353
        :id: std_wp__iso26262__support_1353
        :status: valid
+       :version: 1
 
 
     .. std_wp:: support_1451
        :id: std_wp__iso26262__support_1451
        :status: valid
+       :version: 1
 
 
     .. std_wp:: support_1452
        :id: std_wp__iso26262__support_1452
        :status: valid
+       :version: 1
 
 
     .. std_wp:: support_1551
        :id: std_wp__iso26262__support_1551
        :status: valid
+       :version: 1
 
 
     .. std_wp:: support_1651
        :id: std_wp__iso26262__support_1651
        :status: valid
+       :version: 1
 
 
 
@@ -1658,152 +1935,182 @@ Part 9: Automotive safety integrity level (ASIL)-oriented and safety-oriented an
     .. std_req:: analysis_641
        :id: std_req__iso26262__analysis_641
        :status: valid
+       :version: 1
 
 
     .. std_req:: analysis_642
        :id: std_req__iso26262__analysis_642
        :status: valid
+       :version: 1
 
 
     .. std_req:: analysis_643
        :id: std_req__iso26262__analysis_643
        :status: valid
+       :version: 1
 
 
     .. std_req:: analysis_644
        :id: std_req__iso26262__analysis_644
        :status: valid
+       :version: 1
 
 
     .. std_req:: analysis_741
        :id: std_req__iso26262__analysis_741
        :status: valid
+       :version: 1
 
 
     .. std_req:: analysis_742
        :id: std_req__iso26262__analysis_742
        :status: valid
+       :version: 1
 
 
     .. std_req:: analysis_743
        :id: std_req__iso26262__analysis_743
        :status: valid
+       :version: 1
 
 
     .. std_req:: analysis_744
        :id: std_req__iso26262__analysis_744
        :status: valid
+       :version: 1
 
 
     .. std_req:: analysis_745
        :id: std_req__iso26262__analysis_745
        :status: valid
+       :version: 1
 
 
     .. std_req:: analysis_746
        :id: std_req__iso26262__analysis_746
        :status: valid
+       :version: 1
 
 
     .. std_req:: analysis_747
        :id: std_req__iso26262__analysis_747
        :status: valid
+       :version: 1
 
 
     .. std_req:: analysis_748
        :id: std_req__iso26262__analysis_748
        :status: valid
+       :version: 1
 
 
     .. std_req:: analysis_749
        :id: std_req__iso26262__analysis_749
        :status: valid
+       :version: 1
 
 
     .. std_req:: analysis_841
        :id: std_req__iso26262__analysis_841
        :status: valid
+       :version: 1
 
 
     .. std_req:: analysis_842
        :id: std_req__iso26262__analysis_842
        :status: valid
+       :version: 1
 
 
     .. std_req:: analysis_843
        :id: std_req__iso26262__analysis_843
        :status: valid
+       :version: 1
 
 
     .. std_req:: analysis_844
        :id: std_req__iso26262__analysis_844
        :status: valid
+       :version: 1
 
 
     .. std_req:: analysis_845
        :id: std_req__iso26262__analysis_845
        :status: valid
+       :version: 1
 
 
     .. std_req:: analysis_846
        :id: std_req__iso26262__analysis_846
        :status: valid
+       :version: 1
 
 
     .. std_req:: analysis_847
        :id: std_req__iso26262__analysis_847
        :status: valid
+       :version: 1
 
 
     .. std_req:: analysis_848
        :id: std_req__iso26262__analysis_848
        :status: valid
+       :version: 1
 
 
     .. std_req:: analysis_849
        :id: std_req__iso26262__analysis_849
        :status: valid
+       :version: 1
 
 
     .. std_req:: analysis_8410
        :id: std_req__iso26262__analysis_8410
        :status: valid
+       :version: 1
 
 
 * Workproducts
     .. std_wp:: analysis_551
        :id: std_wp__iso26262__analysis_551
        :status: valid
+       :version: 1
 
 
     .. std_wp:: analysis_552
        :id: std_wp__iso26262__analysis_552
        :status: valid
+       :version: 1
 
 
     .. std_wp:: analysis_651
        :id: std_wp__iso26262__analysis_651
        :status: valid
+       :version: 1
 
 
     .. std_wp:: analysis_751
        :id: std_wp__iso26262__analysis_751
        :status: valid
+       :version: 1
 
 
     .. std_wp:: analysis_752
        :id: std_wp__iso26262__analysis_752
        :status: valid
+       :version: 1
 
 
     .. std_wp:: analysis_851
        :id: std_wp__iso26262__analysis_851
        :status: valid
+       :version: 1
 
 
     .. std_wp:: analysis_852
        :id: std_wp__iso26262__analysis_852
        :status: valid
+       :version: 1
 
 
 .. note::

--- a/process/standards/isopas8926/isopas8926.rst
+++ b/process/standards/isopas8926/isopas8926.rst
@@ -21,180 +21,222 @@ ISO PAS 8926
     .. std_req:: Pas1
        :id: std_req__isopas8926__441
        :status: valid
+       :version: 1
 
     .. std_req:: Pas2
        :id: std_req__isopas8926__4421
        :status: valid
+       :version: 1
 
     .. std_req:: Pas3
        :id: std_req__isopas8926__4422
        :status: valid
+       :version: 1
 
     .. std_req:: Pas4
        :id: std_req__isopas8926__4423
        :status: valid
+       :version: 1
 
     .. std_req:: Pas5
        :id: std_req__isopas8926__4424
        :status: valid
+       :version: 1
 
     .. std_req:: Pas6
        :id: std_req__isopas8926__4425
        :status: valid
+       :version: 1
 
     .. std_req:: Pas7
        :id: std_req__isopas8926__4426
        :status: valid
+       :version: 1
 
     .. std_req:: Pas8
        :id: std_req__isopas8926__4427
        :status: valid
+       :version: 1
 
     .. std_req:: Pas9
        :id: std_req__isopas8926__4428
        :status: valid
+       :version: 1
 
     .. std_req:: Pas10
        :id: std_req__isopas8926__4429
        :status: valid
+       :version: 1
 
     .. std_req:: Pas11
        :id: std_req__isopas8926__44210
        :status: valid
+       :version: 1
 
     .. std_req:: Pas12
        :id: std_req__isopas8926__4431
        :status: valid
+       :version: 1
 
     .. std_req:: Pas13
        :id: std_req__isopas8926__44321
        :status: valid
+       :version: 1
 
     .. std_req:: Pas14
        :id: std_req__isopas8926__44322
        :status: valid
+       :version: 1
 
     .. std_req:: Pas19
        :id: std_req__isopas8926__4433
        :status: valid
+       :version: 1
 
     .. std_req:: Pas18
        :id: std_req__isopas8926__44341
        :status: valid
+       :version: 1
 
     .. std_req:: Pas17
        :id: std_req__isopas8926__44342
        :status: valid
+       :version: 1
 
     .. std_req:: Pas18
        :id: std_req__isopas8926__44411
        :status: valid
+       :version: 1
 
     .. std_req:: Pas19
        :id: std_req__isopas8926__44412
        :status: valid
+       :version: 1
 
     .. std_req:: Pas20
        :id: std_req__isopas8926__44421
        :status: valid
+       :version: 1
 
     .. std_req:: Pas21
        :id: std_req__isopas8926__44422
        :status: valid
+       :version: 1
 
     .. std_req:: Pas22
        :id: std_req__isopas8926__44423
        :status: valid
+       :version: 1
 
     .. std_req:: Pas23
        :id: std_req__isopas8926__44431
        :status: valid
+       :version: 1
 
     .. std_req:: Pas24
        :id: std_req__isopas8926__44432
        :status: valid
+       :version: 1
 
     .. std_req:: Pas25
        :id: std_req__isopas8926__44433
        :status: valid
+       :version: 1
 
     .. std_req:: Pas26
        :id: std_req__isopas8926__44441
        :status: valid
+       :version: 1
 
     .. std_req:: Pas27
        :id: std_req__isopas8926__44442
        :status: valid
+       :version: 1
 
     .. std_req:: Pas28
        :id: std_req__isopas8926__44443
        :status: valid
+       :version: 1
 
     .. std_req:: Pas29
        :id: std_req__isopas8926__445
        :status: valid
+       :version: 1
 
     .. std_req:: Pas30
        :id: std_req__isopas8926__44611
        :status: valid
+       :version: 1
 
     .. std_req:: Pas31
        :id: std_req__isopas8926__44612
        :status: valid
+       :version: 1
 
     .. std_req:: Pas32
        :id: std_req__isopas8926__4462
        :status: valid
+       :version: 1
 
     .. std_req:: Pas33
        :id: std_req__isopas8926__4463
        :status: valid
+       :version: 1
 
 
 * Workproducts:
     .. std_wp:: isopas8926__4511
        :id: std_wp__isopas8926__4511
        :status: valid
+       :version: 1
 
 
     .. std_wp:: isopas8926__4512
        :id: std_wp__isopas8926__4512
        :status: valid
+       :version: 1
 
 
     .. std_wp:: isopas8926__4521
        :id: std_wp__isopas8926__4521
        :status: valid
+       :version: 1
 
 
     .. std_wp:: isopas8926__4522
        :id: std_wp__isopas8926__4522
        :status: valid
+       :version: 1
 
 
     .. std_wp:: isopas8926__4523
        :id: std_wp__isopas8926__4523
        :status: valid
+       :version: 1
 
 
     .. std_wp:: isopas8926__4524
        :id: std_wp__isopas8926__4524
        :status: valid
+       :version: 1
 
 
     .. std_wp:: isopas8926__4525
        :id: std_wp__isopas8926__4525
        :status: valid
+       :version: 1
 
 
     .. std_wp:: isopas8926__4526
        :id: std_wp__isopas8926__4526
        :status: valid
+       :version: 1
 
 
     .. std_wp:: isopas8926__4527
        :id: std_wp__isopas8926__4527
        :status: valid
+       :version: 1
 
 
 

--- a/process/standards/isosae21434/isosae21434.rst
+++ b/process/standards/isosae21434/isosae21434.rst
@@ -50,60 +50,74 @@ Clause 5: Organizational cybersecurity management
     .. std_req:: org_management_5421
        :id: std_req__isosae21434__org_management_5421
        :status: valid
+       :version: 1
 
     .. std_req:: org_management_5422
        :id: std_req__isosae21434__org_management_5422
        :status: valid
+       :version: 1
 
     .. std_req:: org_management_5423
        :id: std_req__isosae21434__org_management_5423
        :status: valid
+       :version: 1
 
     .. std_req:: org_management_5441
        :id: std_req__isosae21434__org_management_5441
        :status: valid
+       :version: 1
 
     .. std_req:: org_management_5442
        :id: std_req__isosae21434__org_management_5442
        :status: valid
+       :version: 1
 
     .. std_req:: org_management_5443
        :id: std_req__isosae21434__org_management_5443
        :status: valid
+       :version: 1
 
     .. std_req:: org_management_5451
        :id: std_req__isosae21434__org_management_5451
        :status: valid
+       :version: 1
 
     .. std_req:: org_management_5452
        :id: std_req__isosae21434__org_management_5452
        :status: valid
+       :version: 1
 
     .. std_req:: org_management_5461
        :id: std_req__isosae21434__org_management_5461
        :status: valid
+       :version: 1
 
 
 * Work products
     .. std_wp:: org_management_551
        :id: std_wp__isosae21434__org_management_551
        :status: valid
+       :version: 1
 
     .. std_wp:: org_management_552
        :id: std_wp__isosae21434__org_management_552
        :status: valid
+       :version: 1
 
     .. std_wp:: org_management_553
        :id: std_wp__isosae21434__org_management_553
        :status: valid
+       :version: 1
 
     .. std_wp:: org_management_554
        :id: std_wp__isosae21434__org_management_554
        :status: valid
+       :version: 1
 
     .. std_wp:: org_management_555
        :id: std_wp__isosae21434__org_management_555
        :status: valid
+       :version: 1
 
 
 Clause 6: Project dependent cybersecurity management
@@ -113,120 +127,149 @@ Clause 6: Project dependent cybersecurity management
    .. std_req:: prj_management_6411
        :id: std_req__isosae21434__prj_management_6411
        :status: valid
+       :version: 1
 
    .. std_req:: prj_management_6421
        :id: std_req__isosae21434__prj_management_6421
        :status: valid
+       :version: 1
 
    .. std_req:: prj_management_6422
        :id: std_req__isosae21434__prj_management_6422
        :status: valid
+       :version: 1
 
    .. std_req:: prj_management_6423
        :id: std_req__isosae21434__prj_management_6423
        :status: valid
+       :version: 1
 
    .. std_req:: prj_management_6424
        :id: std_req__isosae21434__prj_management_6424
        :status: valid
+       :version: 1
 
    .. std_req:: prj_management_6425
        :id: std_req__isosae21434__prj_management_6425
        :status: valid
+       :version: 1
 
    .. std_req:: prj_management_6426
        :id: std_req__isosae21434__prj_management_6426
        :status: valid
+       :version: 1
 
    .. std_req:: prj_management_6427
        :id: std_req__isosae21434__prj_management_6427
        :status: valid
+       :version: 1
 
    .. std_req:: prj_management_6428
        :id: std_req__isosae21434__prj_management_6428
        :status: valid
+       :version: 1
 
    .. std_req:: prj_management_6429
        :id: std_req__isosae21434__prj_management_6429
        :status: valid
+       :version: 1
 
    .. std_req:: prj_management_64210
        :id: std_req__isosae21434__prj_management_64210
        :status: valid
+       :version: 1
 
    .. std_req:: prj_management_64211
        :id: std_req__isosae21434__prj_management_64211
        :status: valid
+       :version: 1
 
    .. std_req:: prj_management_6431
        :id: std_req__isosae21434__prj_management_6431
        :status: valid
+       :version: 1
 
    .. std_req:: prj_management_6432
        :id: std_req__isosae21434__prj_management_6432
        :status: valid
+       :version: 1
 
    .. std_req:: prj_management_6441
        :id: std_req__isosae21434__prj_management_6441
        :status: valid
+       :version: 1
 
    .. std_req:: prj_management_6442
        :id: std_req__isosae21434__prj_management_6442
        :status: valid
+       :version: 1
 
    .. std_req:: prj_management_6443
        :id: std_req__isosae21434__prj_management_6443
        :status: valid
+       :version: 1
 
    .. std_req:: prj_management_6451
        :id: std_req__isosae21434__prj_management_6451
        :status: valid
+       :version: 1
 
    .. std_req:: prj_management_6452
        :id: std_req__isosae21434__prj_management_6452
        :status: valid
+       :version: 1
 
    .. std_req:: prj_management_6453
        :id: std_req__isosae21434__prj_management_6453
        :status: valid
+       :version: 1
 
    .. std_req:: prj_management_6461
        :id: std_req__isosae21434__prj_management_6461
        :status: valid
+       :version: 1
 
    .. std_req:: prj_management_6462
        :id: std_req__isosae21434__prj_management_6462
        :status: valid
+       :version: 1
 
    .. std_req:: prj_management_6471
        :id: std_req__isosae21434__prj_management_6471
        :status: valid
+       :version: 1
 
    .. std_req:: prj_management_6491
        :id: std_req__isosae21434__prj_management_6491
        :status: valid
+       :version: 1
 
    .. std_req:: prj_management_6492
        :id: std_req__isosae21434__prj_management_6492
        :status: valid
+       :version: 1
 
 
 * Work products
     .. std_wp:: prj_management_651
        :id: std_wp__isosae21434__prj_management_651
        :status: valid
+       :version: 1
 
     .. std_wp:: prj_management_652
        :id: std_wp__isosae21434__prj_management_652
        :status: valid
+       :version: 1
 
     .. std_wp:: prj_management_653
        :id: std_wp__isosae21434__prj_management_653
        :status: valid
+       :version: 1
 
     .. std_wp:: prj_management_654
        :id: std_wp__isosae21434__prj_management_654
        :status: valid
+       :version: 1
 
 
 Clause 8: Continual cybersecurity activities
@@ -236,60 +279,74 @@ Clause 8: Continual cybersecurity activities
    .. std_req:: continual_8321
        :id: std_req__isosae21434__continual_8321
        :status: valid
+       :version: 1
 
    .. std_req:: continual_8322
        :id: std_req__isosae21434__continual_8322
        :status: valid
+       :version: 1
 
    .. std_req:: continual_8323
        :id: std_req__isosae21434__continual_8323
        :status: valid
+       :version: 1
 
    .. std_req:: continual_8421
        :id: std_req__isosae21434__continual_8421
        :status: valid
+       :version: 1
 
    .. std_req:: continual_8521
        :id: std_req__isosae21434__continual_8521
        :status: valid
+       :version: 1
 
    .. std_req:: continual_8522
        :id: std_req__isosae21434__continual_8522
        :status: valid
+       :version: 1
 
    .. std_req:: continual_8621
        :id: std_req__isosae21434__continual_8621
        :status: valid
+       :version: 1
 
    .. std_req:: continual_8622
        :id: std_req__isosae21434__continual_8622
        :status: valid
+       :version: 1
 
 
 * Work products
     .. std_wp:: continual_8331
        :id: std_wp__isosae21434__continual_8331
        :status: valid
+       :version: 1
 
     .. std_wp:: continual_8332
        :id: std_wp__isosae21434__continual_8332
        :status: valid
+       :version: 1
 
     .. std_wp:: continual_8333
        :id: std_wp__isosae21434__continual_8333
        :status: valid
+       :version: 1
 
     .. std_wp:: continual_8431
        :id: std_wp__isosae21434__continual_8431
        :status: valid
+       :version: 1
 
     .. std_wp:: continual_8531
        :id: std_wp__isosae21434__continual_8531
        :status: valid
+       :version: 1
 
     .. std_wp:: continual_8631
        :id: std_wp__isosae21434__continual_8631
        :status: valid
+       :version: 1
 
 
 Clause 10: Product development
@@ -299,84 +356,104 @@ Clause 10: Product development
    .. std_req:: development_10411
       :id: std_req__isosae21434__development_10411
       :status: valid
+      :version: 1
 
    .. std_req:: development_10412
       :id: std_req__isosae21434__development_10412
       :status: valid
+      :version: 1
 
    .. std_req:: development_10413
       :id: std_req__isosae21434__development_10413
       :status: valid
+      :version: 1
 
    .. std_req:: development_10414
       :id: std_req__isosae21434__development_10414
       :status: valid
+      :version: 1
 
    .. std_req:: development_10415
       :id: std_req__isosae21434__development_10415
       :status: valid
+      :version: 1
 
    .. std_req:: development_10416
       :id: std_req__isosae21434__development_10416
       :status: valid
+      :version: 1
 
    .. std_req:: development_10417
       :id: std_req__isosae21434__development_10417
       :status: valid
+      :version: 1
 
    .. std_req:: development_10418
       :id: std_req__isosae21434__development_10418
       :status: valid
+      :version: 1
 
    .. std_req:: development_10421
       :id: std_req__isosae21434__development_10421
       :status: valid
+      :version: 1
 
    .. std_req:: development_10422
       :id: std_req__isosae21434__development_10422
       :status: valid
+      :version: 1
 
    .. std_req:: development_10423
       :id: std_req__isosae21434__development_10423
       :status: valid
+      :version: 1
 
    .. std_req:: development_10424
       :id: std_req__isosae21434__development_10424
       :status: valid
+      :version: 1
 
    .. std_req:: development_10425
       :id: std_req__isosae21434__development_10425
       :status: valid
+      :version: 1
 
 
 * Work products
     .. std_wp:: development_1051
        :id: std_wp__isosae21434__development_1051
        :status: valid
+       :version: 1
 
     .. std_wp:: development_1052
        :id: std_wp__isosae21434__development_1052
        :status: valid
+       :version: 1
 
     .. std_wp:: development_1053
        :id: std_wp__isosae21434__development_1053
        :status: valid
+       :version: 1
 
     .. std_wp:: development_1054
        :id: std_wp__isosae21434__development_1054
        :status: valid
+       :version: 1
 
     .. std_wp:: development_1055
        :id: std_wp__isosae21434__development_1055
        :status: valid
+       :version: 1
 
     .. std_wp:: development_1056
        :id: std_wp__isosae21434__development_1056
        :status: valid
+       :version: 1
 
     .. std_wp:: development_1057
        :id: std_wp__isosae21434__development_1057
        :status: valid
+       :version: 1
 
 
 Clause 13: Operations and maintenance
@@ -386,20 +463,24 @@ Clause 13: Operations and maintenance
    .. std_req:: maintenance_13321
       :id: std_req__isosae21434__maintenance_13321
       :status: valid
+      :version: 1
 
    .. std_req:: maintenance_13322
       :id: std_req__isosae21434__maintenance_13322
       :status: valid
+      :version: 1
 
    .. std_req:: maintenance_13421
       :id: std_req__isosae21434__maintenance_13421
       :status: valid
+      :version: 1
 
 
 * Work products
     .. std_wp:: maintenance_13331
        :id: std_wp__isosae21434__maintenance_13331
        :status: valid
+       :version: 1
 
 
 Clause 15: Threat analysis and risk assessment methods
@@ -410,76 +491,94 @@ Clause 15: Threat analysis and risk assessment methods
    .. std_req:: assessment_15621
       :id: std_req__isosae21434__assessment_15621
       :status: valid
+      :version: 1
 
    .. std_req:: assessment_15622
       :id: std_req__isosae21434__assessment_15622
       :status: valid
+      :version: 1
 
    .. std_req:: assessment_15721
       :id: std_req__isosae21434__assessment_15721
       :status: valid
+      :version: 1
 
    .. std_req:: assessment_15722
       :id: std_req__isosae21434__assessment_15722
       :status: valid
+      :version: 1
 
    .. std_req:: assessment_15723
       :id: std_req__isosae21434__assessment_15723
       :status: valid
+      :version: 1
 
    .. std_req:: assessment_15724
       :id: std_req__isosae21434__assessment_15724
       :status: valid
+      :version: 1
 
    .. std_req:: assessment_15725
       :id: std_req__isosae21434__assessment_15725
       :status: valid
+      :version: 1
 
    .. std_req:: assessment_15821
       :id: std_req__isosae21434__assessment_15821
       :status: valid
+      :version: 1
 
    .. std_req:: assessment_15822
       :id: std_req__isosae21434__assessment_15822
       :status: valid
+      :version: 1
 
    .. std_req:: assessment_15921
       :id: std_req__isosae21434__assessment_15921
       :status: valid
+      :version: 1
 
 
 * Work products
     .. std_wp:: assessment_15331
        :id: std_wp__isosae21434__assessment_15331
        :status: valid
+       :version: 1
 
     .. std_wp:: assessment_15332
        :id: std_wp__isosae21434__assessment_15332
        :status: valid
+       :version: 1
 
     .. std_wp:: assessment_15431
        :id: std_wp__isosae21434__assessment_15431
        :status: valid
+       :version: 1
 
     .. std_wp:: assessment_15531
        :id: std_wp__isosae21434__assessment_15531
        :status: valid
+       :version: 1
 
     .. std_wp:: assessment_15631
        :id: std_wp__isosae21434__assessment_15631
        :status: valid
+       :version: 1
 
     .. std_wp:: assessment_15731
        :id: std_wp__isosae21434__assessment_15731
        :status: valid
+       :version: 1
 
     .. std_wp:: assessment_15831
        :id: std_wp__isosae21434__assessment_15831
        :status: valid
+       :version: 1
 
     .. std_wp:: assessment_15931
        :id: std_wp__isosae21434__assessment_15931
        :status: valid
+       :version: 1
 
 
 .. note::

--- a/process/trustable/assertions/assertions.rst
+++ b/process/trustable/assertions/assertions.rst
@@ -21,6 +21,7 @@ Assertions
 .. assertion:: TA-SUPPLY-CHAIN
    :id: assertion__trust__ta-supply-chain
    :status: valid
+   :version: 1
 
    All sources for XYZ and tools are mirrored in our controlled environment
 
@@ -75,6 +76,7 @@ Assertions
 .. assertion:: TA-INPUTS
    :id: assertion__trust__ta-inputs
    :status: valid
+   :version: 1
 
    Components and tools used to construct and verify XYZ are assessed, to identify
    potential risks and issues
@@ -157,6 +159,7 @@ Assertions
 .. assertion:: TA-TESTS
    :id: assertion__trust__ta-tests
    :status: valid
+   :version: 1
 
    All tests for XYZ, and its build and test environments, are constructed from
    controlled/mirrored sources and are reproducible, with any exceptions documented
@@ -205,6 +208,7 @@ Assertions
 .. assertion:: TA-RELEASES
    :id: assertion__trust__ta-releases
    :status: valid
+   :version: 1
 
    Construction of XYZ releases is fully repeatable and the results are fully
    reproducible, with any exceptions documented and justified.
@@ -267,6 +271,7 @@ Assertions
 .. assertion:: TA-ITERATIONS
    :id: assertion__trust__ta-iterations
    :status: valid
+   :version: 1
 
    All constructed iterations of XYZ include source code, build instructions,
    tests, results and attestations.
@@ -311,6 +316,7 @@ Assertions
 .. assertion:: TA-FIXES
    :id: assertion__trust__ta-fixes
    :status: valid
+   :version: 1
 
    Known bugs or misbehaviours are analysed and triaged, and critical fixes or
    mitigations are implemented or applied.
@@ -381,6 +387,7 @@ Assertions
 .. assertion:: TA-UPDATES
    :id: assertion__trust__ta-updates
    :status: valid
+   :version: 1
 
    XYZ components, configurations and tools are updated under specified change and
    configuration management controls.
@@ -413,6 +420,7 @@ Assertions
 .. assertion:: TA-BEHAVIOURS
    :id: assertion__trust__ta-behaviours
    :status: valid
+   :version: 1
 
    Expected or required behaviours for XYZ are identified, specified, verified and
    validated based on analysis.
@@ -467,6 +475,7 @@ Assertions
 .. assertion:: TA-MISBEHAVIOURS
    :id: assertion__trust__ta-misbehaviours
    :status: valid
+   :version: 1
 
    Prohibited misbehaviours for XYZ are identified, and mitigations are specified,
    verified and validated based on analysis.
@@ -565,6 +574,7 @@ Assertions
 .. assertion:: TA-INDICATORS
    :id: assertion__trust__ta-indicators
    :status: valid
+   :version: 1
 
    Advance warning indicators for misbehaviours are identified, and monitoring
    mechanisms are specified, verified and validated based on analysis.
@@ -646,6 +656,7 @@ Assertions
 .. assertion:: TA-CONSTRAINTS
    :id: assertion__trust__ta-constraints
    :status: valid
+   :version: 1
 
    Constraints on adaptation and deployment of XYZ are specified.
 
@@ -706,6 +717,7 @@ Assertions
 .. assertion:: TA-VALIDATION
    :id: assertion__trust__ta-validation
    :status: valid
+   :version: 1
 
    All specified tests are executed repeatedly, under defined conditions in
    controlled environments, according to specified objectives.
@@ -746,6 +758,7 @@ Assertions
 .. assertion:: TA-DATA
    :id: assertion__trust__ta-data
    :status: valid
+   :version: 1
 
    Data is collected from tests, and from monitoring of deployed software,
    according to specified objectives.
@@ -787,6 +800,7 @@ Assertions
 .. assertion:: TA-ANALYSIS
    :id: assertion__trust__ta-analysis
    :status: valid
+   :version: 1
 
    Collected data from tests and monitoring of deployed software is analysed
    according to specified objectives.
@@ -839,6 +853,7 @@ Assertions
 .. assertion:: TA-METHODOLOGIES
    :id: assertion__trust__ta-methodologies
    :status: valid
+   :version: 1
 
    Manual methodologies applied for XYZ by contributors, and their results, are
    managed according to specified objectives.
@@ -886,6 +901,7 @@ Assertions
 .. assertion:: TA-CONFIDENCE
    :id: assertion__trust__ta-confidence
    :status: valid
+   :version: 1
 
    Confidence in XYZ is measured based on results of analysis
 

--- a/process/trustable/index.rst
+++ b/process/trustable/index.rst
@@ -48,7 +48,13 @@ To calculate the score link evidences to the Trustable Assertions (TA).
 .. tsf:: TRUSTABLE SOFTWARE
    :id: tsf__trust__trustable-software
    :status: valid
-   :links: tenet__trust__tt-provenance, tenet__trust__tt-construction, tenet__trust__tt-changes, tenet__trust__tt-expectations, tenet__trust__tt-results, tenet__trust__tt-confidence
+   :version: 1
+   :links: tenet__trust__tt-provenance[version==1],
+           tenet__trust__tt-construction[version==1],
+           tenet__trust__tt-changes[version==1],
+           tenet__trust__tt-expectations[version==1],
+           tenet__trust__tt-results[version==1],
+           tenet__trust__tt-confidence[version==1]
 
     This release of XYZ is Trustable.
 

--- a/process/trustable/tenets/tenets.rst
+++ b/process/trustable/tenets/tenets.rst
@@ -21,7 +21,8 @@ Tenets
 .. tenet:: TT-PROVENANCE
    :id: tenet__trust__tt-provenance
    :status: valid
-   :links: assertion__trust__ta-supply-chain, assertion__trust__ta-inputs
+   :version: 1
+   :links: assertion__trust__ta-supply-chain[version==1], assertion__trust__ta-inputs[version==1]
 
    All source code (and attestations for claims) for XYZ are provided with
    known provenance.
@@ -57,7 +58,8 @@ Tenets
 .. tenet:: TT-CONSTRUCTION
    :id: tenet__trust__tt-construction
    :status: valid
-   :links: assertion__trust__ta-tests, assertion__trust__ta-releases, assertion__trust__ta-iterations
+   :version: 1
+   :links: assertion__trust__ta-tests[version==1], assertion__trust__ta-releases[version==1], assertion__trust__ta-iterations[version==1]
 
    Tools are provided to build XYZ from trusted sources (also provided) with
    full reproducibility.
@@ -88,7 +90,8 @@ Tenets
 .. tenet:: TT-CHANGES
    :id: tenet__trust__tt-changes
    :status: valid
-   :links: assertion__trust__ta-fixes, assertion__trust__ta-updates
+   :version: 1
+   :links: assertion__trust__ta-fixes[version==1], assertion__trust__ta-updates[version==1]
 
    XYZ is actively maintained, with regular updates to dependencies, and changes
    are verified to prevent regressions.
@@ -121,7 +124,11 @@ Tenets
 .. tenet:: TT-EXPECTATIONS
    :id: tenet__trust__tt-expectations
    :status: valid
-   :links: assertion__trust__ta-behaviours, assertion__trust__ta-misbehaviours, assertion__trust__ta-indicators, assertion__trust__ta-constraints
+   :version: 1
+   :links: assertion__trust__ta-behaviours[version==1],
+           assertion__trust__ta-misbehaviours[version==1],
+           assertion__trust__ta-indicators[version==1],
+           assertion__trust__ta-constraints[version==1]
 
    Documentation is provided, specifying what XYZ is expected to do, and what
    it must not do, and how this is verified.
@@ -150,7 +157,8 @@ Tenets
 .. tenet:: TT-RESULTS
    :id: tenet__trust__tt-results
    :status: valid
-   :links: assertion__trust__ta-validation, assertion__trust__ta-data, assertion__trust__ta-analysis
+   :version: 1
+   :links: assertion__trust__ta-validation[version==1], assertion__trust__ta-data[version==1], assertion__trust__ta-analysis[version==1]
 
    Evidence is provided to demonstrate that XYZ does what it is supposed to
    do, and does not do what it must not do.
@@ -175,7 +183,8 @@ Tenets
 .. tenet:: TT-CONFIDENCE
    :id: tenet__trust__tt-confidence
    :status: valid
-   :links: assertion__trust__ta-methodologies, assertion__trust__ta-confidence
+   :version: 1
+   :links: assertion__trust__ta-methodologies[version==1], assertion__trust__ta-confidence[version==1]
 
    Confidence in XYZ is measured by analysing actual performance in tests and in
    production.


### PR DESCRIPTION
* Added :version: 1 after every :status: line in all 1258 need directive blocks
* Appended [version==1] to every ID in all cross-link fields (complies, satisfies, links, contains, responsible, output, input, approved_by, has, supported_by, realizes)
* Reformatted fields with ≥ 4 IDs to one-per-line continuation style (239 fields reformatted)
* Applied transforms inside code-block:: zones too as much as possible (e.g., the template examples in process_management_templates.rst)


Note: this needs to be merged and released together with docs-as-code https://github.com/eclipse-score/docs-as-code/pull/599, as there is a circular dependency. Metamodel there, examples/application here, docs-as-code is based on requirements, requirements are based on docs-as-code.

Resolves https://github.com/eclipse-score/process_description/issues/706