### PR TITLE
upgrade docs-as-code version 4.5.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -41,9 +41,4 @@ python.toolchain(
 # Documentation tooling
 #
 ###############################################################################
-bazel_dep(name = "score_docs_as_code", version = "4.4.1")
-git_override(
-    module_name = "score_docs_as_code",
-    commit = "4090f017f935899b15ea3d0b2649b359ee6a72d8",
-    remote = "https://github.com/eclipse-score/docs-as-code.git",
-)
+bazel_dep(name = "score_docs_as_code", version = "4.5.0")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -286,6 +286,8 @@
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/rules_shell/0.4.1/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/score_devcontainer/1.7.0/MODULE.bazel": "f9a5971fbd05f0ed14e7a373dbf58af72a5c58d081537a75c314daaf61c92ae9",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/score_devcontainer/1.7.0/source.json": "a3f55522fd9f63fae7a92f3cb5f91c25ae7474a39e9f9c633f0cf797fc0ca8e5",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/score_docs_as_code/4.5.0/MODULE.bazel": "4cfe52fe8b8dbeaf7e87500036391da278f72f1c2b41b689ffdd4337196dd8fe",
+    "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/score_docs_as_code/4.5.0/source.json": "e01b29a3e9640a0d41d880d7da525e451115649d90f097ed66d09808c9135486",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/stardoc/0.5.1/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/stardoc/0.5.3/MODULE.bazel": "not found",
     "https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/modules/stardoc/0.5.6/MODULE.bazel": "not found",


### PR DESCRIPTION
switch to clean release of docs-as-code

Note: docs-as-code 4.5.0 is based on process 1.6.0