### PR TITLE
Set verification process to ML2

### DIFF
--- a/process/index.rst
+++ b/process/index.rst
@@ -148,7 +148,7 @@ Development
       Develop and unit-test software units according to the design.
 
    .. grid-item-card::
-      :class-card: card-ml1
+      :class-card: card-ml2
 
       :ref:`Verification <process_verification>`
       ^^^


### PR DESCRIPTION
After all findings from audit have been implemented in the process description and the verification plan in the score main repository is updated the maturity level can be set to ML2.

Requires following PRs to be merged before:
- [x] https://github.com/eclipse-score/process_description/pull/719
- [x] https://github.com/eclipse-score/score/pull/3022


Closes: #681