### PR TITLE
fix one link and update some requirements automation status

### DIFF
--- a/process/process_areas/architecture_design/guidance/architecture_process_reqs.rst
+++ b/process/process_areas/architecture_design/guidance/architecture_process_reqs.rst
@@ -227,7 +227,7 @@ Checks for Architectural Design
    :id: gd_req__arch_attr_mandatory
    :status: valid
    :version: 1
-   :tags: prio_1_automation, attribute, check
+   :tags: done_automation, attribute, check
    :satisfies: wf__cr_mt_featarch[version==1], wf__cr_mt_comparch[version==1]
 
    It shall be checked if all mandatory attributes for each architectural element are provided by the user. For all elements following attributes shall be mandatory:
@@ -262,7 +262,7 @@ Checks for Architectural Design
    :id: gd_req__arch_linkage_security_trace
    :status: valid
    :version: 1
-   :tags: prio_2_automation, attribute, check
+   :tags: done_automation, attribute, check
    :satisfies: wf__cr_mt_featarch[version==1], wf__cr_mt_comparch[version==1]
 
    It shall be checked that security relevant architectural elements (Security==YES) can only be linked against security relevant architectural elements.
@@ -271,7 +271,7 @@ Checks for Architectural Design
    :id: gd_req__arch_linkage_requirement
    :status: valid
    :version: 1
-   :tags: prio_1_automation, attribute, check
+   :tags: done_automation, attribute, check
    :satisfies: wf__cr_mt_featarch[version==1], wf__cr_mt_comparch[version==1]
 
    It shall be checked that each architectural element (safety!=QM) is linked against at least one safety requirement (safety!=QM).

--- a/process/process_areas/architecture_design/guidance/component_architecture_template.rst
+++ b/process/process_areas/architecture_design/guidance/component_architecture_template.rst
@@ -27,4 +27,4 @@ Component Architecture Template
               std_req__aspice_40__iic-04-04[version==1]
 
    For the content see the
-   `module template documentation <https://eclipse-score.github.io/module_template/component_architecture_template.html>`__.
+   `module template documentation <https://eclipse-score.github.io/module_template/main/score/component_example/docs/architecture/component_architecture.html>`__.


### PR DESCRIPTION
This pull request updates the architectural design process guidance by marking several requirements as automated and updates a documentation link in the component architecture template.

Process guidance updates:

* Updated the `:tags:` field from `prio_1_automation` or `prio_2_automation` to `done_automation` for the following requirements in `architecture_process_reqs.rst`, indicating their automation is complete:
  * Mandatory attribute checks for architectural elements (`gd_req__arch_attr_mandatory`)
  * Security linkage checks for architectural elements (`gd_req__arch_linkage_security_trace`)
  * Requirement linkage checks for safety-related architectural elements (`gd_req__arch_linkage_requirement`)

Documentation update:

* Updated the module template documentation link in `component_architecture_template.rst` to point to the new component architecture documentation location.