### PR TITLE
Improvment: Align Safety Analysis Process Requirements

### DIFF
--- a/process/process_areas/safety_analysis/guidance/safety_analysis_process_reqs.rst
+++ b/process/process_areas/safety_analysis/guidance/safety_analysis_process_reqs.rst
@@ -187,13 +187,8 @@ Safety Analysis Linkage
    :complies: std_req__iso26262__analysis_842[version==1], std_req__iso26262__software_7410[version==1], std_req__iso26262__software_7411[version==1]
 
    Each Safety Analysis shall be automatically linked (inverse direction) to the corresponding architecture view via
-   the "violates by" linkage. The following linkages are defined in detail:
-   
-       * plat_saf_dfa <-> feat_arc_sta
-       * feat_saf_dfa <-> feat_arc_sta
-       * feat_saf_dfa <-> comp_arc_sta
-       * feat_saf_fmea <-> feat_arc_dyn, feat_arc_sta
-       * comp_saf_fmea <-> comp_arc_dyn, comp_arc_sta
+   the "violates by" linkage. The linkages are defined in detail at :need:`gd_req__saf_linkage_check`.
+
 
 .. gd_req:: Safety Analysis attribute: check Requirements linkage
    :id: gd_req__saf_attr_requirements_check

--- a/process/process_areas/safety_analysis/guidance/safety_analysis_process_reqs.rst
+++ b/process/process_areas/safety_analysis/guidance/safety_analysis_process_reqs.rst
@@ -170,6 +170,13 @@ Safety Analysis Linkage
    :complies: std_req__iso26262__analysis_842[version==1], std_req__iso26262__software_7410[version==1], std_req__iso26262__software_7411[version==1]
 
    Safety Analysis shall be linked to the architecture view on the corresponding level via the attribute violates.
+   The following linkages are defined in detail:
+
+       * plat_saf_dfa <-> feat_arc_sta
+       * feat_saf_dfa <-> feat_arc_sta
+       * feat_saf_dfa <-> comp_arc_sta
+       * feat_saf_fmea <-> feat_arc_dyn, feat_arc_sta
+       * comp_saf_fmea <-> comp_arc_dyn, comp_arc_sta
 
 .. gd_req:: Safety Analysis Linkage
    :id: gd_req__saf_linkage
@@ -179,7 +186,14 @@ Safety Analysis Linkage
    :satisfies: wf__analyse_platform_featarch[version==1], wf__analyse_featarch[version==1], wf__analyse_comparch[version==1]
    :complies: std_req__iso26262__analysis_842[version==1], std_req__iso26262__software_7410[version==1], std_req__iso26262__software_7411[version==1]
 
-   Each Safety Analysis shall be automatically linked (inverse direction) to the corresponding architecture view via the "violates by" linkage.
+   Each Safety Analysis shall be automatically linked (inverse direction) to the corresponding architecture view via
+   the "violates by" linkage. The following linkages are defined in detail:
+   
+       * plat_saf_dfa <-> feat_arc_sta
+       * feat_saf_dfa <-> feat_arc_sta
+       * feat_saf_dfa <-> comp_arc_sta
+       * feat_saf_fmea <-> feat_arc_dyn, feat_arc_sta
+       * comp_saf_fmea <-> comp_arc_dyn, comp_arc_sta
 
 .. gd_req:: Safety Analysis attribute: check Requirements linkage
    :id: gd_req__saf_attr_requirements_check


### PR DESCRIPTION
Aligned gd_req__saf_linkage_check and gd_req__sec_linkage_check witch [gd_req__saf_linkage_check](https://eclipse-score.github.io/process_description//main/process_areas/safety_analysis/guidance/safety_analysis_process_reqs.html#gd_req__saf_linkage_check).

Only the content description has changed. Implementation in docs-as-code is at it was, so versions will kept.