### PR TITLE
fix(ci): trigger docs build on release published instead of created

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,7 @@ on:
     branches:
       - main
   release:
-    types: [created]
+    types: [published]
   merge_group:
     types: [checks_requested]
 


### PR DESCRIPTION
Draft releases do not fire workflow events. Since all releases are created as drafts first, the 'created' type never triggers a build. The 'published' type fires when the draft is made public.