### PR TITLE
Fix: Add versions where missing

### DIFF
--- a/process/process_areas/architecture_design/guidance/architecture_process_reqs.rst
+++ b/process/process_areas/architecture_design/guidance/architecture_process_reqs.rst
@@ -348,6 +348,7 @@ Process Monitoring and Improvement
 .. gd_req:: Monitor architecture process performance
    :id: gd_req__arch_process_monitoring
    :status: valid
+   :version: 1
    :tags: manual_prio_2, process_monitoring
    :complies: std_req__aspice_40__gp-324, std_req__aspice_40__iic-03-06
    :satisfies: wf__cr_mt_featarch, wf__cr_mt_comparch

--- a/process/release_notes/release_note_v_2_0_0.rst
+++ b/process/release_notes/release_note_v_2_0_0.rst
@@ -20,6 +20,7 @@ Release Note v2.0.0
    :status: valid
    :safety: ASIL_B
    :security: YES
+   :version: 1
    :realizes: wp__module_sw_release_note
    :tags:
 

--- a/process/release_notes/release_note_v_2_0_1.rst
+++ b/process/release_notes/release_note_v_2_0_1.rst
@@ -19,6 +19,7 @@ Release Note v2.0.1
    :id: doc__process_description_release_note_v201
    :status: valid
    :safety: ASIL_B
+   :version: 1
    :security: YES
    :realizes: wp__module_sw_release_note
    :tags:


### PR DESCRIPTION
These 3 needs objects were missing the `version` I added that now to them as in future DaC releases this is mandatory.