### PR TITLE
Bug: Link to static code analysis

### DIFF
--- a/process/process_areas/verification/guidance/verification_methods.rst
+++ b/process/process_areas/verification/guidance/verification_methods.rst
@@ -34,6 +34,7 @@ Methods
    * :ref:`Fault Injection <ver_fault>`
    * :ref:`Interface Test <ver_interface>`
    * :ref:`Structural Coverage <ver_structural>`
+   * :ref:`Static Code Analysis <ver_sta>`
 
 .. _ver_fault:
 

--- a/process/process_areas/verification/guidance/verification_plan_template.rst
+++ b/process/process_areas/verification/guidance/verification_plan_template.rst
@@ -33,7 +33,8 @@ Verification Plan Template
                std_req__aspice_40__SWE-5-BP2[version==1],
                std_req__aspice_40__SWE-6-BP2[version==1],
                std_req__aspice_40__SWE-5-BP3[version==1],
-               std_req__aspice_40__iic-06-50[version==1]
+               std_req__aspice_40__iic-06-50[version==1],
+               std_req__iso26262__software_942[version==1]
 
     This document implements :need:`wp__verification_plan`.
 


### PR DESCRIPTION
The link to the standard requirement which asks for static code analysis did not match completely to where we defined this type of verification.