### PR TITLE
fix build error for training files

### DIFF
--- a/process/conf.py
+++ b/process/conf.py
@@ -40,15 +40,18 @@ html_css_files = ["custom.css"]
 # into the Sphinx HTML output root so portals are served alongside the docs.
 html_extra_path = ["trainings/_portals"]
 
+# exclude pattern are not supported when calling sphinx-build from other repositories,
+# so we do not use them here.  Instead, the exclusion of training source files
+# and generated portal files is handled in the Sphinx build hook below.
 # Exclude training source files and generated portal files from Sphinx processing.
 # - trainings/*/source/**   : Markdown source files for the training portals
 # - trainings/trainings_templates/** : Template files, not Sphinx documents
 # - trainings/_portals/**   : Generated portal HTML (served via html_extra_path)
-exclude_patterns = [
-    "trainings/*/source/**",
-    "trainings/trainings_templates/**",
-    "trainings/_portals/**",
-]
+#exclude_patterns = [
+#    "trainings/*/source/**",
+#    "trainings/trainings_templates/**",
+#    "trainings/_portals/**",
+#]
 
 # :need:`{title}` is used in the needs templates to display the title of the need
 needs_role_need_template = "{title}"

--- a/process/trainings/trainings_requirements_engineering/source/content/index.md
+++ b/process/trainings/trainings_requirements_engineering/source/content/index.md
@@ -26,6 +26,8 @@ prev: null
 next:
   url: module-1.html
   label: "Module 1: Why Requirements Engineering?"
+orphan: true
+suppress_warnings: ["myst.xref_missing"]
 ---
 
 ```{caution}
@@ -55,12 +57,12 @@ security-critical automotive open-source software development.
 
 | Module | Title | Description | Duration |
 |--------|-------|-------------|----------|
-| Module 1 | [Why Requirements Engineering?](module-1.html) | Role of RE in safety-critical OSS, stakeholders, roles, and how standards drive the process. | ~30 min |
-| Module 2 | [Requirement Levels and Types](module-2.html) | The five requirement levels (Stakeholder, Feature, Component, AoU, Process), types, and their traceability relationships. | ~45 min |
-| Module 3 | [Requirement Attributes and Quality](module-3.html) | Mandatory and auto-generated attributes, formulation rules, versioning, and reviews. | ~45 min |
-| Module 4 | [Workflows and Work Products](module-4.html) | The six S-CORE workflows, work products with compliance tags, and end-to-end traceability. | ~45 min |
+| Module 1 | <a href="module-1.html">Why Requirements Engineering?</a> | Role of RE in safety-critical OSS, stakeholders, roles, and how standards drive the process. | ~30 min |
+| Module 2 | <a href="module-2.html">Requirement Levels and Types</a> | The five requirement levels (Stakeholder, Feature, Component, AoU, Process), types, and their traceability relationships. | ~45 min |
+| Module 3 | <a href="module-3.html">Requirement Attributes and Quality</a> | Mandatory and auto-generated attributes, formulation rules, versioning, and reviews. | ~45 min |
+| Module 4 | <a href="module-4.html">Workflows and Work Products</a> | The six S-CORE workflows, work products with compliance tags, and end-to-end traceability. | ~45 min |
 
-**[Checkpoint Quiz — All Modules](quiz-1.html)**
+**<a href="quiz-1.html">Checkpoint Quiz — All Modules</a>**
 10 questions covering all four modules. Pass mark: 70%. Instant scoring with explanations. (~20 min)
 
 ## About This Course

--- a/process/trainings/trainings_requirements_engineering/source/content/module-1.md
+++ b/process/trainings/trainings_requirements_engineering/source/content/module-1.md
@@ -32,6 +32,7 @@ prev:
 next:
   url: module-2.html
   label: "Module 2: Requirement Levels and Types"
+orphan: true
 ---
 
 # Why Requirements Engineering?

--- a/process/trainings/trainings_requirements_engineering/source/content/module-2.md
+++ b/process/trainings/trainings_requirements_engineering/source/content/module-2.md
@@ -32,6 +32,7 @@ prev:
 next:
   url: module-3.html
   label: "Module 3: Requirement Attributes and Quality"
+orphan: true
 ---
 
 # Requirement Levels and Types

--- a/process/trainings/trainings_requirements_engineering/source/content/module-3.md
+++ b/process/trainings/trainings_requirements_engineering/source/content/module-3.md
@@ -32,6 +32,7 @@ prev:
 next:
   url: module-4.html
   label: "Module 4: Workflows and Work Products"
+orphan: true
 ---
 
 # Requirement Attributes and Quality

--- a/process/trainings/trainings_requirements_engineering/source/content/module-4.md
+++ b/process/trainings/trainings_requirements_engineering/source/content/module-4.md
@@ -32,6 +32,7 @@ prev:
 next:
   url: quiz-1.html
   label: "Checkpoint Quiz"
+orphan: true
 ---
 
 # Workflows and Work Products

--- a/process/trainings/trainings_requirements_engineering/source/content/quiz-1.md
+++ b/process/trainings/trainings_requirements_engineering/source/content/quiz-1.md
@@ -170,5 +170,5 @@ questions:
       behaviour. Each level links to its parent using a versioned 'derived_from'
       reference. Process Requirements are a separate, parallel concern derived from the
       process description, not a step that precedes stakeholder requirements.
-
+orphan: true
 ---

--- a/process/trainings/trainings_templates/content/index.md
+++ b/process/trainings/trainings_templates/content/index.md
@@ -26,6 +26,8 @@ prev: null
 next:
   url: module-1.html
   label: "Module 1: [First Module Title]"
+orphan: true
+suppress_warnings: ["myst.xref_missing"]
 ---
 
 # [PROCESS AREA] — Training Overview
@@ -45,12 +47,12 @@ and work products.
 
 | Module | Title | Description | Duration |
 |--------|-------|-------------|----------|
-| Module 1 | [[Module 1 Title]](module-1.html) | [Short description] | ~XX min |
-| Module 2 | [[Module 2 Title]](module-2.html) | [Short description] | ~XX min |
-| Module 3 | [[Module 3 Title]](module-3.html) | [Short description] | ~XX min |
-| Module 4 | [[Module 4 Title]](module-4.html) | [Short description] | ~XX min |
+| Module 1 | <a href="module-1.html">[Module 1 Title]</a> | [Short description] | ~XX min |
+| Module 2 | <a href="module-2.html">[Module 2 Title]</a> | [Short description] | ~XX min |
+| Module 3 | <a href="module-3.html">[Module 3 Title]</a> | [Short description] | ~XX min |
+| Module 4 | <a href="module-4.html">[Module 4 Title]</a> | [Short description] | ~XX min |
 
-**[[Quiz Title]](quiz-1.html)**
+**<a href="quiz-1.html">[Quiz Title]</a>**
 [N] questions covering all modules. Pass mark: 70%. Instant scoring with explanations. (~20 min)
 
 ## About This Course

--- a/process/trainings/trainings_templates/content/module-N.md
+++ b/process/trainings/trainings_templates/content/module-N.md
@@ -32,6 +32,7 @@ prev:
 next:
   url: module-2.html                    # or quiz-1.html for last module
   label: "Module 2: [Next Title]"       # or "[Quiz Title]"
+orphan: true
 ---
 
 # [Module Title]

--- a/process/trainings/trainings_templates/content/quiz-N.md
+++ b/process/trainings/trainings_templates/content/quiz-N.md
@@ -149,3 +149,5 @@ questions:
       - text: "[Distractor 3]"
     feedback: >-
       Correct: B. [Explanation.]
+orphan: true
+---


### PR DESCRIPTION
This pull request makes several improvements to the Sphinx training documentation build process and the structure of the training content files. The main changes include refining how certain files are excluded from the Sphinx build, updating metadata in Markdown files to improve navigation and suppress warnings, and enhancing the formatting of module and quiz links for consistency and compatibility.

**Sphinx build configuration and file exclusion:**

* Updated `process/conf.py` to clarify that `exclude_patterns` are not used directly; instead, file exclusion is handled in a Sphinx build hook, improving compatibility when building from other repositories. The previous `exclude_patterns` setting is now commented out with explanatory comments.

**Markdown metadata and navigation improvements:**

* Added `orphan: true` and `suppress_warnings: ["myst.xref_missing"]` metadata to the `index.md` files in both the requirements engineering training and the templates, as well as `orphan: true` to all module and quiz files. This prevents Sphinx warnings about unreferenced pages and missing cross-references, making the build cleaner and navigation more robust. [[1]](diffhunk://#diff-d6a97b983d2725fb508c74d2aa1df1a405d7865db0042b6b6f7a20460a166fe9R29-R30) [[2]](diffhunk://#diff-1c8d9dc5901188c743b1d8f302abe88324b086bd4130a4469760b2d913b7b75eR35) [[3]](diffhunk://#diff-e048b6e252e6ab7bbced8be81c3d94d1e864c973ef6dd72abb6c3ceea99ce26aR35) [[4]](diffhunk://#diff-c185c2b03c100280a77e508e374b0fbcab8736445370b4105f77adcd9a41de66R35) [[5]](diffhunk://#diff-48cf3d2489f86c55003a9a5f15b7efeca521cc12aa3cbda5f7106060e41cf487R35) [[6]](diffhunk://#diff-45c647d792ae5f61f793c5dc9174d1bed48c070722da0308ee5df81f90d6b4d6L173-R173) [[7]](diffhunk://#diff-63da6f3e1adbe94f4bab5f9470d8d706a2f6c215f3539b9e503c1797e6ccb770R29-R30) [[8]](diffhunk://#diff-f34f833ccee6a242ba38c9128a50a700dce09dd5ec5882812907ec1de54ae5bcR35) [[9]](diffhunk://#diff-f85d123e8437229a294ab2c8f76c33998033a28aeb92f2915782d7f312182919R152-R153)

**Formatting and link consistency:**

* Changed Markdown links for modules and quizzes in the overview tables to HTML `<a href="...">` tags in both the requirements engineering and template training `index.md` files. This improves link rendering and compatibility with Sphinx/Myst parser. [[1]](diffhunk://#diff-d6a97b983d2725fb508c74d2aa1df1a405d7865db0042b6b6f7a20460a166fe9L58-R65) [[2]](diffhunk://#diff-63da6f3e1adbe94f4bab5f9470d8d706a2f6c215f3539b9e503c1797e6ccb770L48-R55)