### PR TITLE
update most needextend directives to affect only the current file

### DIFF
--- a/process/process_areas/change_management/change_management_workflow.rst
+++ b/process/process_areas/change_management/change_management_workflow.rst
@@ -153,7 +153,7 @@ For a detailed explanation of workflows and their role within the process model,
 
    Otherwise the responsible teams keeps the status "in implementation".
 
-.. needextend:: docname is not None and "process_areas/change_management" in docname
+.. needextend:: "c.this_doc()"
    :+tags: change_management
 
 RAS(IC) for Change Management:

--- a/process/process_areas/change_management/guidance/change_management_reqs.rst
+++ b/process/process_areas/change_management/guidance/change_management_reqs.rst
@@ -280,5 +280,5 @@ Change Request Traceability Impact Analysis Tool
       :align: center
       :alt: How to follow changes for impact analysis iteratively.
 
-.. needextend:: docname is not None and "process_areas/change_management" in docname
+.. needextend:: "c.this_doc()"
    :+tags: change_management

--- a/process/process_areas/change_management/index.rst
+++ b/process/process_areas/change_management/index.rst
@@ -28,5 +28,5 @@ Change Management
    change_management_workflow
    change_management_workproducts
 
-.. needextend:: docname is not None and "process_areas/change_management" in docname
+.. needextend:: "c.this_doc()"
    :+tags: change_management

--- a/process/process_areas/implementation/guidance/implementation_process_reqs.rst
+++ b/process/process_areas/implementation/guidance/implementation_process_reqs.rst
@@ -194,7 +194,7 @@ Dependency Analysis
    It shall show the libraries used by the component (i.e. which libraries are linked to the component,
    defined as CI build tool target) up to the leaves of the tree.
 
-.. needextend:: docname is not None and "process_areas/implementation" in docname
+.. needextend:: "c.this_doc()"
    :+tags: implementation
 
 .. _impl_process_requirements_complexity:

--- a/process/process_areas/implementation/index.rst
+++ b/process/process_areas/implementation/index.rst
@@ -27,5 +27,5 @@ Implementation
    implementation_workflow
    implementation_workproducts
 
-.. needextend:: docname is not None and "process_areas/implementation" in docname
+.. needextend:: "c.this_doc()"
    :+tags: implementation

--- a/process/process_areas/problem_resolution/index.rst
+++ b/process/process_areas/problem_resolution/index.rst
@@ -28,5 +28,5 @@ Problem Resolution
    problem_resolution_workflow
    problem_resolution_workproducts
 
-.. needextend:: docname is not None and "process_areas/problem_resolution" in docname
+.. needextend:: "c.this_doc()"
    :+tags: problem_resolution

--- a/process/process_areas/problem_resolution/problem_resolution_workflow.rst
+++ b/process/process_areas/problem_resolution/problem_resolution_workflow.rst
@@ -112,7 +112,7 @@ For a detailed explanation of workflows and their role within the process model,
 
    Otherwise the :need:`Committer <rl__committer>` keeps the status "in implementation".
 
-.. needextend:: docname is not None and "process_areas/problem_resolution" in docname
+.. needextend:: "c.this_doc()"
    :+tags: problem_resolution
 
 RAS(IC) for Problem Resolution:

--- a/process/process_areas/process_management/guidance/process_management_reqs.rst
+++ b/process/process_areas/process_management/guidance/process_management_reqs.rst
@@ -114,5 +114,5 @@ Process Building Blocks Checks
    :ref:`process_management_templates` are provided and correctly linked by the user.
 
 
-.. needextend:: docname is not None and "process_areas/process_management" in docname
+.. needextend:: "c.this_doc()"
    :+tags: process_management

--- a/process/process_areas/process_management/index.rst
+++ b/process/process_areas/process_management/index.rst
@@ -28,5 +28,5 @@ Process Management
    process_management_workflow
    process_management_workproducts
 
-.. needextend:: docname is not None and "process_areas/process_management" in docname
+.. needextend:: "c.this_doc()"
    :+tags: process_management

--- a/process/process_areas/process_management/process_management_workflow.rst
+++ b/process/process_areas/process_management/process_management_workflow.rst
@@ -64,7 +64,7 @@ For a detailed explanation of workflows and their role within the process model,
    triggered, if required.
 
 
-.. needextend:: docname is not None and "process_areas/process_management" in docname
+.. needextend:: "c.this_doc()"
    :+tags: process_management
 
 RAS(IC) for Process Management:

--- a/process/process_areas/quality_management/index.rst
+++ b/process/process_areas/quality_management/index.rst
@@ -27,5 +27,5 @@ Quality Management
    quality_workflow
    quality_workproducts
 
-.. needextend:: docname is not None and "process_areas/quality_management" in docname
+.. needextend:: "c.this_doc()"
    :+tags: quality_management

--- a/process/process_areas/quality_management/quality_workflow.rst
+++ b/process/process_areas/quality_management/quality_workflow.rst
@@ -117,7 +117,7 @@ For a detailed explanation of workflows and their role within the process model,
    | The :need:`rl__quality_manager` is responsible to adjust the quality management plan, if deviations are detected.
 
 
-.. needextend:: docname is not None and "process_areas/quality_management" in docname
+.. needextend:: "c.this_doc()"
    :+tags: quality_management
 
 RAS(IC) for Safety Analysis

--- a/process/process_areas/safety_analysis/guidance/safety_analysis_process_reqs.rst
+++ b/process/process_areas/safety_analysis/guidance/safety_analysis_process_reqs.rst
@@ -305,5 +305,5 @@ FMEA Process Requirements
    The fault ID links to the corresponding fault which describes how a potential violation can occur.
 
 
-.. needextend:: docname is not None and "process_areas/safety_analysis" in docname
+.. needextend:: "c.this_doc()"
    :+tags: safety_analysis

--- a/process/process_areas/safety_analysis/index.rst
+++ b/process/process_areas/safety_analysis/index.rst
@@ -27,5 +27,5 @@ Safety Analysis
    safety_analysis_workflow
    safety_analysis_workproducts
 
-.. needextend:: docname is not None and "process_areas/safety_analysis" in docname
+.. needextend:: "c.this_doc()"
    :+tags: safety_analysis

--- a/process/process_areas/safety_management/index.rst
+++ b/process/process_areas/safety_management/index.rst
@@ -27,5 +27,5 @@ Safety Management
    safety_management_workflow
    safety_management_workproducts
 
-.. needextend:: docname is not None and "process_areas/safety_management" in docname
+.. needextend:: "c.this_doc()"
    :+tags: safety_management

--- a/process/process_areas/safety_management/safety_management_workflow.rst
+++ b/process/process_areas/safety_management/safety_management_workflow.rst
@@ -174,7 +174,7 @@ Safety Management Workflows
    | The outcome is a change impact analysis report and a documented decision, which are reviewed and approved as part of the Safety Management process.
 
 
-.. needextend:: docname is not None and "process_areas/safety_management" in docname
+.. needextend:: "c.this_doc()"
    :+tags: safety_management
 
 RAS(IC) for Safety Management:

--- a/process/process_areas/security_analysis/guidance/security_analysis_process_reqs.rst
+++ b/process/process_areas/security_analysis/guidance/security_analysis_process_reqs.rst
@@ -370,5 +370,5 @@ Threat Models Process Requirements
    attack can occur.
 
 
-.. needextend:: docname is not None and "process_areas/security_analysis" in docname
+.. needextend:: "c.this_doc()"
    :+tags: security_analysis

--- a/process/process_areas/security_analysis/index.rst
+++ b/process/process_areas/security_analysis/index.rst
@@ -29,5 +29,5 @@ Security Analysis
    security_analysis_workflow
    security_analysis_workproducts
 
-.. needextend:: docname is not None and "process_areas/security_analysis" in docname
+.. needextend:: "c.this_doc()"
    :+tags: security_analysis

--- a/process/process_areas/security_management/index.rst
+++ b/process/process_areas/security_management/index.rst
@@ -28,5 +28,5 @@ Security Management
    security_management_workflow
    security_management_workproducts
 
-.. needextend:: docname is not None and "process_areas/security_management" in docname
+.. needextend:: "c.this_doc()"
    :+tags: security_management

--- a/process/process_areas/security_management/security_management_workflow.rst
+++ b/process/process_areas/security_management/security_management_workflow.rst
@@ -192,7 +192,7 @@ For a detailed explanation of workflows and their role within the process model,
    | The Security Manager :need:`rl__security_manager` consults all project/platform stakeholder as defined in :need:`doc_concept__security_management_process` for security topics and executes regularly security trainings.
 
 
-.. needextend:: docname is not None and "process_areas/security_management" in docname
+.. needextend:: "c.this_doc()"
    :+tags: security_management
 
 RAS(IC) for Security Management:


### PR DESCRIPTION
Since docs-as-code is moving towards supporting more fine grained docs-targets and embedding documentations into documentations, we cannot reliably predict cross document behavior of needextend. Sometimes it may affect a different set of needs than other times.

For example when needextend is applied to "x in docname", and someone else embedds process documentation into their module, and for whatever reason they also have "x", then suddenly the needextend will affect more files/needs.

This was already problematic in reference_integration in the past, we just got lucky due to "unique enough" names. But that will not suffice for a broader rollout.

---

This PR changes about 70% of needextend directives in process_descriptions. Those where the change is a single one-liner.

Verification performed: needs_json generated before the change, change applied, needs_json generated again, no diff.