### PR TITLE
remove operations from examples

### DIFF
--- a/process/process_areas/architecture_design/guidance/architecture_process_reqs.rst
+++ b/process/process_areas/architecture_design/guidance/architecture_process_reqs.rst
@@ -212,8 +212,8 @@ Traceability to Requirements and AoU
 
    **Examples:**
 
-   * feat_req <-> feat_arc_(sta|dyn), logic_arc_(int|int_op)
-   * comp_req <-> comp_arc_(sta|dyn), real_arc_(int|int_op)
+   * feat_req <-> feat_arc_(sta|dyn), logic_arc_int
+   * comp_req <-> comp_arc_(sta|dyn), real_arc_int
 
 .. gd_req:: Architecture attribute: fulfils (AoU)
    :id: gd_req__arch_attr_fulfils_aou


### PR DESCRIPTION
This pull request updates the traceability guidance in the architecture process requirements documentation to simplify and clarify the mapping between requirements and architecture elements.

Documentation update:

* Simplified the example traceability mappings in the `Traceability to Requirements and AoU` section by removing the `_op` suffix from architecture element identifiers, making the mappings easier to read and understand. (`process/process_areas/architecture_design/guidance/architecture_process_reqs.rst`)