### PR TITLE
remove superflued optional linking of logic_arc_int_op

### DIFF
--- a/process/process_areas/architecture_design/_assets/metamodel_architectural_design.drawio.svg
+++ b/process/process_areas/architecture_design/_assets/metamodel_architectural_design.drawio.svg
@@ -1,4 +1,4 @@
-<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" style="background: transparent; background-color: transparent;" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="781px" height="447px" viewBox="-0.5 -0.5 781 447" content="&lt;mxfile&gt;&lt;diagram name=&quot;Seite-1&quot; id=&quot;tF9axOo42Ag17eEaFQkn&quot;&gt;1Vttc6I6FP41ztz9YIcXwfJxa+ve3rW7ne3O3dv90okSkS0QJ0Sr/fU3gUQIAYqKxbozO+QQYjgvz3nOie2Zo3DzBYPl4g65MOgZmrvpmdc9w7B0k/7PBFsucJxU4GHfTUV6JnjwXyEXaly68l0YSxMJQgHxl7JwhqIIzogkAxijF3naHAXyty6BBxXBwwwEqvSX75JFKr00hpn8b+h7C/HNus3fLwRiMn+TeAFc9JITmTc9c4QRIulVuBnBgOlO6CV9blxxd7cxDCPS5AHnl9cf/bP+92XxePX19bvTN4PnPrfOGgQr/sJ8s2QrNABdqhA+RJgskIciENxk0iuMVpEL2ddodJTNmSC0pEKdCv9AQrbcumBFEBUtSBjwuzByPzNb0WGEIphKxn4Q8CVjAjARM2YBiGN/JsR8GltG1QhXUoxWeAZr1CA8C2APkpp5XDtMJbkv4Pr+AlEICd7SCRgGgPhr2YcAd0VvNy+zFr3gBtvDeAPFeH40C1bUFE/TbakdJ2BKw1PSPQh8L2JqpUqDmArWEBOfBsBnfmOKCEEhMzOM/VcwTdZjVlkiPyLJO1lXPeuaSgK2/BWYPXuJS4xQgOiK1y6cg1VASi1U65V0J3BTFuZ8F1IkSQbgT2kXfCmOPsLQje3DV75nr5ot29ed0mXFCmg+j6kfFe27218jkxuKdalyUeTFTzR89g/SfLhtfPIfM+KFxUeP3KTs+nqTH2zFIKIbzz3Eho/5e9ljyUg8N1vhdQINHyrOdavtQE8epa8GtrkJPIIq/czRJDfT7QLCF6ZbZu18epFu4FCPrFNpzk3HEJAVhj3DTmJ+iumVx67+mtM7nxTfldPHy8In8GEJEju+UE4h+26l7RWwqASFgpYMjY9fsvyui6S9yOV2rs32cXx4FklYCj4envnI0+QAzsIzi2FdBgpjL6TIUMnIw5JeC0sxwegZikTTo7aln/H4KJAwGoJE6xhxlBNdVpGBuDUmEPqum/rauzEBERpHM4G+dqGZpswGrHbIgCVzgcEJuECdn+YsPkEesxcV3jITzhmIchR2/fUOhgM27Qng2RN9kU9iBt1DblLnKG1YHcK0Wha9xawFOHPgLGVbw4Po1lBCUf0NFD0c9qyGsHdeNZC1TxBkVOT7EmK6OxSVsBQpPJ7QsnvGUowFU++asogNdM5Z2k//zodM/3oJZIXLAIaQVxjvzQAaJvidI7WR4XVDzsXtJPhCfrfeK787ikV/wL1xLZ/3MX1cxrUPkfkHRudop1KtbtCuUXvkrS7L4dCoN+2fOOeFje/TKD0BOAq/a6ERagzFmYUAMqMVdBTL8FUv3wsddbXxVAWPVRj4UQDQGnQOgPZZAOCuKtoNkkoq60hXFEWnoIl6Z/VSeRzaRqFeNgrOkG6UP3WCeFS7mHkCqrEvNLRV3GI/ijC3ObwZxZNjUywWIdACFmtDcUq8lRZql6ie4lBq/Wc5uZ3ebdeLULPwt28/52MiOl4HYoF+IBaUHmLVd4ur8GN4OIDszreOZFZN0eREJ1OKLw0HhZaDWYCT9JUUOFEWutQKC2knw6VS51QbRDRcYz8m8ROanwf3qwuqdupizZI73y1RP/1SRjHj3cifatURCpcU0Nn+VNY3ozfPle0Nhh02urfX/eHXW3vyezwJf28eg8dw+rPkYKELstcITEv3390p/1Fqrzx0aI8x7fFbHlX9tb7SCkxZmlxMHvtznVMyoTrPy5nwDrmroLQSDZF7rpBkOx1CktqsmUAPRm6NVvS3tVIZCUlxcI9iP+malsTOpDAhrTqUUJujiHAs0wds7AdBjjDOLfaPz8vJ008ZxbSTTzsGtQrF4aDsAMkuMaherCIPsahaGYYgcgFBuKT5pjQvy+p/StmHlzKH1503OHwyuofYp/tnFkuEeavVMvg3c0ROk1aJIoXs2BJvIBd5A9u+sEwn+9jyik1Zum3tt257pF393QpaskhjrbxufaO66PvwXuPoF0WyfrCnlKzVnneUnDNPfGp6Q0vtUnQRiofk0NKtLIPImTdvd6MlZC6w/4GpInMZMBfL8Qa4TIfZXxuktsj+ZMO8+R8=&lt;/diagram&gt;&lt;/mxfile&gt;">
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" style="background: transparent; background-color: transparent;" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="781px" height="447px" viewBox="-0.5 -0.5 781 447" content="&lt;mxfile&gt;&lt;diagram name=&quot;Seite-1&quot; id=&quot;tF9axOo42Ag17eEaFQkn&quot;&gt;1Vpbc5s6EP41njl9sIeLwfZj48Q9OXXaTNM5PemLRzYypgHECPmWX38kkAxCGN9wSNyZDlqkRey3+7G7SsscBpsvGESLB+RAv2VozqZl3rYMwzI0+j8TbFOB3R+kAhd7TirSM8GT9wq5kK9zl54DY2kiQcgnXiQLZygM4YxIMoAxWsvT5siXnxoBFyqCpxnwVekvzyGLVNo3epn8b+i5C/Fk3ebvFwAxmb9JvAAOWudE5l3LHGKESHoVbIbQZ7YTdknXjfbc3W0Mw5Acs2Dwy20P/1n9u14833x9/T5om/5L20y1rIC/5C/MN0u2wgLQoQbhQ4TJArkoBP5dJr3BaBk6kD1Go6NszhihiAp1KvwDCdlydMGSICpakMDnd2HofGZY0WGIQphKRp7vc5UxAZiIGTMfxLE3E2I+jalRLcKNFKMlnsEKMwjPAtiFpGIetw4zSe4B3N5fIAogwVs6AUMfEG8l+xDgruju5mVo0QsO2AngdRXwvHDmLykUk+m2FMcxmNLwlGwPfM8NmVmp0SCmghXExKMB8JnfmCJCUMBghrH3CqaJPoZKhLyQJO9k3bSsWyrxmfobMHtxE5cYIh9RjbcOnIOlT0oRqvRKuhO4KQtzvgspkiQA+Cqtw1Vx9hFAH40P1/zIXjVT29YHpWqFBjSfx9SPivju9ncU5IaCLjUuCt14QsPn9CDNh9vGI/8xEDsWHz1zSNn17SY/2IpBSDeeW8SGz/l72bJkJNbNlniVUMOHinPdqjvQk6X01cA2N4FH0F4/G2iSm+l2geEL0y2zcj69SDdwrkdWmTTnpiMIyBLDlmEnMT/F9MplV3/N6Z1Piu/Kn4/1wiPwKQIJjmuaU8i+uxd7hSz2kkLBSobGx+vs+66Lj/Yi923n1qyfx9VIHyOXUTAV3jNWnjNrcHM63mpnT59NmwA8m1A/+CRm0D3kJjVubsNq0N5qfnPoEylYlBNUKW32zuLNnkSc+gHi3Gv5mjlJYRFTG3QsCTFTLyCR8ixfV0FIqioF1JSKFVV1sZN1SmhlTPU9gpjaEIUlJCYF3QRFzRNaMcJ2eDXGaGIDDdcVMcHoBYo0tEX9kf5Go4tSiMGRKUTtGcRlgJQQYRD5MIA8AamlVAg8x0mRO1gqqABUO9LFpUBb6+iGTEZ8dCFfyjoF7rWWAlWOmEP0BzyZ1/LZBKbLZV77EPlE12ic7dQErhm2O6p6OlSEnU+N+rHl1eB9cePb9FGuQI7C72rokxg90dIURGbUwo5CDdfafyt21NW6dB897uPAj0KAVrdxArTfBQHuaq3dIKnPsobVnlLrGmmi6CC9fUu5PA5to1CFG29biOk9lWRzCajGHmhoyxjWl40S5jbnd635x/FYLhYhUAMXaz1b7i/X07UuJKrX6Fmv/kTj++nDdrUINAt/+/ZzPiLimOJMLtDP5ILSHre4c6BXU+CP3vkEsmt/X5hZHcsmV2pcK77U6xZaDuaZLaK+VlCkXY2XSp1TbRDRcI29mMQTNH8fuV9VUNVTF2uWfExWU+qn92UWM94s+VNRHaIgooTO9qdmfTN6871me91eg+3z7W279/XeHv8ejYPfm2f/OZj+LDmuaCLZO4pMS/ff3CHgRWbfe5RRX8Z0wlG/av5KX6mFpixNLiYvPc2/ZiZU5Xk5CB+Qs/RLK9EAOe+VkuxBg5SkNmvG0IWhU2EV/bBV9kZCUhw8othLuqYlsTMuTEirDiXU5igknMv0Lht7vp9LGOcW+8fn5eTpryzFtJNfPYBaheKwW3aAZJcAqheryHMQVSvDAIQOIAiXNN+U5mVZ/U9T9l5fzuH1wYEcPhk9QuzR/TPEEmEetcsOZXOWtEoMKWSXlnhducjr2nbHMgfZz5Y1Hpul29ZpeutL2vuKc6CIRRpr5TXrG/uLvg/vNQO9U0zWz/aUEl31eUfJOfPYo9AbWopL0UUoH5JzS7eyL4j85c3jbtTEzIXsv2uqzFxGzMVy/AhepsPsj5FTLLK/6Dbv/gc=&lt;/diagram&gt;&lt;/mxfile&gt;">
     <defs/>
     <g>
         <g>
@@ -69,28 +69,6 @@
             </g>
         </g>
         <g>
-            <path d="M 250 106 L 250 149.63" fill="none" stroke="#0000ff" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 255), rgb(205, 205, 255));"/>
-            <path d="M 250 154.88 L 246.5 147.88 L 250 149.63 L 253.5 147.88 Z" fill="#0000ff" stroke="#0000ff" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 255), rgb(205, 205, 255)); stroke: light-dark(rgb(0, 0, 255), rgb(205, 205, 255));"/>
-        </g>
-        <g>
-            <g transform="translate(-0.5 -0.5)">
-                <switch>
-                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 127px; margin-left: 251px;">
-                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; background-color: #ffffff; ">
-                                <div style="display: inline-block; font-size: 11px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; background-color: light-dark(#ffffff, var(--ge-dark-color, #121212)); white-space: nowrap; ">
-                                    includes
-                                </div>
-                            </div>
-                        </div>
-                    </foreignObject>
-                    <text x="251" y="130" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="11px" text-anchor="middle">
-                        includes
-                    </text>
-                </switch>
-            </g>
-        </g>
-        <g>
             <rect x="220" y="46" width="120" height="60" fill="#ffffff" stroke="#000000" pointer-events="all" style="fill: light-dark(#ffffff, var(--ge-dark-color, #121212)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
@@ -115,14 +93,14 @@
             </g>
         </g>
         <g>
-            <path d="M 310 156 L 310 112.37" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
-            <path d="M 310 107.12 L 313.5 114.12 L 310 112.37 L 306.5 114.12 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 279.5 156 L 279.5 112.37" fill="none" stroke="#000000" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
+            <path d="M 279.5 107.12 L 283 114.12 L 279.5 112.37 L 276 114.12 Z" fill="#000000" stroke="#000000" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(0, 0, 0), rgb(255, 255, 255)); stroke: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 131px; margin-left: 310px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 131px; margin-left: 280px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #000000; background-color: #ffffff; ">
                                 <div style="display: inline-block; font-size: 11px; font-family: &quot;Helvetica&quot;; color: light-dark(#000000, #ffffff); line-height: 1.2; pointer-events: all; background-color: light-dark(#ffffff, var(--ge-dark-color, #121212)); white-space: nowrap; ">
                                     included_by
@@ -130,7 +108,7 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="310" y="134" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="11px" text-anchor="middle">
+                    <text x="280" y="134" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="11px" text-anchor="middle">
                         included_by
                     </text>
                 </switch>

--- a/process/process_areas/architecture_design/guidance/architecture_process_reqs.rst
+++ b/process/process_areas/architecture_design/guidance/architecture_process_reqs.rst
@@ -80,7 +80,7 @@ Architectural Model
 .. gd_req:: Correlations of the architectural building blocks
    :id: gd_req__arch_build_blocks_corr
    :status: valid
-   :version: 2
+   :version: 3
    :tags: done_automation
    :complies: std_req__iso26262__support_6431[version==1], std_req__iso26262__support_6432[version==1]
    :satisfies: wf__cr_mt_featarch[version==1], wf__cr_mt_comparch[version==1]


### PR DESCRIPTION
This pull request updates the version of the "Correlations of the architectural building blocks" guidance requirement in the architecture design process documentation.

Documentation update:

* Updated the `:version:` field of the `gd_req__arch_build_blocks_corr` requirement from 2 to 3 in `architecture_process_reqs.rst` to reflect the latest revision.