### PR TITLE
chore(docs): align score_docs_as_code repository files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,8 @@ user.bazelrc
 .ruff_cache
 
 # docs:incremental and docs:ide_support build artifacts
-/_build*
-process/ubproject.toml
+_build
+ubproject.toml
 
 # Vale - editorial style guide
 .vale.ini


### PR DESCRIPTION
<!-- repo-sync-policy: score-docs-as-code.gitignore-and-cleanup -->

## Policy

**`score-docs-as-code.gitignore-and-cleanup`**

Replace legacy documentation ignore entries and remove the obsolete docs/ubproject.toml configuration file.


## Why this repository?

`MODULE.bazel` declares the required direct Bazel dependency or dependencies: `score_docs_as_code`.

## Changes

- `.gitignore`: replace '/_build*' with '_build'
- `.gitignore`: replace 'process/ubproject.toml' with 'ubproject.toml'

---

This pull request is managed by `repo-sync` and may be updated by a later policy run.  
Note: the tool itself is in proof of concept stage and may not be fully stable yet. Please report any issues to #infrastructure.
