### PR TITLE
Rename _platform_templates to platform_management_templates

### DIFF
--- a/process/process_areas/platform_management/guidance/platform_management_guideline.rst
+++ b/process/process_areas/platform_management/guidance/platform_management_guideline.rst
@@ -36,7 +36,7 @@ This document describes the general guidances for Platform Management based on t
 General Hints
 =============
 
-A template of the Platform Management Plan for <Project> is described in the :ref:`Platform Management Plan Template <platform_templates>`.
+A template of the Platform Management Plan for <Project> is described in the :ref:`Platform Management Plan Template <platform_management_templates>`.
 
 An iterative and incremental development model shall be used.
 
@@ -51,7 +51,7 @@ Templates
 ---------
 
 The content of the Platform Management Plan shall consider the
-:ref:`Platform Management Plan Template <platform_templates>`.
+:ref:`Platform Management Plan Template <platform_management_templates>`.
 
 Activities for Platform Management Plan
 =======================================

--- a/process/process_areas/platform_management/guidance/platform_management_template.rst
+++ b/process/process_areas/platform_management/guidance/platform_management_template.rst
@@ -12,7 +12,7 @@
    # SPDX-License-Identifier: Apache-2.0
    # *******************************************************************************
 
-.. _platform_templates:
+.. _platform_management_templates:
 
 Platform Management Template
 ============================

--- a/process/process_areas/platform_management/platform_management_concept.rst
+++ b/process/process_areas/platform_management/platform_management_concept.rst
@@ -28,7 +28,7 @@ including the requirements of the different stakeholders for the Platform Manage
 Key concept
 ***********
 The Platform Management Plan is the container for all plan documents. As container it shall include
-the plans defined in the :ref:`Platform Management Plan Template <platform_templates>`.
+the plans defined in the :ref:`Platform Management Plan Template <platform_management_templates>`.
 The concept of the plan documents, beside Project Management is defined in the
 corresponding process areas, which generate them.
 
@@ -66,7 +66,7 @@ Also requirements of standards need to be taken into consideration:
 Plans for Platform Management
 *****************************
 
-Compare :ref:`Platform Management Plan Template <platform_templates>`.
+Compare :ref:`Platform Management Plan Template <platform_management_templates>`.
 
 
 Activities for the Platform Management Plan

--- a/process/process_areas/platform_management/platform_management_workflow.rst
+++ b/process/process_areas/platform_management/platform_management_workflow.rst
@@ -43,7 +43,7 @@ For a detailed explanation of workflows and their role within the process model,
    :has: doc_concept__platform_process[version==1], doc_getstrt__platform_process[version==1]
 
    The Platform Management Plan shall include the plans as defined by the
-   :ref:`Platform Management Plan Template <platform_templates>`.
+   :ref:`Platform Management Plan Template <platform_management_templates>`.
 
    The project management plan should contain the scope of work, project life cycle, work packages,
    planning and monitoring approaches, project schedule, escalation and communication path.

--- a/process/process_areas/platform_management/platform_management_workproducts.rst
+++ b/process/process_areas/platform_management/platform_management_workproducts.rst
@@ -23,7 +23,7 @@ Platform Management Work Products
    :complies:
 
    The Platform Management Plan shall include the plans as defined by the
-   :ref:`Platform Management Plan Template <platform_templates>`.
+   :ref:`Platform Management Plan Template <platform_management_templates>`.
 
    The main purpose of the plan documents is to define strategies, so that
 


### PR DESCRIPTION
renaming of the needs-document-intro of ".. _platform_templates:" to .. "_platform_management_templates" to align with documents and avoid misleading references