### PR TITLE
fix: Fix needextend for future needextend changes

### DIFF
--- a/process/folder_templates/platform/features/feature_name/requirements/index.rst
+++ b/process/folder_templates/platform/features/feature_name/requirements/index.rst
@@ -77,5 +77,5 @@ Feature Requirements
     - Adjust ``valid_from`` and ``valid_until`` to the right version numbers
     - Set ``status`` to ``valid`` and start the review/merge process
 
-.. needextend:: docname is not None and "feature_name" in id
+.. needextend:: c.this_doc() and docname is not None and "feature_name" in id
    :+tags: feature_name

--- a/process/folder_templates/platform/requirements/stakeholder/index.rst
+++ b/process/folder_templates/platform/requirements/stakeholder/index.rst
@@ -72,5 +72,5 @@ Stakeholder Requirements
     - Add other needed requirements for the platform
     - Set ``status`` to ``valid`` and start the review/merge process
 
-.. needextend:: "platform" in id
+.. needextend:: c.this_doc() and "platform" in id
    :+tags: platform

--- a/process/process_areas/architecture_design/architecture_concept.rst
+++ b/process/process_areas/architecture_design/architecture_concept.rst
@@ -573,3 +573,6 @@ Limitations
 * Grouping functionality needs improvement
 * Manual extendability is limited to the same type as the underlying drawing, either class or association diagram types
 * Currently only uses the need attributes *includes, included_by, uses, implements*
+
+.. needextend:: "c.this_doc()"
+   :+tags: architecture_design

--- a/process/process_areas/architecture_design/architecture_getstrt.rst
+++ b/process/process_areas/architecture_design/architecture_getstrt.rst
@@ -37,3 +37,6 @@ General Workflow
    Architecture Design Workflow
 
 The above figure shows all steps which are required to create an architectural design. In this getting started only a short overview is given. A more detailed description of all the step is provided in the :need:`guideline <gd_guidl__arch_design>`.
+
+.. needextend:: "c.this_doc()"
+   :+tags: architecture_design

--- a/process/process_areas/architecture_design/architecture_roles.rst
+++ b/process/process_areas/architecture_design/architecture_roles.rst
@@ -27,3 +27,6 @@ Contributing Roles:
 A detailed overview of the responsibility for the steps of the architecture design process is listed here:
 
 :ref:`arch_workflow`
+
+.. needextend:: "c.this_doc()"
+   :+tags: architecture_design

--- a/process/process_areas/architecture_design/architecture_workflow.rst
+++ b/process/process_areas/architecture_design/architecture_workflow.rst
@@ -91,3 +91,6 @@ RAS(IC) for Architecture Design:
    :sort: status
    :columns: id as "Activity";responsible as "Responsible";approved_by as "Approver";supported_by as "Supporter"
    :colwidths: 30,30,30,30
+
+.. needextend:: "c.this_doc()"
+   :+tags: architecture_design

--- a/process/process_areas/architecture_design/architecture_workproducts.rst
+++ b/process/process_areas/architecture_design/architecture_workproducts.rst
@@ -70,3 +70,6 @@ Architecture Work Products
 
    Depends on architecture guideline and tooling.
    May include several methods like inspection, modelling, ... which are selected in projects SW Verification Plan.
+
+.. needextend:: "c.this_doc()"
+   :+tags: architecture_design

--- a/process/process_areas/architecture_design/guidance/architecture_guideline.rst
+++ b/process/process_areas/architecture_design/guidance/architecture_guideline.rst
@@ -359,3 +359,6 @@ Since SCORE provides a middleware platform, the following aspects are explicitly
 * System-level safety architecture (e.g., ASIL decomposition at vehicle level)
 
 Architectural views describing integration aspects at the system level (above platform boundary) are the responsibility of the platform user (system integrator). The platform shall provide Assumptions of Use (AoU) documenting architectural constraints that the platform user must satisfy. These responsibilities shall be communicated to platform users via AoUs associated with the platform and feature architectures.
+
+.. needextend:: "c.this_doc()"
+   :+tags: architecture_design

--- a/process/process_areas/architecture_design/guidance/architecture_inspection_checklist.rst
+++ b/process/process_areas/architecture_design/guidance/architecture_inspection_checklist.rst
@@ -30,7 +30,7 @@ Architecture Inspection Checklist Template
                std_req__aspice_40__SWE-2-BP4[version==1],
                std_req__aspice_40__iic-13-51[version==1],
                std_req__aspice_40__SWE-2-BP5[version==1],
-               std_req__aspice_40__iic-08-63[version==1], 
+               std_req__aspice_40__iic-08-63[version==1],
                std_req__aspice_40__iic-03-06[version==1]
 
     For the content see here:
@@ -39,3 +39,6 @@ Architecture Inspection Checklist Template
     - `Feature Architecture Inspection Checklist <https://eclipse-score.github.io/module_template/main/features/feature_example/architecture/chklst_arc_inspection.html>`__
 
     These two documents have the same questions, but different scope and document naming.
+
+.. needextend:: "c.this_doc()"
+   :+tags: architecture_design

--- a/process/process_areas/architecture_design/guidance/architecture_process_reqs.rst
+++ b/process/process_areas/architecture_design/guidance/architecture_process_reqs.rst
@@ -360,3 +360,6 @@ Process Monitoring and Improvement
    Monitoring is expected as a periodic, predominantly manual activity (for example as part of quality checks and retrospectives), not as a fully automated check.
 
    Improvement actions should be handled according to :ref:`pm_monitor_improve_process`.
+
+.. needextend:: "c.this_doc()"
+   :+tags: architecture_design

--- a/process/process_areas/architecture_design/guidance/component_architecture_template.rst
+++ b/process/process_areas/architecture_design/guidance/component_architecture_template.rst
@@ -28,3 +28,6 @@ Component Architecture Template
 
    For the content see the
    `module template documentation <https://eclipse-score.github.io/module_template/main/components/component_example/architecture/component_architecture.html>`__.
+
+.. needextend:: "c.this_doc()"
+   :+tags: architecture_design

--- a/process/process_areas/architecture_design/guidance/feature_architecture_template.rst
+++ b/process/process_areas/architecture_design/guidance/feature_architecture_template.rst
@@ -25,3 +25,6 @@ Feature Architecture Template
                std_req__aspice_40__iic-04-04[version==1]
 
     For the content see here: :ref:`feature_architecture_template`
+
+.. needextend:: "c.this_doc()"
+   :+tags: architecture_design

--- a/process/process_areas/architecture_design/guidance/index.rst
+++ b/process/process_areas/architecture_design/guidance/index.rst
@@ -23,3 +23,6 @@ Guidances
    feature_architecture_template
    component_architecture_template
    architecture_process_reqs
+
+.. needextend:: "c.this_doc()"
+   :+tags: architecture_design

--- a/process/process_areas/architecture_design/index.rst
+++ b/process/process_areas/architecture_design/index.rst
@@ -27,7 +27,3 @@ Architecture Design
    architecture_roles
    architecture_workflow
    architecture_workproducts
-
-
-.. needextend:: docname is not None and "process_areas/architecture_design" in docname
-   :+tags: architecture_design

--- a/process/process_areas/change_management/change_management_concept.rst
+++ b/process/process_areas/change_management/change_management_concept.rst
@@ -169,3 +169,6 @@ The standards require that a Change Request can be traced throughout the complet
 hierarchy levels including all affected work products.
 
 In general the traceability is visualized in the general traceability concept (:ref:`general_concepts_traceability`).
+
+.. needextend:: "c.this_doc()"
+   :+tags: change_management

--- a/process/process_areas/change_management/change_management_getstrt.rst
+++ b/process/process_areas/change_management/change_management_getstrt.rst
@@ -51,3 +51,6 @@ For every change identified, the following workflows are executed:
 * Close the change request according to :need:`wf__change_close_cr`
 
 In addition create a change management plan as part of the platform management plan according to :need:`wf__platform_cr_mt_platform_mgmt_plan`
+
+.. needextend:: "c.this_doc()"
+   :+tags: change_management

--- a/process/process_areas/change_management/change_management_roles.rst
+++ b/process/process_areas/change_management/change_management_roles.rst
@@ -28,3 +28,6 @@ Contributing Roles:
 A detailed overview of the responsibility for the steps of the requirement process is listed here:
 
 :ref:`workflow_chm_requirements`
+
+.. needextend:: "c.this_doc()"
+   :+tags: change_management

--- a/process/process_areas/change_management/change_management_workflow.rst
+++ b/process/process_areas/change_management/change_management_workflow.rst
@@ -166,6 +166,3 @@ RAS(IC) for Change Management:
    :sort: status
    :columns: id as "Activity";responsible as "Responsible";approved_by as "Approver";supported_by as "Supporter"
    :colwidths: 30,30,30,30
-
-.. needextend:: "c.this_doc()"
-   :+tags: change_management

--- a/process/process_areas/change_management/change_management_workflow.rst
+++ b/process/process_areas/change_management/change_management_workflow.rst
@@ -166,3 +166,6 @@ RAS(IC) for Change Management:
    :sort: status
    :columns: id as "Activity";responsible as "Responsible";approved_by as "Approver";supported_by as "Supporter"
    :colwidths: 30,30,30,30
+
+.. needextend:: "c.this_doc()"
+   :+tags: change_management

--- a/process/process_areas/change_management/change_management_workproducts.rst
+++ b/process/process_areas/change_management/change_management_workproducts.rst
@@ -81,3 +81,6 @@ Change Management Work Products
    | Change Request for a new component or a modification of an existing component,
    | which changes the scope of the component.
    | This includes the allocation of components into SW Modules.
+
+.. needextend:: "c.this_doc()"
+   :+tags: change_management

--- a/process/process_areas/change_management/guidance/change_management_checklist.rst
+++ b/process/process_areas/change_management/guidance/change_management_checklist.rst
@@ -86,3 +86,6 @@ Checklists
       * - 11
         - Does the Change Request has verification measure as specified?
         -
+
+.. needextend:: "c.this_doc()"
+   :+tags: change_management

--- a/process/process_areas/change_management/guidance/change_management_component_template.rst
+++ b/process/process_areas/change_management/guidance/change_management_component_template.rst
@@ -33,3 +33,6 @@ Component Template
               std_req__aspice_40__iic-14-02[version==1]
 
    for the content see `Component Request Template <https://eclipse-score.github.io/module_template/main/components/component_example/index.html>`__
+
+.. needextend:: "c.this_doc()"
+   :+tags: change_management

--- a/process/process_areas/change_management/guidance/change_management_decision_record_template.rst
+++ b/process/process_areas/change_management/guidance/change_management_decision_record_template.rst
@@ -24,3 +24,6 @@ Decision Record Template
    :complies: std_req__aspice_40__SWE-2-BP3[version==1], std_req__aspice_40__iic-17-00[version==1]
 
    For the content see here: :ref:`decision_record_template`.
+
+.. needextend:: "c.this_doc()"
+   :+tags: change_management

--- a/process/process_areas/change_management/guidance/change_management_feature_template.rst
+++ b/process/process_areas/change_management/guidance/change_management_feature_template.rst
@@ -35,3 +35,6 @@ Feature Template
               std_req__aspice_40__iic-14-02[version==1]
 
    for the content see :need:`doc__feature_name`
+
+.. needextend:: "c.this_doc()"
+   :+tags: change_management

--- a/process/process_areas/change_management/guidance/change_management_guideline.rst
+++ b/process/process_areas/change_management/guidance/change_management_guideline.rst
@@ -305,3 +305,6 @@ Tailoring
    The reasoning is:
 
    - Trustable Software Framework is planned for evaluation of existing OSS, thus the requirements for evaluation are not applicable.
+
+.. needextend:: "c.this_doc()"
+   :+tags: change_management

--- a/process/process_areas/change_management/guidance/change_management_impact_analysis_template.rst
+++ b/process/process_areas/change_management/guidance/change_management_impact_analysis_template.rst
@@ -128,3 +128,6 @@ License Impact
 ==============
 
 [How could the copyright impacted by the license of the new contribution?]
+
+.. needextend:: "c.this_doc()"
+   :+tags: change_management

--- a/process/process_areas/change_management/guidance/index.rst
+++ b/process/process_areas/change_management/guidance/index.rst
@@ -25,3 +25,6 @@ Guidance
    change_management_impact_analysis_template
    change_management_reqs
    change_management_decision_record_template
+
+.. needextend:: "c.this_doc()"
+   :+tags: change_management

--- a/process/process_areas/change_management/index.rst
+++ b/process/process_areas/change_management/index.rst
@@ -27,6 +27,3 @@ Change Management
    change_management_roles
    change_management_workflow
    change_management_workproducts
-
-.. needextend:: "c.this_doc()"
-   :+tags: change_management

--- a/process/process_areas/configuration_management/configuration_concept.rst
+++ b/process/process_areas/configuration_management/configuration_concept.rst
@@ -60,3 +60,6 @@ Almost all requirements of the standards towards configuration management can be
 standard versioning tooling and of tooling for the "Docs-as-Code" approach.
 
 For the automated storage additional tooling is needed see :doc:`guidance/configuration_process_req`)
+
+.. needextend:: "c.this_doc()"
+   :+tags: configuration_management

--- a/process/process_areas/configuration_management/configuration_getstrt.rst
+++ b/process/process_areas/configuration_management/configuration_getstrt.rst
@@ -29,3 +29,6 @@ In case you are appointed as a :need:`rl__project_lead` in the project:
 
 As a normal contributor or committer consult the configuration management plan, it should
 be mainly your task to use the project's selected version management tool.
+
+.. needextend:: "c.this_doc()"
+   :+tags: configuration_management

--- a/process/process_areas/configuration_management/configuration_roles.rst
+++ b/process/process_areas/configuration_management/configuration_roles.rst
@@ -26,3 +26,6 @@ Contributing Roles:
 A detailed overview of the responsibility for the steps of the configuration management is listed here:
 
 :need:`wf__platform_cr_mt_platform_mgmt_plan`
+
+.. needextend:: "c.this_doc()"
+   :+tags: configuration_management

--- a/process/process_areas/configuration_management/configuration_workflow.rst
+++ b/process/process_areas/configuration_management/configuration_workflow.rst
@@ -24,3 +24,6 @@ Thus the work flow :need:`wf__platform_cr_mt_platform_mgmt_plan` applies.
 Baselines (sets of configuration items and their versions) defining a SW Release on platform or module level
 are created as part of this process but are documented in the respective release notes.
 This is part of workflows :need:`wf__rel_mod_rel_note` and :need:`wf__rel_platform_rel_note`
+
+.. needextend:: "c.this_doc()"
+   :+tags: configuration_management

--- a/process/process_areas/configuration_management/configuration_workproducts.rst
+++ b/process/process_areas/configuration_management/configuration_workproducts.rst
@@ -23,3 +23,6 @@ Configuration Management Work Products
    :complies: std_wp__iso26262__support_751[version==1]
 
    Config Management Plan (Part of the Platform Management Plan, :need:`wp__platform_mgmt`)
+
+.. needextend:: "c.this_doc()"
+   :+tags: configuration_management

--- a/process/process_areas/configuration_management/guidance/configuration_process_req.rst
+++ b/process/process_areas/configuration_management/guidance/configuration_process_req.rst
@@ -93,3 +93,6 @@ Configuration Management Process Requirements
    It shall be possible to define global tags with the docs-as-code tool, which can be used for filtering and reporting.
 
    Note: This requirement exists to enable the use of global tags for filtering and reporting purposes, while still prohibiting the overriding of mandatory attributes or elements globally.
+
+.. needextend:: "c.this_doc()"
+   :+tags: configuration_management

--- a/process/process_areas/configuration_management/guidance/configuration_templates.rst
+++ b/process/process_areas/configuration_management/guidance/configuration_templates.rst
@@ -182,3 +182,6 @@ The respective tools used in the project are:
 Note 1: A versioning tool covers part of configuration management but not all (namely: storage, retrieval, control and modification, branching and baselining).
 
 Note 2: A "Docs-as-Code" tool is used to identify, attribute and link parts of text files and generate human and machine readable documentation.
+
+.. needextend:: "c.this_doc()"
+   :+tags: configuration_management

--- a/process/process_areas/configuration_management/index.rst
+++ b/process/process_areas/configuration_management/index.rst
@@ -26,6 +26,3 @@ Configuration Management
    configuration_roles
    configuration_workflow
    configuration_workproducts
-
-.. needextend:: docname is not None and "process_areas/configuration_management" in docname
-   :+tags: configuration_management

--- a/process/process_areas/documentation_management/documentation_concept.rst
+++ b/process/process_areas/documentation_management/documentation_concept.rst
@@ -86,3 +86,6 @@ Guidance
 ^^^^^^^^
 
 The document management guideline can be found here :need:`gd_guidl__documentation`.
+
+.. needextend:: "c.this_doc()"
+   :+tags: documentation_management

--- a/process/process_areas/documentation_management/documentation_getstrt.rst
+++ b/process/process_areas/documentation_management/documentation_getstrt.rst
@@ -28,3 +28,6 @@ General Workflow
 ****************
 
 The main workflow is to create and maintain the :need:`wp__document_mgt_plan`.
+
+.. needextend:: "c.this_doc()"
+   :+tags: documentation_management

--- a/process/process_areas/documentation_management/documentation_roles.rst
+++ b/process/process_areas/documentation_management/documentation_roles.rst
@@ -30,3 +30,6 @@ Contributing Roles:
 A detailed overview of the responsibility for the steps of the documentation management is listed here:
 
 :need:`wf__platform_cr_mt_platform_mgmt_plan`
+
+.. needextend:: "c.this_doc()"
+   :+tags: documentation_management

--- a/process/process_areas/documentation_management/documentation_workflow.rst
+++ b/process/process_areas/documentation_management/documentation_workflow.rst
@@ -22,3 +22,6 @@ management plan. Thus the work flow :need:`wf__platform_cr_mt_platform_mgmt_plan
 
 The documentation management plan should contain the strategy to manage the identified
 documentations in an effective and repeatable way for the project life cycle.
+
+.. needextend:: "c.this_doc()"
+   :+tags: documentation_management

--- a/process/process_areas/documentation_management/documentation_workproducts.rst
+++ b/process/process_areas/documentation_management/documentation_workproducts.rst
@@ -33,3 +33,6 @@ Documentation Management Work Products
    * How to avoid distribution of obsolete documents?
    * Which formal elements are used?
    * List of all documents including their status
+
+.. needextend:: "c.this_doc()"
+   :+tags: documentation_management

--- a/process/process_areas/documentation_management/guidance/documentation_checklist.rst
+++ b/process/process_areas/documentation_management/guidance/documentation_checklist.rst
@@ -62,3 +62,6 @@ Checklists
       * - 6
         - Is the Document linked via realizes to the correct workproduct of the process description?
         -
+
+.. needextend:: "c.this_doc()"
+   :+tags: documentation_management

--- a/process/process_areas/documentation_management/guidance/documentation_guideline.rst
+++ b/process/process_areas/documentation_management/guidance/documentation_guideline.rst
@@ -110,3 +110,6 @@ In principle same as lifecycle model 2, but an additional inspection step is req
 as described here: :ref:`review_concept`.
 
 Example: :need:`wp__requirements_stkh`
+
+.. needextend:: "c.this_doc()"
+   :+tags: documentation_management

--- a/process/process_areas/documentation_management/guidance/documentation_process_reqs.rst
+++ b/process/process_areas/documentation_management/guidance/documentation_process_reqs.rst
@@ -121,3 +121,6 @@ Document Management Process Requirements
    which is usually the person with "write-rights" on the document approving
    the merge of a Pull Request (this may also be more than one person).
    Note that every approver is also reviewer.
+
+.. needextend:: "c.this_doc()"
+   :+tags: documentation_management

--- a/process/process_areas/documentation_management/guidance/documentation_templates.rst
+++ b/process/process_areas/documentation_management/guidance/documentation_templates.rst
@@ -29,3 +29,6 @@ Documentation Templates
    |    :security: <YES|NO>
    |    :safety: <QM|ASIL_B>
    |    :realizes: wp__<name of wp in process description>
+
+.. needextend:: "c.this_doc()"
+   :+tags: documentation_management

--- a/process/process_areas/documentation_management/index.rst
+++ b/process/process_areas/documentation_management/index.rst
@@ -26,6 +26,3 @@ Documentation Management
    documentation_roles
    documentation_workflow
    documentation_workproducts
-
-.. needextend:: docname is not None and "process_areas/documentation_management" in docname
-   :+tags: documentation_management

--- a/process/process_areas/implementation/guidance/detailed_design_template.rst
+++ b/process/process_areas/implementation/guidance/detailed_design_template.rst
@@ -28,3 +28,6 @@ Detailed Design Template
               std_req__aspice_40__iic-04-05[version==1]
 
    For the content see here: `Detailed Design Template <https://eclipse-score.github.io/module_template/main/components/component_example/detailed_design/index.html>`__
+
+.. needextend:: "c.this_doc()"
+   :+tags: implementation

--- a/process/process_areas/implementation/guidance/implementation_checklist.rst
+++ b/process/process_areas/implementation/guidance/implementation_checklist.rst
@@ -32,3 +32,6 @@ Implementation Inspection Checklist
     For the content see here:
 
     - `Component Implementation Inspection Checklist <https://eclipse-score.github.io/module_template/main/components/component_example/detailed_design/chklst_impl_inspection.html>`__
+
+.. needextend:: "c.this_doc()"
+   :+tags: implementation

--- a/process/process_areas/implementation/guidance/implementation_guideline.rst
+++ b/process/process_areas/implementation/guidance/implementation_guideline.rst
@@ -274,3 +274,6 @@ Example using PlantUML:
    UnitA -> UnitB : request()
    UnitB --> UnitA : response()
    @enduml
+
+.. needextend:: "c.this_doc()"
+   :+tags: implementation

--- a/process/process_areas/implementation/guidance/software_development_template.rst
+++ b/process/process_areas/implementation/guidance/software_development_template.rst
@@ -65,3 +65,6 @@ SW development tools
 ^^^^^^^^^^^^^^^^^^^^
 
 Description of used SW development tools.
+
+.. needextend:: "c.this_doc()"
+   :+tags: implementation

--- a/process/process_areas/implementation/implementation_concept.rst
+++ b/process/process_areas/implementation/implementation_concept.rst
@@ -61,3 +61,6 @@ continuous improvements in quality through multiple cycles of refinement.
 The implementation concept intentionally stays at a high level. Practical guidance for
 unit decomposition, source-code documentation, optional diagrams and naming consistency
 for traceability is defined in :need:`Implementation Guideline <gd_guidl__implementation>`.
+
+.. needextend:: "c.this_doc()"
+   :+tags: implementation

--- a/process/process_areas/implementation/implementation_getstrt.rst
+++ b/process/process_areas/implementation/implementation_getstrt.rst
@@ -62,3 +62,6 @@ Developer Experience
 
 There are some tests intended to check e.g. format which are described in
 https://github.com/eclipse-score/score/blob/main/README.md.
+
+.. needextend:: "c.this_doc()"
+   :+tags: implementation

--- a/process/process_areas/implementation/implementation_roles.rst
+++ b/process/process_areas/implementation/implementation_roles.rst
@@ -25,3 +25,6 @@ Contributing Roles:
 A detailed overview of the responsibility for the steps of the requirement process is listed here:
 
 :ref:`workflow_implementation`
+
+.. needextend:: "c.this_doc()"
+   :+tags: implementation

--- a/process/process_areas/implementation/implementation_workflow.rst
+++ b/process/process_areas/implementation/implementation_workflow.rst
@@ -80,3 +80,6 @@ RAS(IC) for Implementation:
    :sort: status
    :columns: id as "Activity";responsible as "Responsible";approved_by as "Approver";supported_by as "Supporter"
    :colwidths: 30,30,30,30
+
+.. needextend:: "c.this_doc()"
+   :+tags: implementation

--- a/process/process_areas/implementation/implementation_workproducts.rst
+++ b/process/process_areas/implementation/implementation_workproducts.rst
@@ -51,3 +51,6 @@ Implementation Work Products
    - coding guideline (e.g. MISRA, can also include style guide or naming convention)
    - SW configuration guideline
    - development tools
+
+.. needextend:: "c.this_doc()"
+   :+tags: implementation

--- a/process/process_areas/implementation/index.rst
+++ b/process/process_areas/implementation/index.rst
@@ -26,6 +26,3 @@ Implementation
    implementation_roles
    implementation_workflow
    implementation_workproducts
-
-.. needextend:: "c.this_doc()"
-   :+tags: implementation

--- a/process/process_areas/platform_management/guidance/platform_management_guideline.rst
+++ b/process/process_areas/platform_management/guidance/platform_management_guideline.rst
@@ -154,3 +154,6 @@ Tailoring
    The reasoning is:
 
    - Main deliveries are source code, which is not a product, thus product risk management and process risk is not applicable (for safety and security related risk separate processes as safety/security analysis exists).
+
+.. needextend:: "c.this_doc()"
+   :+tags: platform_management

--- a/process/process_areas/platform_management/guidance/platform_management_template.rst
+++ b/process/process_areas/platform_management/guidance/platform_management_template.rst
@@ -116,3 +116,6 @@ Plan Work Products
       -
       - this document
       - see above
+
+.. needextend:: "c.this_doc()"
+   :+tags: platform_management

--- a/process/process_areas/platform_management/index.rst
+++ b/process/process_areas/platform_management/index.rst
@@ -27,6 +27,3 @@ Platform Management
    platform_management_roles
    platform_management_workflow
    platform_management_workproducts
-
-.. needextend:: docname is not None and "process_areas/platform_management" in docname
-   :+tags: platform_management

--- a/process/process_areas/platform_management/platform_management_concept.rst
+++ b/process/process_areas/platform_management/platform_management_concept.rst
@@ -84,3 +84,6 @@ Monitor/Improve Platform Management Plan
 :need:`Project Lead <rl__project_lead>` is responsible for the monitoring of the
 work products and activities against the platform management plan. If deviations are detected,
 the plan must be adjusted.
+
+.. needextend:: "c.this_doc()"
+   :+tags: platform_management

--- a/process/process_areas/platform_management/platform_management_getstrt.rst
+++ b/process/process_areas/platform_management/platform_management_getstrt.rst
@@ -26,3 +26,6 @@ In case you want to manage contributions to <Project> consider to:
 * Contact the :need:`Project Lead <rl__project_lead>` for your contribution to establish planning and reporting
 * Make familiar with the management, development and supporting process descriptions in :ref:`process_description`
 * Make familiar with the relevant sections of the `Platform Management Plan <gd_temp__platform_mgmt_plan>`
+
+.. needextend:: "c.this_doc()"
+   :+tags: platform_management

--- a/process/process_areas/platform_management/platform_management_roles.rst
+++ b/process/process_areas/platform_management/platform_management_roles.rst
@@ -28,3 +28,6 @@ Contributing Roles:
 A detailed overview of the responsibility for the steps of the platform management process is listed here:
 
 :ref:`workflow_platform_management`
+
+.. needextend:: "c.this_doc()"
+   :+tags: platform_management

--- a/process/process_areas/platform_management/platform_management_workflow.rst
+++ b/process/process_areas/platform_management/platform_management_workflow.rst
@@ -84,3 +84,6 @@ RAS(IC) for Platform Management:
    :sort: status
    :columns: id as "Activity";responsible as "Responsible";approved_by as "Approver";supported_by as "Supporter"
    :colwidths: 30,30,30,30
+
+.. needextend:: "c.this_doc()"
+   :+tags: platform_management

--- a/process/process_areas/platform_management/platform_management_workproducts.rst
+++ b/process/process_areas/platform_management/platform_management_workproducts.rst
@@ -55,3 +55,6 @@ Platform Management Work Products
    Defines the schedule of the project.
 
    Defines escalation path.
+
+.. needextend:: "c.this_doc()"
+   :+tags: platform_management

--- a/process/process_areas/problem_resolution/guidance/problem_resolution_checklist.rst
+++ b/process/process_areas/problem_resolution/guidance/problem_resolution_checklist.rst
@@ -95,3 +95,6 @@ Problem Checklist
       * - 14
         - If the Problem report is not closed and pending solution measures are open, escalated to the :need:`rl__safety_manager` or :need:`rl__security_manager`?
         -
+
+.. needextend:: "c.this_doc()"
+   :+tags: problem_resolution

--- a/process/process_areas/problem_resolution/guidance/problem_resolution_guideline.rst
+++ b/process/process_areas/problem_resolution/guidance/problem_resolution_guideline.rst
@@ -303,3 +303,6 @@ When confirmed, the author sets the status to "closed" manually, if not done aut
 
 :need:`[[title]] <rl__committer>` has the freedom to reject it at any time by setting the status
 to "reject".
+
+.. needextend:: "c.this_doc()"
+   :+tags: problem_resolution

--- a/process/process_areas/problem_resolution/guidance/problem_resolution_reqs.rst
+++ b/process/process_areas/problem_resolution/guidance/problem_resolution_reqs.rst
@@ -218,3 +218,6 @@ Problem Resolution Checks
 
    ISSUEs related to Problem Reports shall not automatically closed, if linked ISSUEs or PRs are closed or merged and
    these ISSUEs shall be closed only manually from the :need:`Committer <rl__committer>`.
+
+.. needextend:: "c.this_doc()"
+   :+tags: problem_resolution

--- a/process/process_areas/problem_resolution/guidance/problem_resolution_template.rst
+++ b/process/process_areas/problem_resolution/guidance/problem_resolution_template.rst
@@ -187,3 +187,6 @@ Problem escalations
 
 | (to be filled out during :need:`wf__problem_initiate_monitor_pr`)
 | (to be updated during :need:`wf__problem_close_pr`)
+
+.. needextend:: "c.this_doc()"
+   :+tags: problem_resolution

--- a/process/process_areas/problem_resolution/index.rst
+++ b/process/process_areas/problem_resolution/index.rst
@@ -27,6 +27,3 @@ Problem Resolution
    problem_resolution_roles
    problem_resolution_workflow
    problem_resolution_workproducts
-
-.. needextend:: "c.this_doc()"
-   :+tags: problem_resolution

--- a/process/process_areas/problem_resolution/problem_resolution_concept.rst
+++ b/process/process_areas/problem_resolution/problem_resolution_concept.rst
@@ -137,3 +137,6 @@ Problem Report to be closed.
 
 Especially the effectiveness of the solution measures must be shown, based on convincing
 arguments, e.g. verification measures must be used to confirm the implementation.
+
+.. needextend:: "c.this_doc()"
+   :+tags: problem_resolution

--- a/process/process_areas/problem_resolution/problem_resolution_getstrt.rst
+++ b/process/process_areas/problem_resolution/problem_resolution_getstrt.rst
@@ -48,3 +48,6 @@ For every problem identified, the following workflows are executed:
 * Close the problem resolution according to :need:`wf__problem_close_pr`
 
 In addition create a problem resolution plan as part of the platform management plan according to :need:`wf__platform_cr_mt_platform_mgmt_plan`.
+
+.. needextend:: "c.this_doc()"
+   :+tags: problem_resolution

--- a/process/process_areas/problem_resolution/problem_resolution_roles.rst
+++ b/process/process_areas/problem_resolution/problem_resolution_roles.rst
@@ -30,3 +30,6 @@ A detailed overview of the responsibilities for the steps of the problem resolut
 listed here:
 
 :ref:`workflow_prm_requirements`
+
+.. needextend:: "c.this_doc()"
+   :+tags: problem_resolution

--- a/process/process_areas/problem_resolution/problem_resolution_workflow.rst
+++ b/process/process_areas/problem_resolution/problem_resolution_workflow.rst
@@ -125,6 +125,3 @@ RAS(IC) for Problem Resolution:
    :sort: status
    :columns: id as "Activity";responsible as "Responsible";approved_by as "Approver";supported_by as "Supporter"
    :colwidths: 30,30,30,30
-
-.. needextend:: "c.this_doc()"
-   :+tags: problem_resolution

--- a/process/process_areas/problem_resolution/problem_resolution_workflow.rst
+++ b/process/process_areas/problem_resolution/problem_resolution_workflow.rst
@@ -125,3 +125,6 @@ RAS(IC) for Problem Resolution:
    :sort: status
    :columns: id as "Activity";responsible as "Responsible";approved_by as "Approver";supported_by as "Supporter"
    :colwidths: 30,30,30,30
+
+.. needextend:: "c.this_doc()"
+   :+tags: problem_resolution

--- a/process/process_areas/problem_resolution/problem_resolution_workproducts.rst
+++ b/process/process_areas/problem_resolution/problem_resolution_workproducts.rst
@@ -23,3 +23,6 @@ Problem Resolution Work Products
    :complies: std_wp__iso26262__support_851[version==1]
 
    Problem Resolution Plan (Part of the Platform Management Plan)
+
+.. needextend:: "c.this_doc()"
+   :+tags: problem_resolution

--- a/process/process_areas/process_management/guidance/process_management_guideline.rst
+++ b/process/process_areas/process_management/guidance/process_management_guideline.rst
@@ -209,3 +209,6 @@ Tailoring
    - For IICs concerning commitment, agreements, organizational processes, as these are not in the scope of the current project.
    - For IICs concerning GPs (2 and 3), at the are not addressed yet in the current project phase or higher, which are out of scope for the current project phase.
    - For IICs concerning specific techniques or methods not used in the current project.
+
+.. needextend:: "c.this_doc()"
+   :+tags: process_management

--- a/process/process_areas/process_management/guidance/process_management_templates.rst
+++ b/process/process_areas/process_management/guidance/process_management_templates.rst
@@ -279,3 +279,6 @@ Templates
    'fullfils' link from a 'TEXT FILE' to a work product defined in the process
    description. This link is implemented by the ':realize:' attribute in the template
    above.
+
+.. needextend:: "c.this_doc()"
+   :+tags: process_management

--- a/process/process_areas/process_management/index.rst
+++ b/process/process_areas/process_management/index.rst
@@ -27,6 +27,3 @@ Process Management
    process_management_roles
    process_management_workflow
    process_management_workproducts
-
-.. needextend:: "c.this_doc()"
-   :+tags: process_management

--- a/process/process_areas/process_management/process_management_concept.rst
+++ b/process/process_areas/process_management/process_management_concept.rst
@@ -140,3 +140,6 @@ Every :need:`rl__contributor` can propose improvements using the project ISSUE T
 system.
 
 Improvements are approved by the :need:`rl__process_community`.
+
+.. needextend:: "c.this_doc()"
+   :+tags: process_management

--- a/process/process_areas/process_management/process_management_getstrt.rst
+++ b/process/process_areas/process_management/process_management_getstrt.rst
@@ -37,3 +37,6 @@ For every change identified, the following workflows are executed:
 * Create and maintain process management strategy according to :need:`wf__cr_mt_process_mgt_strategy`
 * Define and approves process description according to :need:`wf__def_app_process_description`
 * Monitor and improve process implementation and trigger improvements according  :need:`wf__mon_imp_process_description`
+
+.. needextend:: "c.this_doc()"
+   :+tags: process_management

--- a/process/process_areas/process_management/process_management_roles.rst
+++ b/process/process_areas/process_management/process_management_roles.rst
@@ -28,3 +28,6 @@ Contributing Roles:
 A detailed overview of the responsibility for the steps of the requirement process is listed here:
 
 :ref:`workflow_process_management_requirements`
+
+.. needextend:: "c.this_doc()"
+   :+tags: process_management

--- a/process/process_areas/process_management/process_management_workflow.rst
+++ b/process/process_areas/process_management/process_management_workflow.rst
@@ -77,3 +77,6 @@ RAS(IC) for Process Management:
    :sort: status
    :columns: id as "Activity";responsible as "Responsible";approved_by as "Approver";supported_by as "Supporter"
    :colwidths: 30,30,30,30
+
+.. needextend:: "c.this_doc()"
+   :+tags: process_management

--- a/process/process_areas/process_management/process_management_workflow.rst
+++ b/process/process_areas/process_management/process_management_workflow.rst
@@ -77,6 +77,3 @@ RAS(IC) for Process Management:
    :sort: status
    :columns: id as "Activity";responsible as "Responsible";approved_by as "Approver";supported_by as "Supporter"
    :colwidths: 30,30,30,30
-
-.. needextend:: "c.this_doc()"
-   :+tags: process_management

--- a/process/process_areas/process_management/process_management_workproducts.rst
+++ b/process/process_areas/process_management/process_management_workproducts.rst
@@ -134,3 +134,6 @@ Here only project specific work products are listed, which are generic for the p
    for your project (documented in the PMP), to be able to demonstrate completeness.
    It is not really a work product definition,
    but this is the best way to link to the tailored out standard work products.
+
+.. needextend:: "c.this_doc()"
+   :+tags: process_management

--- a/process/process_areas/quality_management/guidance/index.rst
+++ b/process/process_areas/quality_management/guidance/index.rst
@@ -24,3 +24,6 @@ Guidance
    quality_process_reqs
    quality_work_product_review_guideline
    quality_plan_template
+
+.. needextend:: "c.this_doc()"
+   :+tags: quality_management

--- a/process/process_areas/quality_management/guidance/quality_plan_guideline.rst
+++ b/process/process_areas/quality_management/guidance/quality_plan_guideline.rst
@@ -104,3 +104,6 @@ Guideline Quality Management Plan
    | * Training content
    | * Training schedule
    | * Responsible persons
+
+.. needextend:: "c.this_doc()"
+   :+tags: quality_management

--- a/process/process_areas/quality_management/guidance/quality_plan_template.rst
+++ b/process/process_areas/quality_management/guidance/quality_plan_template.rst
@@ -135,3 +135,6 @@ Description of Quality Management Specifics.
 4.4 Quality Management Generic workproducts
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Description of used Generic Workproducts for Quality Management.
+
+.. needextend:: "c.this_doc()"
+   :+tags: quality_management

--- a/process/process_areas/quality_management/guidance/quality_process_reqs.rst
+++ b/process/process_areas/quality_management/guidance/quality_process_reqs.rst
@@ -25,3 +25,6 @@ Process Requirements
 
    | The quality report shall be generated progressively and automatically compiling the work products.
    | A template exists to guide the reporting and the right collection of the required work products.
+
+.. needextend:: "c.this_doc()"
+   :+tags: quality_management

--- a/process/process_areas/quality_management/guidance/quality_report_template.rst
+++ b/process/process_areas/quality_management/guidance/quality_report_template.rst
@@ -68,3 +68,6 @@ Template Quality Report
     - Status of the process improvements (open / closed)
 
     **Note1:** All the above lists are generated automatically
+
+.. needextend:: "c.this_doc()"
+   :+tags: quality_management

--- a/process/process_areas/quality_management/guidance/quality_review_checklist.rst
+++ b/process/process_areas/quality_management/guidance/quality_review_checklist.rst
@@ -457,3 +457,6 @@ Software Development Plan review checklist template
           -
           - Check if all tools used for software development are clearly described and listed in the project's tool list. If possible check if they are used as defined.
           -
+
+.. needextend:: "c.this_doc()"
+   :+tags: quality_management

--- a/process/process_areas/quality_management/guidance/quality_work_product_review_guideline.rst
+++ b/process/process_areas/quality_management/guidance/quality_work_product_review_guideline.rst
@@ -44,3 +44,6 @@ Process
 | Step  8: Trigger authors of WPs with deviations to resolve them in the same PR and close the corresponding bug issue
 | Step  9: If all bug issues are resolved, continue with 5, otherwise continue with 8
 | Step 10: Merge the PR and communicate the result, initial issue is now in status CLOSED
+
+.. needextend:: "c.this_doc()"
+   :+tags: quality_management

--- a/process/process_areas/quality_management/index.rst
+++ b/process/process_areas/quality_management/index.rst
@@ -26,6 +26,3 @@ Quality Management
    quality_roles
    quality_workflow
    quality_workproducts
-
-.. needextend:: "c.this_doc()"
-   :+tags: quality_management

--- a/process/process_areas/quality_management/quality_concept.rst
+++ b/process/process_areas/quality_management/quality_concept.rst
@@ -81,3 +81,6 @@ Every person who contributes shall be trained according to Quality aspects. The 
 by following the workflows which are defined in the different process areas. The Quality Manager is responsible for the
 Quality related workflows. The Quality Manager shall be independent from the development organization with a escalation
 to the Project Lead Circle.
+
+.. needextend:: "c.this_doc()"
+   :+tags: quality_management

--- a/process/process_areas/quality_management/quality_getstrt.rst
+++ b/process/process_areas/quality_management/quality_getstrt.rst
@@ -48,3 +48,6 @@ For every release, the following workflows are executed:
 
 For open issues the issue tracking system is used to track the issues and to ensure that they are resolved in time.
 The issue tracking system is defined in the :need:`wp__issue_track_system`.
+
+.. needextend:: "c.this_doc()"
+   :+tags: quality_management

--- a/process/process_areas/quality_management/quality_roles.rst
+++ b/process/process_areas/quality_management/quality_roles.rst
@@ -58,3 +58,6 @@ Roles
    * Escalation of planning topics to the :need:`rl__project_lead`
    * Definition of quality assurance measures
    * Refusing the approval of work products as defined in the workflows
+
+.. needextend:: "c.this_doc()"
+   :+tags: quality_management

--- a/process/process_areas/quality_management/quality_workproducts.rst
+++ b/process/process_areas/quality_management/quality_workproducts.rst
@@ -64,3 +64,6 @@ Quality Management Work Products
    :complies: std_wp__iso26262__management_552[version==1], std_req__aspice_40__iic-06-04[version==1], std_req__aspice_40__iic-10-51[version==1]
 
    | Trainings shall give dedicated information how to apply the processes and work products in the project.
+
+.. needextend:: "c.this_doc()"
+   :+tags: quality_management

--- a/process/process_areas/release_management/guidance/index.rst
+++ b/process/process_areas/release_management/guidance/index.rst
@@ -21,3 +21,6 @@ Guidance
    release_guideline
    release_templates
    release_process_reqs
+
+.. needextend:: "c.this_doc()"
+   :+tags: release_management

--- a/process/process_areas/release_management/guidance/release_guideline.rst
+++ b/process/process_areas/release_management/guidance/release_guideline.rst
@@ -161,3 +161,6 @@ For the release note a template has been created for module level and for platfo
      - :need:`[[title]] <gd_temp__rel_plat_rel_note>`
 
 The above templates shall be used
+
+.. needextend:: "c.this_doc()"
+   :+tags: release_management

--- a/process/process_areas/release_management/guidance/release_process_reqs.rst
+++ b/process/process_areas/release_management/guidance/release_process_reqs.rst
@@ -25,3 +25,6 @@ Process Requirements
 
    | The release note shall be generated progressively and automatically compiling the content as far as possible.
    | This shall be done according to templates :need:`gd_temp__rel_plat_rel_note` and :need:`gd_temp__rel_mod_rel_note`.
+
+.. needextend:: "c.this_doc()"
+   :+tags: release_management

--- a/process/process_areas/release_management/guidance/release_templates.rst
+++ b/process/process_areas/release_management/guidance/release_templates.rst
@@ -77,3 +77,6 @@ Templates
    | 6. Document project manager's consent by asking review approval of the release note
    | 7. Create the "release" in version management tool according to :need:`gd_guidl__rel_management`
    | 8. Merge PR and close this issue to complete the release
+
+.. needextend:: "c.this_doc()"
+   :+tags: release_management

--- a/process/process_areas/release_management/index.rst
+++ b/process/process_areas/release_management/index.rst
@@ -26,6 +26,3 @@ Release Management
    release_roles
    release_workflow
    release_workproducts
-
-.. needextend:: docname is not None and "process_areas/release_management" in docname
-   :+tags: release_management

--- a/process/process_areas/release_management/release_concept.rst
+++ b/process/process_areas/release_management/release_concept.rst
@@ -121,3 +121,6 @@ Workflow:
 #. When ready for a new release, create a branch release/<version-number> from main (if needed).
 #. Perform final testing and adjustments on the release branch (test results should be available continuously, but maybe not all).
 #. Tag the release in the release branch.
+
+.. needextend:: "c.this_doc()"
+   :+tags: release_management

--- a/process/process_areas/release_management/release_getstrt.rst
+++ b/process/process_areas/release_management/release_getstrt.rst
@@ -46,3 +46,6 @@ The following workflows are executed:
 * According to the planning create the platform handbook :need:`wf__rel_platform_handbook`
 
 In addition create a release management plan as part of the platform management plan according to :need:`wf__platform_cr_mt_platform_mgmt_plan`.
+
+.. needextend:: "c.this_doc()"
+   :+tags: release_management

--- a/process/process_areas/release_management/release_roles.rst
+++ b/process/process_areas/release_management/release_roles.rst
@@ -25,3 +25,6 @@ Contributing Roles:
 
 A detailed overview of the responsibility for the steps of the Release Management process
 is listed here: :need:`doc_concept__rel_process`
+
+.. needextend:: "c.this_doc()"
+   :+tags: release_management

--- a/process/process_areas/release_management/release_workflow.rst
+++ b/process/process_areas/release_management/release_workflow.rst
@@ -133,3 +133,6 @@ RAS(IC) for Release Management:
    :sort: status
    :columns: id as "Activity";responsible as "Responsible";approved_by as "Approver";supported_by as "Supporter"
    :colwidths: 30,30,30,30
+
+.. needextend:: "c.this_doc()"
+   :+tags: release_management

--- a/process/process_areas/release_management/release_workproducts.rst
+++ b/process/process_areas/release_management/release_workproducts.rst
@@ -93,3 +93,6 @@ Release Management Work Products
    - Integration process
    - Getting started guide
    - Contribution guide
+
+.. needextend:: "c.this_doc()"
+   :+tags: release_management

--- a/process/process_areas/requirements_engineering/guidance/index.rst
+++ b/process/process_areas/requirements_engineering/guidance/index.rst
@@ -22,3 +22,6 @@ Guidance
    requirements_inspection_checklist
    requirements_templates
    requirements_process_reqs
+
+.. needextend:: "c.this_doc()"
+   :+tags: requirements_engineering

--- a/process/process_areas/requirements_engineering/guidance/requirements_guideline.rst
+++ b/process/process_areas/requirements_engineering/guidance/requirements_guideline.rst
@@ -294,3 +294,6 @@ Tailoring
 
    - for "system" standard requirements: see platform safety plan in PMP
    - for "software" standard requirements: 644, 646: because they refer to (PMP) tailored work product, 643: because this refers to (PMP) tailored activity
+
+.. needextend:: "c.this_doc()"
+   :+tags: requirements_engineering

--- a/process/process_areas/requirements_engineering/guidance/requirements_inspection_checklist.rst
+++ b/process/process_areas/requirements_engineering/guidance/requirements_inspection_checklist.rst
@@ -38,3 +38,6 @@ Requirement Inspection Checklist
    - :need:`doc__stakeholder_req_inspection`
 
    These have the same questions, but different scope and document naming.
+
+.. needextend:: "c.this_doc()"
+   :+tags: requirements_engineering

--- a/process/process_areas/requirements_engineering/guidance/requirements_process_reqs.rst
+++ b/process/process_areas/requirements_engineering/guidance/requirements_process_reqs.rst
@@ -446,3 +446,6 @@ Process Requirements Checks
 
    Validity attributes (:need:`gd_req__req_attr_valid_from` and :need:`gd_req__req_attr_valid_until`) shall be checked for correctness (i.e. they denote an existing milestone) and consistent (e.g. the until is not before from)
    Several of the above checks are not to be executed on requirements not valid in the next milestone, these are TBD
+
+.. needextend:: "c.this_doc()"
+   :+tags: requirements_engineering

--- a/process/process_areas/requirements_engineering/guidance/requirements_templates.rst
+++ b/process/process_areas/requirements_engineering/guidance/requirements_templates.rst
@@ -133,3 +133,6 @@ Templates
 
    .. note::
       Of the last three columns of the above sentence template table, filling one is mandatory the others are optional.
+
+.. needextend:: "c.this_doc()"
+   :+tags: requirements_engineering

--- a/process/process_areas/requirements_engineering/index.rst
+++ b/process/process_areas/requirements_engineering/index.rst
@@ -26,6 +26,3 @@ Requirements Engineering
    requirements_roles
    requirements_workflow
    requirements_workproducts
-
-.. needextend:: docname is not None and "process_areas/requirements_engineering" in docname
-   :+tags: requirements_engineering

--- a/process/process_areas/requirements_engineering/requirements_concept.rst
+++ b/process/process_areas/requirements_engineering/requirements_concept.rst
@@ -307,3 +307,6 @@ Traceability Concept for Requirements
 The standards require that a requirement can be traced throughout the complete hierarchy levels including its :ref:`implementation <implementation>` and :ref:`verification <process_verification>`.
 
 In general the traceability is visualized in main development work product traceability model (:ref:`general_concepts_traceability`).
+
+.. needextend:: "c.this_doc()"
+   :+tags: requirements_engineering

--- a/process/process_areas/requirements_engineering/requirements_getstrt.rst
+++ b/process/process_areas/requirements_engineering/requirements_getstrt.rst
@@ -49,3 +49,6 @@ Tooling Support
 The requirements templates and examples are built by using the means of a specific "Docs-as-Code" tool,
 but this does not mean that projects are required to use this, as long as the content (e.g. attributes)
 and functionality described in :ref:`process_requirements` is covered by the selected tool.
+
+.. needextend:: "c.this_doc()"
+   :+tags: requirements_engineering

--- a/process/process_areas/requirements_engineering/requirements_roles.rst
+++ b/process/process_areas/requirements_engineering/requirements_roles.rst
@@ -28,3 +28,6 @@ Contributing Roles:
 A detailed overview of the responsibility for the steps of the requirement process is listed here:
 
 :ref:`workflow_requirements`
+
+.. needextend:: "c.this_doc()"
+   :+tags: requirements_engineering

--- a/process/process_areas/requirements_engineering/requirements_workflow.rst
+++ b/process/process_areas/requirements_engineering/requirements_workflow.rst
@@ -134,3 +134,6 @@ RAS(IC) for Requirements Engineering:
    :sort: status
    :columns: id as "Activity";responsible as "Responsible";approved_by as "Approver";supported_by as "Supporter"
    :colwidths: 30,30,30,30
+
+.. needextend:: "c.this_doc()"
+   :+tags: requirements_engineering

--- a/process/process_areas/requirements_engineering/requirements_workproducts.rst
+++ b/process/process_areas/requirements_engineering/requirements_workproducts.rst
@@ -95,3 +95,6 @@ Requirements Engineering Work Products
    Depends on requirements management tooling, expect text based requirements.
 
    Review done with inspection checklist. This checklist may be integrated in requirements/version management tooling.
+
+.. needextend:: "c.this_doc()"
+   :+tags: requirements_engineering

--- a/process/process_areas/safety_analysis/guidance/dfa_failure_initiators.rst
+++ b/process/process_areas/safety_analysis/guidance/dfa_failure_initiators.rst
@@ -203,3 +203,6 @@ DFA failure initiators
   * - SC_01_05
     - Development fault (e.g. human error, insufficient qualification, insufficient methods). Only applicable if diverse development is needed.
     - Medium
+
+.. needextend:: "c.this_doc()"
+   :+tags: safety_analysis

--- a/process/process_areas/safety_analysis/guidance/dfa_templates.rst
+++ b/process/process_areas/safety_analysis/guidance/dfa_templates.rst
@@ -69,3 +69,6 @@ DFA Templates
               std_req__isopas8926__44432[version==1]
 
    For the content see here: `Component DFA Template <https://eclipse-score.github.io/module_template/main/components/component_example/safety_analysis/dfa.html>`__
+
+.. needextend:: "c.this_doc()"
+   :+tags: safety_analysis

--- a/process/process_areas/safety_analysis/guidance/fault_models_guideline.rst
+++ b/process/process_areas/safety_analysis/guidance/fault_models_guideline.rst
@@ -99,3 +99,6 @@ FMEA Fault Models
       - EX_01_06
       - processing is not complete (infinite loop)
       - High
+
+.. needextend:: "c.this_doc()"
+   :+tags: safety_analysis

--- a/process/process_areas/safety_analysis/guidance/fmea_templates.rst
+++ b/process/process_areas/safety_analysis/guidance/fmea_templates.rst
@@ -57,3 +57,6 @@ FMEA Templates
               std_req__isopas8926__44431[version==1]
 
       For the content see here: `Component FMEA Template <https://eclipse-score.github.io/module_template/main/components/component_example/safety_analysis/fmea.html>`__
+
+.. needextend:: "c.this_doc()"
+   :+tags: safety_analysis

--- a/process/process_areas/safety_analysis/guidance/index.rst
+++ b/process/process_areas/safety_analysis/guidance/index.rst
@@ -25,3 +25,6 @@ Guidance
    safety_analysis_checklist
    safety_analysis_guideline
    safety_analysis_process_reqs
+
+.. needextend:: "c.this_doc()"
+   :+tags: safety_analysis

--- a/process/process_areas/safety_analysis/guidance/safety_analysis_checklist.rst
+++ b/process/process_areas/safety_analysis/guidance/safety_analysis_checklist.rst
@@ -32,3 +32,6 @@ Safety Analysis Checklist
 
     - :need:`doc__platform_safety_analysis_fdr` (platform)
     - `Safety Analysis Checklist <https://eclipse-score.github.io/module_template/main/module/safety_mgt/module_safety_analysis_fdr.html>`__ (module)
+
+.. needextend:: "c.this_doc()"
+   :+tags: safety_analysis

--- a/process/process_areas/safety_analysis/guidance/safety_analysis_guideline.rst
+++ b/process/process_areas/safety_analysis/guidance/safety_analysis_guideline.rst
@@ -233,3 +233,6 @@ Tailoring
    The reasoning is:
 
    - see platform safety plan in PMP
+
+.. needextend:: "c.this_doc()"
+   :+tags: safety_analysis

--- a/process/process_areas/safety_analysis/index.rst
+++ b/process/process_areas/safety_analysis/index.rst
@@ -26,6 +26,3 @@ Safety Analysis
    safety_analysis_roles
    safety_analysis_workflow
    safety_analysis_workproducts
-
-.. needextend:: "c.this_doc()"
-   :+tags: safety_analysis

--- a/process/process_areas/safety_analysis/safety_analysis_concept.rst
+++ b/process/process_areas/safety_analysis/safety_analysis_concept.rst
@@ -165,3 +165,6 @@ The Safety Analysis (DFA and FMEA) shall consider the architectural elements on 
 
     | **Example DFA:** Similar to the feature level, but with a focus on the interactions between sub-components within a single component.
     | **Example FMEA:** The FMEA shall used to analyse if the safety requirements of a component can be violated. This might be a unintended sent of a message between two sub-components.
+
+.. needextend:: "c.this_doc()"
+   :+tags: safety_analysis

--- a/process/process_areas/safety_analysis/safety_analysis_getstrt.rst
+++ b/process/process_areas/safety_analysis/safety_analysis_getstrt.rst
@@ -39,3 +39,6 @@ The Safety Analysis is performed in three steps.
 
 The details of what needs to be done in each step are described in the :need:`gd_guidl__safety_analysis`. For the Safety Analysis
 templates are used. The templates are described in the :ref:`FMEA_templates` and :ref:`DFA_templates`.
+
+.. needextend:: "c.this_doc()"
+   :+tags: safety_analysis

--- a/process/process_areas/safety_analysis/safety_analysis_roles.rst
+++ b/process/process_areas/safety_analysis/safety_analysis_roles.rst
@@ -66,3 +66,6 @@ Contributing Roles:
 A detailed overview of the responsibility for the steps of the Safety Analysis process is listed in the section titled "Workflow for Safety Analysis". You can find it here:
 
 :ref:`workflow_safety_analysis`
+
+.. needextend:: "c.this_doc()"
+   :+tags: safety_analysis

--- a/process/process_areas/safety_analysis/safety_analysis_workflow.rst
+++ b/process/process_areas/safety_analysis/safety_analysis_workflow.rst
@@ -134,3 +134,6 @@ RAS(IC) for Safety Analysis  (FMEA and DFA)
    :sort: status
    :columns: id as "Activity";responsible as "Responsible";approved_by as "Approver";supported_by as "Supporter"
    :colwidths: 30,30,30,30
+
+.. needextend:: "c.this_doc()"
+   :+tags: safety_analysis

--- a/process/process_areas/safety_analysis/safety_analysis_workproducts.rst
+++ b/process/process_areas/safety_analysis/safety_analysis_workproducts.rst
@@ -79,3 +79,6 @@ Safety Analysis Work Products
    Perform analysis of safety related and non-safety related sub-elements or sub-elements with different ASIL.
 
    Perform analysis on interactions between safety related and non-safety related lower level components or lower level components with different ASIL of one (higher level) component.
+
+.. needextend:: "c.this_doc()"
+   :+tags: safety_analysis

--- a/process/process_areas/safety_management/guidance/checklist_safety_package.rst
+++ b/process/process_areas/safety_management/guidance/checklist_safety_package.rst
@@ -33,3 +33,6 @@ Safety Package Formal Review Checklist
               std_req__iso26262__management_64105[version==1]
 
    For the content see here: `Safety Package Formal Review Checklist <https://eclipse-score.github.io/module_template/main/module/safety_mgt/module_safety_package_fdr.html>`__
+
+.. needextend:: "c.this_doc()"
+   :+tags: safety_management

--- a/process/process_areas/safety_management/guidance/checklist_safety_plan.rst
+++ b/process/process_areas/safety_management/guidance/checklist_safety_plan.rst
@@ -39,3 +39,6 @@ Safety Plan Formal Review Checklist
               std_req__iso26262__management_64111[version==1]
 
    For the content see here: `Safety Plan Formal Review Checklist <https://eclipse-score.github.io/module_template/main/module/safety_mgt/module_safety_plan_fdr.html>`__
+
+.. needextend:: "c.this_doc()"
+   :+tags: safety_management

--- a/process/process_areas/safety_management/guidance/guideline_component_classification.rst
+++ b/process/process_areas/safety_management/guidance/guideline_component_classification.rst
@@ -38,3 +38,6 @@ Component Classification Guideline
               std_req__aspice_40__REU-2-BP3[version==1]
 
    For the content see here: `Component Classification Template <https://eclipse-score.github.io/module_template/main/components/component_example/component_classification.html>`__
+
+.. needextend:: "c.this_doc()"
+   :+tags: safety_management

--- a/process/process_areas/safety_management/guidance/guideline_safety_management.rst
+++ b/process/process_areas/safety_management/guidance/guideline_safety_management.rst
@@ -263,3 +263,6 @@ Tailoring
    - for "support" standard requirements: The requirement is not applicable for an ASIL_B process
    - for "management" standard requirements: 6453 - not proven in use argument, 6454 - no HW part of SW platform, 6456 - no confidence in use, 64610 - no distributed development
    - for "management" standard requirements 6412*: No assessment planned, as also no finalized safety case is planned
+
+.. needextend:: "c.this_doc()"
+   :+tags: safety_management

--- a/process/process_areas/safety_management/guidance/index.rst
+++ b/process/process_areas/safety_management/guidance/index.rst
@@ -27,3 +27,6 @@ Guidance
    checklist_safety_plan.rst
    checklist_safety_package.rst
    process_req.rst
+
+.. needextend:: "c.this_doc()"
+   :+tags: safety_management

--- a/process/process_areas/safety_management/guidance/process_req.rst
+++ b/process/process_areas/safety_management/guidance/process_req.rst
@@ -39,3 +39,6 @@ Safety Management Process Requirements
 
    Note: This can be done as for documents if the work product is a single sphinx-need.
    For work products collections (e.g. all requirements of a component) an accumulated status is needed (e.g. like "% valid state")
+
+.. needextend:: "c.this_doc()"
+   :+tags: safety_management

--- a/process/process_areas/safety_management/guidance/template_component_classification.rst
+++ b/process/process_areas/safety_management/guidance/template_component_classification.rst
@@ -35,3 +35,6 @@ Component Classification Template
               std_req__aspice_40__iic-15-07[version==1]
 
    For the content see here: `Component Classification Template <https://eclipse-score.github.io/module_template/main/components/component_example/component_classification.html>`__
+
+.. needextend:: "c.this_doc()"
+   :+tags: safety_management

--- a/process/process_areas/safety_management/guidance/template_safety_manual.rst
+++ b/process/process_areas/safety_management/guidance/template_safety_manual.rst
@@ -33,3 +33,6 @@ Safety Manual Template
               std_req__aspice_40__iic-13-53[version==1]
 
    For the content see here: `Safety Manual Template <https://eclipse-score.github.io/module_template/main/module/manuals/safety_manual.html>`__
+
+.. needextend:: "c.this_doc()"
+   :+tags: safety_management

--- a/process/process_areas/safety_management/guidance/templates_safety_plan.rst
+++ b/process/process_areas/safety_management/guidance/templates_safety_plan.rst
@@ -73,3 +73,6 @@ Safety Planning Templates
               std_req__iso26262__management_6421[version==1]
 
    For the content see here: :need:`doc__platform_safety_plan`
+
+.. needextend:: "c.this_doc()"
+   :+tags: safety_management

--- a/process/process_areas/safety_management/index.rst
+++ b/process/process_areas/safety_management/index.rst
@@ -26,6 +26,3 @@ Safety Management
    safety_management_roles
    safety_management_workflow
    safety_management_workproducts
-
-.. needextend:: "c.this_doc()"
-   :+tags: safety_management

--- a/process/process_areas/safety_management/safety_management_concept.rst
+++ b/process/process_areas/safety_management/safety_management_concept.rst
@@ -108,3 +108,6 @@ For the safety planning and safety manual a “Docs-as-Code” approach is used 
 For the activities planning (who, when) we use :need:`wp__issue_track_system` to create and manage issues, and monitor progress through a project management dashboard.
 
 For the reporting (e.g. displaying the status of the work products) additional tooling is created.
+
+.. needextend:: "c.this_doc()"
+   :+tags: safety_management

--- a/process/process_areas/safety_management/safety_management_getstrt.rst
+++ b/process/process_areas/safety_management/safety_management_getstrt.rst
@@ -48,3 +48,6 @@ Additional to the continuous workflows the following workflows shall be executed
 
 For open issues the issue tracking system is used to track the issues and to ensure that they are resolved in time.
 The issue tracking system is defined in the :need:`wp__issue_track_system`.
+
+.. needextend:: "c.this_doc()"
+   :+tags: safety_management

--- a/process/process_areas/safety_management/safety_management_roles.rst
+++ b/process/process_areas/safety_management/safety_management_roles.rst
@@ -71,7 +71,7 @@ Roles
    * Refusing the approval of his team's role nomination (i.e. requesting that the role will be withdrawn)
 
 .. role:: Safety External Auditor
-   :id: rl__safety_external_auditor 
+   :id: rl__safety_external_auditor
    :status: valid
    :version: 1
 
@@ -87,3 +87,6 @@ Roles
    Authority
 
    * Decision on the passing or failing of an audit
+
+.. needextend:: "c.this_doc()"
+   :+tags: safety_management

--- a/process/process_areas/safety_management/safety_management_workproducts.rst
+++ b/process/process_areas/safety_management/safety_management_workproducts.rst
@@ -171,3 +171,6 @@ Safety Management Work Products
    * Feature/Component
 
    It belongs to the Safety Plan.
+
+.. needextend:: "c.this_doc()"
+   :+tags: safety_management

--- a/process/process_areas/security_analysis/guidance/index.rst
+++ b/process/process_areas/security_analysis/guidance/index.rst
@@ -27,3 +27,6 @@ Guidance
    security_analysis_threat_templates
    security_analysis_checklist
    security_analysis_process_reqs
+
+.. needextend:: "c.this_doc()"
+   :+tags: security_analysis

--- a/process/process_areas/security_analysis/guidance/security_analysis_checklist.rst
+++ b/process/process_areas/security_analysis/guidance/security_analysis_checklist.rst
@@ -27,3 +27,6 @@ Security Analysis Checklist
 
    - :need:`doc__platform_name_security_analysis_fdr` (platform)
    - (tbd) `Security Analysis Checklist <https://eclipse-score.github.io/module_template/main/module/security_mgt/index.html>`__ (module)
+
+.. needextend:: "c.this_doc()"
+   :+tags: security_analysis

--- a/process/process_areas/security_analysis/guidance/security_analysis_guideline.rst
+++ b/process/process_areas/security_analysis/guidance/security_analysis_guideline.rst
@@ -157,4 +157,7 @@ The security analysis shall be used to analyze whether the security goals of a f
 Examples for Security Analysis at component level
 =================================================
 
-The security analysis shall be used to analyze whether the vulnerabilities within the component can be exploited. This could be unintended privilege escalation between two sub-components, allowing unauthorized access to senstive data or security-critical functions.  
+The security analysis shall be used to analyze whether the vulnerabilities within the component can be exploited. This could be unintended privilege escalation between two sub-components, allowing unauthorized access to senstive data or security-critical functions.
+
+.. needextend:: "c.this_doc()"
+   :+tags: security_analysis

--- a/process/process_areas/security_analysis/guidance/security_analysis_threat_models_guideline.rst
+++ b/process/process_areas/security_analysis/guidance/security_analysis_threat_models_guideline.rst
@@ -152,3 +152,6 @@ Threat Models for sequence diagrams
       - LA_01_03
       - sensitive data is logged (Information Disclosure)
       - High
+
+.. needextend:: "c.this_doc()"
+   :+tags: security_analysis

--- a/process/process_areas/security_analysis/guidance/security_analysis_threat_scenario_templates.rst
+++ b/process/process_areas/security_analysis/guidance/security_analysis_threat_scenario_templates.rst
@@ -49,3 +49,6 @@ Security Analysis Threat Scenario Templates
    For the content see here: (tbd) `Component Security Analysis Template <https://eclipse-score.github.io/module_template/main/components/component_example/index.html>`__
 
    Future PR (https://github.com/eclipse-score/process_description/issues/409).
+
+.. needextend:: "c.this_doc()"
+   :+tags: security_analysis

--- a/process/process_areas/security_analysis/guidance/security_analysis_threat_scenarios_guideline.rst
+++ b/process/process_areas/security_analysis/guidance/security_analysis_threat_scenarios_guideline.rst
@@ -214,3 +214,6 @@ Security Analysis threat scenarios
   * - SC_01_05
     - Development vulnerabilities (e.g. human error, insufficient security training, insufficient secure coding practices).
     - High
+
+.. needextend:: "c.this_doc()"
+   :+tags: security_analysis

--- a/process/process_areas/security_analysis/guidance/security_analysis_threat_templates.rst
+++ b/process/process_areas/security_analysis/guidance/security_analysis_threat_templates.rst
@@ -38,3 +38,6 @@ Security Analysis Threat Templates
       For the content see here: (tbd) `Component Threat Template <https://eclipse-score.github.io/module_template/main/components/component_example/index.html>`__
 
       Future PR (https://github.com/eclipse-score/process_description/issues/409).
+
+.. needextend:: "c.this_doc()"
+   :+tags: security_analysis

--- a/process/process_areas/security_analysis/index.rst
+++ b/process/process_areas/security_analysis/index.rst
@@ -28,6 +28,3 @@ Security Analysis
    security_analysis_roles
    security_analysis_workflow
    security_analysis_workproducts
-
-.. needextend:: "c.this_doc()"
-   :+tags: security_analysis

--- a/process/process_areas/security_analysis/security_analysis_concept.rst
+++ b/process/process_areas/security_analysis/security_analysis_concept.rst
@@ -157,3 +157,6 @@ The Security Analysis shall consider the architectural elements on different lev
 3. **Component Level**: If a component consists of multiple sub-components, the analysis
    must be extended to these sub-components. This level of detail is necessary to
    identify specific threat models that may not be apparent at higher levels.
+
+.. needextend:: "c.this_doc()"
+   :+tags: security_analysis

--- a/process/process_areas/security_analysis/security_analysis_getstrt.rst
+++ b/process/process_areas/security_analysis/security_analysis_getstrt.rst
@@ -44,3 +44,6 @@ The details of what needs to be done in each step are described in the
 :need:`gd_guidl__security_analysis`. For the Security Analysis
 templates are used. The templates are described in the
 :ref:`security_analysis_threat_templates` and :ref:`security_analysis_templates`.
+
+.. needextend:: "c.this_doc()"
+   :+tags: security_analysis

--- a/process/process_areas/security_analysis/security_analysis_roles.rst
+++ b/process/process_areas/security_analysis/security_analysis_roles.rst
@@ -69,3 +69,6 @@ A detailed overview of the responsibility for the steps of the Security Analysis
 is listed in the section titled "Security Analysis Workflows". You can find it here:
 
 :ref:`workflow_security_analysis`
+
+.. needextend:: "c.this_doc()"
+   :+tags: security_analysis

--- a/process/process_areas/security_analysis/security_analysis_workflow.rst
+++ b/process/process_areas/security_analysis/security_analysis_workflow.rst
@@ -131,3 +131,6 @@ RAS(IC) for Security Analysis
    :sort: status
    :columns: id as "Activity";responsible as "Responsible";approved_by as "Approver";supported_by as "Supporter"
    :colwidths: 30,30,30,30
+
+.. needextend:: "c.this_doc()"
+   :+tags: security_analysis

--- a/process/process_areas/security_analysis/security_analysis_workproducts.rst
+++ b/process/process_areas/security_analysis/security_analysis_workproducts.rst
@@ -78,3 +78,6 @@ Security Analysis Work Products
    Perform analysis on interactions between security-relevant and non-security-relevant
    sub-components or sub-components with different security levels of one component.
    Including potential influences from the other components in the component's module.
+
+.. needextend:: "c.this_doc()"
+   :+tags: security_analysis

--- a/process/process_areas/security_management/guidance/checklist_security_package.rst
+++ b/process/process_areas/security_management/guidance/checklist_security_package.rst
@@ -22,3 +22,6 @@ Security Package Formal Review Checklist
    :complies: std_req__isosae21434__prj_management_6471[version==1], std_req__isosae21434__prj_management_6491[version==1], std_req__isosae21434__prj_management_6492[version==1]
 
    For the content see here: `Security Package Formal Review Checklist <https://eclipse-score.github.io/module_template/main/module/security_mgt/module_security_package_fdr.html>`__
+
+.. needextend:: "c.this_doc()"
+   :+tags: security_management

--- a/process/process_areas/security_management/guidance/checklist_security_plan.rst
+++ b/process/process_areas/security_management/guidance/checklist_security_plan.rst
@@ -72,3 +72,6 @@ Security Plan Formal Review Checklist
               std_req__isosae21434__prj_management_6462[version==1]
 
    For the content see here: `Security Plan Formal Review Checklist <https://eclipse-score.github.io/module_template/main/module/security_mgt/module_security_plan_fdr.html>`__
+
+.. needextend:: "c.this_doc()"
+   :+tags: security_management

--- a/process/process_areas/security_management/guidance/index.rst
+++ b/process/process_areas/security_management/guidance/index.rst
@@ -24,3 +24,6 @@ Guidance
    checklist_security_package
    checklist_security_plan
    security_management_process_reqs
+
+.. needextend:: "c.this_doc()"
+   :+tags: security_management

--- a/process/process_areas/security_management/guidance/security_management_guideline.rst
+++ b/process/process_areas/security_management/guidance/security_management_guideline.rst
@@ -198,3 +198,6 @@ Security Management Guideline
    The Security Package shall be generated progressively and automatically compiling the work products.
    One of the checks to perform on the platform safety package is to check completeness of the
    process compliance to standards, which can be seen from standard linkage charts in :ref:`external_standards`.
+
+.. needextend:: "c.this_doc()"
+   :+tags: security_management

--- a/process/process_areas/security_management/guidance/security_management_process_reqs.rst
+++ b/process/process_areas/security_management/guidance/security_management_process_reqs.rst
@@ -40,3 +40,6 @@ Security Management Process Requirements
 
    Note: This can be done as for documents if the work product is a single sphinx-need.
    For work products collections (e.g. all requirements of a component) an accumulated status is needed (e.g. like "% valid state")
+
+.. needextend:: "c.this_doc()"
+   :+tags: security_management

--- a/process/process_areas/security_management/guidance/security_manual_templates.rst
+++ b/process/process_areas/security_management/guidance/security_manual_templates.rst
@@ -29,3 +29,6 @@ Security Manual Templates
    :complies: std_req__isosae21434__development_10421[version==1], std_req__isosae21434__development_10422[version==1]
 
    For the content see here: `Module Security Manual Template <https://eclipse-score.github.io/module_template/main/module/manuals/security_manual.html>`__
+
+.. needextend:: "c.this_doc()"
+   :+tags: security_management

--- a/process/process_areas/security_management/guidance/security_plan_templates.rst
+++ b/process/process_areas/security_management/guidance/security_plan_templates.rst
@@ -101,3 +101,6 @@ Security Planning Templates
               std_req__isosae21434__prj_management_6462[version==1]
 
    For the content see here: `Module Security Plan Template <https://eclipse-score.github.io/module_template/main/module/security_mgt/module_security_plan.html>`__
+
+.. needextend:: "c.this_doc()"
+   :+tags: security_management

--- a/process/process_areas/security_management/index.rst
+++ b/process/process_areas/security_management/index.rst
@@ -27,6 +27,3 @@ Security Management
    security_management_roles
    security_management_workflow
    security_management_workproducts
-
-.. needextend:: "c.this_doc()"
-   :+tags: security_management

--- a/process/process_areas/security_management/security_management_concept.rst
+++ b/process/process_areas/security_management/security_management_concept.rst
@@ -106,3 +106,6 @@ For the activities planning (who, when) we use :need:`wp__issue_track_system` to
 Also, refer :need:`wf__mr_sec_analyses` for the monitoring of security analyses.
 
 For the reporting (e.g. displaying the status of the work products) additional tooling is created (see :doc:`guidance/security_management_process_reqs`).
+
+.. needextend:: "c.this_doc()"
+   :+tags: security_management

--- a/process/process_areas/security_management/security_management_getstrt.rst
+++ b/process/process_areas/security_management/security_management_getstrt.rst
@@ -46,3 +46,6 @@ Some of the workproducts are currently either tailored out or not in scope of th
 Refer :need:`wp__tailoring_work_products` section for the details about tailoring.
 
 .. note:: The term security is used here synonymously for the term cybersecurity as defined in ISO SAE 21434.
+
+.. needextend:: "c.this_doc()"
+   :+tags: security_management

--- a/process/process_areas/security_management/security_management_roles.rst
+++ b/process/process_areas/security_management/security_management_roles.rst
@@ -84,3 +84,6 @@ Roles
    Authority
 
    * Decision on the passing or failing of an audit
+
+.. needextend:: "c.this_doc()"
+   :+tags: security_management

--- a/process/process_areas/security_management/security_management_workproducts.rst
+++ b/process/process_areas/security_management/security_management_workproducts.rst
@@ -160,3 +160,6 @@ Security Management Work Products
 
    Module Software Bill of Material
    - comprehensive inventory of software components to ensure security, integrity, and compliance.
+
+.. needextend:: "c.this_doc()"
+   :+tags: security_management

--- a/process/process_areas/tool_management/guidance/index.rst
+++ b/process/process_areas/tool_management/guidance/index.rst
@@ -22,3 +22,6 @@ Guidance
    tool_management_checklist
    tool_management_template
    tool_management_reqs
+
+.. needextend:: "c.this_doc()"
+   :+tags: tool_management

--- a/process/process_areas/tool_management/guidance/tool_management_checklist.rst
+++ b/process/process_areas/tool_management/guidance/tool_management_checklist.rst
@@ -112,3 +112,6 @@ Tool Verification Report Review Checklist
       * - 16
         - Is the tool confidence level based on tool impact and tool error detection defined?
         -
+
+.. needextend:: "c.this_doc()"
+   :+tags: tool_management

--- a/process/process_areas/tool_management/guidance/tool_management_guideline.rst
+++ b/process/process_areas/tool_management/guidance/tool_management_guideline.rst
@@ -49,3 +49,6 @@ Tailoring
    The reasoning is:
 
    - Some methods for tool qualification are not applied
+
+.. needextend:: "c.this_doc()"
+   :+tags: tool_management

--- a/process/process_areas/tool_management/guidance/tool_management_reqs.rst
+++ b/process/process_areas/tool_management/guidance/tool_management_reqs.rst
@@ -119,3 +119,6 @@ Tool Verification Report Checks
       :style: table
       :columns: title
       :colwidths: 30
+
+.. needextend:: "c.this_doc()"
+   :+tags: tool_management

--- a/process/process_areas/tool_management/guidance/tool_management_template.rst
+++ b/process/process_areas/tool_management/guidance/tool_management_template.rst
@@ -37,3 +37,6 @@ Tool Verification Report Template
               std_req__aspice_40__SUP-8-BP2[version==1]
 
    For the content see here: :need:`doc_tool__tool_name_version`
+
+.. needextend:: "c.this_doc()"
+   :+tags: tool_management

--- a/process/process_areas/tool_management/index.rst
+++ b/process/process_areas/tool_management/index.rst
@@ -26,6 +26,3 @@ Tool Management
    tool_management_roles
    tool_management_workflow
    tool_management_workproducts
-
-.. needextend:: docname is not None and "docs/process/tool_management" in docname
-   :+tags: tool_management

--- a/process/process_areas/tool_management/tool_management_concept.rst
+++ b/process/process_areas/tool_management/tool_management_concept.rst
@@ -85,3 +85,6 @@ Attributes for Tool Management
 
 The required attributes for the Tool Verification Report are defined here:
 :ref:`tlm_process_attributes`.
+
+.. needextend:: "c.this_doc()"
+   :+tags: tool_management

--- a/process/process_areas/tool_management/tool_management_getstrt.rst
+++ b/process/process_areas/tool_management/tool_management_getstrt.rst
@@ -41,3 +41,6 @@ For every tool identified, the following workflows are executed:
 * Approve tool verification report according to :need:`wf__tool_approve_tool_verification_report`
 
 In addition create a tool management plan as part of the platform management plan according to :need:`wf__platform_cr_mt_platform_mgmt_plan`.
+
+.. needextend:: "c.this_doc()"
+   :+tags: tool_management

--- a/process/process_areas/tool_management/tool_management_roles.rst
+++ b/process/process_areas/tool_management/tool_management_roles.rst
@@ -28,3 +28,6 @@ A detailed overview of the responsibilities for the steps of the tool management
 listed here:
 
 :ref:`tlm_workflows`
+
+.. needextend:: "c.this_doc()"
+   :+tags: tool_management

--- a/process/process_areas/tool_management/tool_management_workflow.rst
+++ b/process/process_areas/tool_management/tool_management_workflow.rst
@@ -100,7 +100,7 @@ For a detailed explanation of workflows and their role within the process model,
    If the verification is not successful or due to any other reason, e.g. the tool is
    not needed any more as planned, the tool verification may also rejected at this point.
 
-.. needextend:: docname is not None and "process_areas/tool_management" in docname
+.. needextend:: c.this_doc() and docname is not None and "process_areas/tool_management" in docname
    :+tags: tool_management
 
 RAS(IC) for Tool Management:

--- a/process/process_areas/tool_management/tool_management_workproducts.rst
+++ b/process/process_areas/tool_management/tool_management_workproducts.rst
@@ -40,3 +40,6 @@ Tool Management Work Products
 
    Based on TCL the appropriate qualification methods shall be applied. For the project
    the method **validation of software tool** must be used.
+
+.. needextend:: "c.this_doc()"
+   :+tags: tool_management

--- a/process/process_areas/verification/guidance/index.rst
+++ b/process/process_areas/verification/guidance/index.rst
@@ -27,3 +27,6 @@ Guidance
    verification_plan_template
    verification_report_template
    verification_process_reqs
+
+.. needextend:: "c.this_doc()"
+   :+tags: verification

--- a/process/process_areas/verification/guidance/verification_guideline.rst
+++ b/process/process_areas/verification/guidance/verification_guideline.rst
@@ -201,3 +201,6 @@ Tailoring
    - For SW requirement 1141, 1143, 1144 the SW only points to AoUs, but will not be executed on the final product environment as part of the project scope.
    - For SW requirement 1142 there will be :need:`wp__verification_platform_int_test` available for re-use, but they are not supposed to deliver full coverage.
      Fault Injection Testing is not considered for higher level integration testing.
+
+.. needextend:: "c.this_doc()"
+   :+tags: verification

--- a/process/process_areas/verification/guidance/verification_methods.rst
+++ b/process/process_areas/verification/guidance/verification_methods.rst
@@ -424,3 +424,6 @@ How to perform fuzzy testing:
 
    **5. Analyze and Fix Issues** When a problem is detected, analyze the input that caused it
    and fix the underlying issue in the code.
+
+.. needextend:: "c.this_doc()"
+   :+tags: verification

--- a/process/process_areas/verification/guidance/verification_plan_template.rst
+++ b/process/process_areas/verification/guidance/verification_plan_template.rst
@@ -294,3 +294,6 @@ Verification Plan Template
          It should include information about any specific hardware platforms or simulators used.
          It should also define how the verification environment interacts with the CI system, including
          access control and maintenance.
+
+.. needextend:: "c.this_doc()"
+   :+tags: verification

--- a/process/process_areas/verification/guidance/verification_process_reqs.rst
+++ b/process/process_areas/verification/guidance/verification_process_reqs.rst
@@ -246,3 +246,6 @@ Process Requirements
     when a new component is added to the system or an existing component is updated via a PR.
 
     **TODO: Align this to the ongoing work in https://github.com/eclipse-score/reference_integration/pull/190 which reworks the CI reference integration execution.**
+
+.. needextend:: "c.this_doc()"
+   :+tags: verification

--- a/process/process_areas/verification/guidance/verification_report_template.rst
+++ b/process/process_areas/verification/guidance/verification_report_template.rst
@@ -70,3 +70,6 @@ Verification Report Templates
     This document implements :need:`wp__verification_platform_ver_report`.
 
      |  For the content, see :need:`doc__platform_verification_report`.
+
+.. needextend:: "c.this_doc()"
+   :+tags: verification

--- a/process/process_areas/verification/guidance/verification_specification.rst
+++ b/process/process_areas/verification/guidance/verification_specification.rst
@@ -143,3 +143,6 @@ Additional information can also be found in :need:`gd_guidl__verification_guide`
 
 The specification is part of the test implementation and has to comply to the requirements
 specified in :need:`gd_req__verification_link_tests`.
+
+.. needextend:: "c.this_doc()"
+   :+tags: verification

--- a/process/process_areas/verification/guidance/verification_templates.rst
+++ b/process/process_areas/verification/guidance/verification_templates.rst
@@ -144,3 +144,6 @@ Python Properties Template
 
 When writing test cases in python, they shall follow the recommendations from the official python and community documentation.
 https://docs.python-guide.org/writing/tests/
+
+.. needextend:: "c.this_doc()"
+   :+tags: verification

--- a/process/process_areas/verification/index.rst
+++ b/process/process_areas/verification/index.rst
@@ -26,6 +26,3 @@ Verification
    verification_roles
    verification_workflows
    verification_workproducts
-
-.. needextend:: docname is not None and "process_areas/verification" in docname
-   :+tags: verification

--- a/process/process_areas/verification/verification_concept.rst
+++ b/process/process_areas/verification/verification_concept.rst
@@ -214,3 +214,6 @@ Also, details in :ref:`external_tsf` to collect evidence required for component 
 of the externally provided component.
 Eclipse projects are further supposed to align with the Eclipse Functional Safety Process which is documented
 in the `Eclipse Foundation Functional Safety Process GitLab <https://gitlab.eclipse.org/eclipsefdn/emo-team/policies/functional-safety-process>`_.
+
+.. needextend:: "c.this_doc()"
+   :+tags: verification

--- a/process/process_areas/verification/verification_getstrt.rst
+++ b/process/process_areas/verification/verification_getstrt.rst
@@ -49,3 +49,6 @@ The workflows can be split into 4 major parts:
   available for a specific baseline.
 
 The details of what needs to be done in each part are described in the :ref:`verification_workflows`.
+
+.. needextend:: "c.this_doc()"
+   :+tags: verification

--- a/process/process_areas/verification/verification_roles.rst
+++ b/process/process_areas/verification/verification_roles.rst
@@ -36,3 +36,6 @@ The tool verification and qualification is handled by:
 
 Approval is handled by:
    * :need:`Project Lead <rl__project_lead>`
+
+.. needextend:: "c.this_doc()"
+   :+tags: verification

--- a/process/process_areas/verification/verification_workflows.rst
+++ b/process/process_areas/verification/verification_workflows.rst
@@ -306,3 +306,6 @@ RAS(IC) for Verification:
    :sort: status
    :columns: id as "Activity";responsible as "Responsible";approved_by as "Approver";supported_by as "Supporter"
    :colwidths: 30,30,30,30
+
+.. needextend:: "c.this_doc()"
+   :+tags: verification

--- a/process/process_areas/verification/verification_workproducts.rst
+++ b/process/process_areas/verification/verification_workproducts.rst
@@ -200,3 +200,6 @@ As part of tool management as supporting function it is handled as follows
      * :need:`wf__tool_create_tool_verification_report` describes implementation of :need:`wp__tool_verification_report`
 
 It is planned in the :need:`wp__platform_mgmt`
+
+.. needextend:: "c.this_doc()"
+   :+tags: verification

--- a/process/standards/aspice_40/aspice.rst
+++ b/process/standards/aspice_40/aspice.rst
@@ -450,4 +450,4 @@ Appendix
 .. needtable:: General Practices
    :style: datatables
    :columns: id;title;status;content
-   :filter: c.this_doc()
+   :filter: "c.this_doc()"

--- a/process/standards/aspice_40/iic/iic-02.rst
+++ b/process/standards/aspice_40/iic/iic-02.rst
@@ -32,5 +32,5 @@
        - facilities
 
 
-.. needextend:: "c.this_doc()" 
+.. needextend:: "c.this_doc()"
    :+tags: aspice40_iic02

--- a/process/standards/aspice_40/iic/iic-06.rst
+++ b/process/standards/aspice_40/iic/iic-06.rst
@@ -64,5 +64,5 @@
    - References to corresponding procedures or regulations
 
 
-.. needextend:: "c.this_doc()" 
+.. needextend:: "c.this_doc()"
    :+tags: aspice40_iic06

--- a/process/standards/aspice_40/iic/iic-07.rst
+++ b/process/standards/aspice_40/iic/iic-07.rst
@@ -172,5 +172,5 @@
    - Effective controls over access
 
 
-.. needextend:: "c.this_doc()" 
+.. needextend:: "c.this_doc()"
    :+tags: aspice40_iic07

--- a/process/standards/aspice_40/iic/iic-10.rst
+++ b/process/standards/aspice_40/iic/iic-10.rst
@@ -69,5 +69,5 @@
    - Required samples
 
 
-.. needextend:: "c.this_doc()" 
+.. needextend:: "c.this_doc()"
    :+tags: aspice40_iic10

--- a/process/standards/aspice_40/iic/iic-12.rst
+++ b/process/standards/aspice_40/iic/iic-12.rst
@@ -31,5 +31,5 @@
    - Identifies the person who will be qualifying the reuse candidate
 
 
-.. needextend:: "c.this_doc()" 
+.. needextend:: "c.this_doc()"
    :+tags: aspice40_iic12

--- a/process/standards/aspice_40/iic/iic-14.rst
+++ b/process/standards/aspice_40/iic/iic-14.rst
@@ -98,5 +98,5 @@
      amount of the complete set of all software parts of the software
 
 
-.. needextend:: "c.this_doc()" 
+.. needextend:: "c.this_doc()"
    :+tags: aspice40_iic14

--- a/process/standards/aspice_40/iic/iic-15.rst
+++ b/process/standards/aspice_40/iic/iic-15.rst
@@ -210,5 +210,5 @@
          within established quantitative control limits
 
 
-.. needextend:: "c.this_doc()" 
+.. needextend:: "c.this_doc()"
    :+tags: aspice40_iic15

--- a/process/standards/aspice_40/iic/iic-18.rst
+++ b/process/standards/aspice_40/iic/iic-18.rst
@@ -161,5 +161,5 @@
    - Conditions, constraints, assumptions
 
 
-.. needextend:: "c.this_doc()" 
+.. needextend:: "c.this_doc()"
    :+tags: aspice40_iic18

--- a/process/standards/aspice_40/man/man.3.rst
+++ b/process/standards/aspice_40/man/man.3.rst
@@ -216,5 +216,5 @@ Base practices
       Refer to SUP.9 for resolution of problems
 
 
-.. needextend:: "c.this_doc()" 
+.. needextend:: "c.this_doc()"
    :+tags: aspice40_man3

--- a/process/standards/aspice_40/man/man.5.rst
+++ b/process/standards/aspice_40/man/man.5.rst
@@ -120,5 +120,5 @@ Base practices
       Corrective actions may involve reevaluation of risks, developing and implementing new mitigation concepts or adjusting the existing concepts.
 
 
-.. needextend:: "c.this_doc()" 
+.. needextend:: "c.this_doc()"
    :+tags: aspice40_man5

--- a/process/standards/aspice_40/pim/pim.3.rst
+++ b/process/standards/aspice_40/pim/pim.3.rst
@@ -157,5 +157,5 @@ Identify issues from the analysis of process performance and derive improvement 
    Knowledge gained from the improvements and progress of the improvement implementation is communicated to affected parties.
 
 
-.. needextend:: "c.this_doc()"  
+.. needextend:: "c.this_doc()"
    :+tags: aspice40_pim3

--- a/process/standards/aspice_40/reu/reu.2.rst
+++ b/process/standards/aspice_40/reu/reu.2.rst
@@ -110,5 +110,5 @@ Base practices
 
 
 
-.. needextend:: "c.this_doc()"  
+.. needextend:: "c.this_doc()"
    :+tags: aspice40_reu2

--- a/process/standards/aspice_40/spl/spl.2.rst
+++ b/process/standards/aspice_40/spl/spl.2.rst
@@ -127,5 +127,5 @@ Base practices
 
 
 
-.. needextend:: "c.this_doc()"     
+.. needextend:: "c.this_doc()"
    :+tags: aspice40_spl2

--- a/process/standards/aspice_40/sup/sup.1.rst
+++ b/process/standards/aspice_40/sup/sup.1.rst
@@ -145,5 +145,5 @@ Base practices
       The decision whether to escalate non-conformances may be based on criteria such as delay of resolution, urgency, and risk.
 
 
-.. needextend:: "c.this_doc()" 
+.. needextend:: "c.this_doc()"
    :+tags: aspice40_sup1

--- a/process/standards/aspice_40/sup/sup.10.rst
+++ b/process/standards/aspice_40/sup/sup.10.rst
@@ -115,5 +115,5 @@ Base practices
          Examples for informing affected parties can be daily standup meetings or tool-supported workflows.
 
 
-.. needextend:: "c.this_doc()" 
+.. needextend:: "c.this_doc()"
    :+tags: aspice40_sup10

--- a/process/standards/aspice_40/sup/sup.9.rst
+++ b/process/standards/aspice_40/sup/sup.9.rst
@@ -119,5 +119,5 @@ Base practices
       how and when they were found, what their impacts were, etc.
 
 
-.. needextend:: "c.this_doc()" 
+.. needextend:: "c.this_doc()"
    :+tags: aspice40_sup9

--- a/process/standards/aspice_40/swe/swe.1.rst
+++ b/process/standards/aspice_40/swe/swe.1.rst
@@ -165,5 +165,5 @@ Base practices
    of impact on the operating environment, to all affected parties.
 
 
-.. needextend:: "c.this_doc()" 
+.. needextend:: "c.this_doc()"
    :+tags: aspice40_swe1

--- a/process/standards/aspice_40/swe/swe.4.rst
+++ b/process/standards/aspice_40/swe/swe.4.rst
@@ -119,5 +119,5 @@ Base practices
       parties to judge the consequences.
 
 
-.. needextend:: "c.this_doc()" 
+.. needextend:: "c.this_doc()"
    :+tags: aspice40_swe4

--- a/process/standards/aspice_40/swe/swe.6.rst
+++ b/process/standards/aspice_40/swe/swe.6.rst
@@ -130,5 +130,5 @@ Base practices
       parties to judge the consequences.
 
 
-.. needextend:: "c.this_doc()"     
+.. needextend:: "c.this_doc()"
    :+tags: aspice40_swe6

--- a/process/standards/iso26262/iso26262.rst
+++ b/process/standards/iso26262/iso26262.rst
@@ -2169,5 +2169,5 @@ Exida Audit Status of Iso Requirements
    type == 'std_req' and "__support" in id and 'n/a' in tags
 
 
-.. needextend:: docname is not None and "process/standards/iso26262" in docname
+.. needextend:: c.this_doc() and docname is not None and "process/standards/iso26262" in docname
    :+tags: iso26262

--- a/process/standards/isopas8926/isopas8926.rst
+++ b/process/standards/isopas8926/isopas8926.rst
@@ -243,5 +243,5 @@ ISO PAS 8926
 .. note::
    Sub-Clause numbers from the official standard document are used for Ids creation for better reference.
 
-.. needextend:: docname is not None and "process/standards/isopas8926" in docname
+.. needextend:: c.this_doc() and docname is not None and "process/standards/isopas8926" in docname
    :+tags: isopas8926

--- a/process/standards/isosae21434/isosae21434.rst
+++ b/process/standards/isosae21434/isosae21434.rst
@@ -589,5 +589,5 @@ Clause 15: Threat analysis and risk assessment methods
    All work products of the relevant clauses are included in the list to enable the documentation of the project wide tailoring,
    but the related requirements are not included as these are not needed to be covered.
 
-.. needextend:: docname is not None and "process/standards/isosae21434" in docname
+.. needextend:: c.this_doc() and docname is not None and "process/standards/isosae21434" in docname
    :+tags: isosae21434


### PR DESCRIPTION

The future Docs-AS-Code releases will enforce that `needextends` directives can no longer adapt / change needs that are in a different document, therefore now `c.this_doc()` has to be in the future in every `needextend`. 

This PR fixes this. 

Tested with docs-as-code overwrite: 

```
git_override(
    module_name = "score_docs_as_code",
    commit="eeaa863b5a323639593fe73721232ee3ce699681",
    remote="https://github.com/eclipse-score/docs-as-code"
)
```

## ⚠️ This PR was AI supported, please have a look especially at the `+tag` definitions.   
## They should have been copied directly from the overlying `index.rst` but you never know what these clankers sometimes do.   
### The spot checks I did were correct, but I'm not too familiar with the contents, so take that with a grain of salt
