### PR TITLE
fix: migrate needs role template to Jinja

### DIFF
--- a/process/conf.py
+++ b/process/conf.py
@@ -53,8 +53,8 @@ html_extra_path = ["trainings/_portals"]
 #    "trainings/_portals/**",
 #]
 
-# :need:`{title}` is used in the needs templates to display the title of the need
-needs_role_need_template = "{title}"
+# :need:`{{ title }}` is used in the needs templates to display the title of the need
+needs_role_need_template = "{{ title }}"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What changed

Migrates needs_role_need_template from the deprecated Python format placeholder syntax to Jinja syntax.

## Why

Sphinx-Needs warns that support for the title placeholder form will be removed in a future release.

## Impact

Need-role links continue to show their titles without triggering the deprecation warning.

## Validation

- bazel run //:docs